### PR TITLE
feat: multi-account follow-ups — resolve #36, #37, #38

### DIFF
--- a/src/maildb/cli.py
+++ b/src/maildb/cli.py
@@ -98,6 +98,14 @@ def ingest_run(
     mbox_path: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),  # noqa: B008
     account: str = typer.Option(..., "--account", help="Email address of the source account."),
     skip_embed: bool = typer.Option(False, "--skip-embed", help="Skip the embedding phase."),
+    force_new_import: bool = typer.Option(
+        False,
+        "--force-new-import",
+        help=(
+            "Always allocate a new imports row. By default, an in-progress "
+            "import for the same account+file is resumed."
+        ),
+    ),
 ) -> None:
     """Run the full ingest pipeline for an mbox file."""
     _validate_account(account)
@@ -121,6 +129,7 @@ def ingest_run(
         embedding_dimensions=settings.embedding_dimensions,
         skip_embed=skip_embed,
         source_account=account,
+        force_new_import=force_new_import,
     )
     _print_status_dict(result)
 

--- a/src/maildb/db.py
+++ b/src/maildb/db.py
@@ -21,11 +21,22 @@ def create_pool(config: Settings) -> ConnectionPool:
 def init_db(pool: ConnectionPool) -> None:
     """Apply idempotent table DDL from schema_tables.sql.
 
-    Self-tightens emails.source_account to NOT NULL once every row is tagged.
+    - Backfills email_accounts from legacy emails.source_account/import_id rows.
+    - Self-tightens emails.source_account to NOT NULL once every row is tagged.
     """
     schema_sql = importlib.resources.files("maildb").joinpath("schema_tables.sql").read_text()
     with pool.connection() as conn:
         conn.execute(schema_sql)
+
+        # Mirror any legacy (emails.source_account, emails.import_id) pairs
+        # into email_accounts. Safe to re-run — ON CONFLICT DO NOTHING.
+        conn.execute(
+            """INSERT INTO email_accounts (email_id, source_account, import_id)
+               SELECT id, source_account, import_id FROM emails
+               WHERE source_account IS NOT NULL AND import_id IS NOT NULL
+               ON CONFLICT DO NOTHING"""
+        )
+
         cur = conn.execute("SELECT count(*) FROM emails WHERE source_account IS NULL")
         null_rows = cur.fetchone()[0]  # type: ignore[index]
         if null_rows == 0:

--- a/src/maildb/ingest/orchestrator.py
+++ b/src/maildb/ingest/orchestrator.py
@@ -31,6 +31,47 @@ def _get_pool(database_url: str) -> ConnectionPool:
     return ConnectionPool(conninfo=database_url, min_size=1, max_size=5, open=True)
 
 
+def _resume_or_create_import(
+    pool: ConnectionPool,
+    *,
+    source_account: str,
+    source_file: str,
+    force_new_import: bool,
+) -> tuple[UUID, bool]:
+    """Return (import_id, created_new) for this pipeline run.
+
+    Reuses the most recent status='running' row for the same
+    (source_account, source_file) unless force_new_import is True.
+    Returns whether the row was newly created so the caller knows
+    whether a failure should mark it failed.
+    """
+    if not force_new_import:
+        with pool.connection() as conn:
+            cur = conn.execute(
+                """SELECT id FROM imports
+                   WHERE source_account = %(acct)s
+                     AND source_file = %(file)s
+                     AND status = 'running'
+                   ORDER BY started_at DESC
+                   LIMIT 1""",
+                {"acct": source_account, "file": source_file},
+            )
+            row = cur.fetchone()
+        if row is not None:
+            logger.info("resuming_import", import_id=str(row[0]))
+            return row[0], False
+
+    import_id = uuid4()
+    with pool.connection() as conn:
+        conn.execute(
+            """INSERT INTO imports (id, source_account, source_file, status)
+               VALUES (%(id)s, %(account)s, %(file)s, 'running')""",
+            {"id": import_id, "account": source_account, "file": source_file},
+        )
+        conn.commit()
+    return import_id, True
+
+
 def backfill_source_account(pool: ConnectionPool, *, account: str) -> dict[str, Any]:
     """Tag all emails with NULL source_account using the given account.
 
@@ -80,13 +121,19 @@ def run_pipeline(
     embedding_model: str = "nomic-embed-text",
     embedding_dimensions: int = 768,
     skip_embed: bool = False,
+    force_new_import: bool = False,
 ) -> dict[str, Any]:
-    """Run the full ingest pipeline. Restartable."""
+    """Run the full ingest pipeline. Restartable.
+
+    By default, a still-running imports row for the same
+    (source_account, source_file) is resumed instead of a new one being
+    created. Pass force_new_import=True to always start fresh.
+    """
     if parse_workers == -1:
         parse_workers = max(1, (os.cpu_count() or 2) - 1)
 
     pool = _get_pool(database_url)
-    import_id: UUID = uuid4()
+    import_id: UUID
     import_row_created = False
 
     try:
@@ -116,16 +163,18 @@ def run_pipeline(
                     embedding_model=embedding_model,
                     embedding_dimensions=embedding_dimensions,
                     skip_embed=skip_embed,
+                    force_new_import=False,
                 )
 
-            # Restart check passed — now safe to claim the imports row.
-            with pool.connection() as conn:
-                conn.execute(
-                    """INSERT INTO imports (id, source_account, source_file, status)
-                       VALUES (%(id)s, %(account)s, %(file)s, 'running')""",
-                    {"id": import_id, "account": source_account, "file": str(mbox_path)},
-                )
-                conn.commit()
+            # Restart check passed — adopt a still-running row or create one.
+            # Once we have the import_id, we "own" it for this run, so
+            # any failure below should mark it failed.
+            import_id, _was_created = _resume_or_create_import(
+                pool,
+                source_account=source_account,
+                source_file=str(mbox_path),
+                force_new_import=force_new_import,
+            )
             import_row_created = True
 
             if split_status["total"] == 0:

--- a/src/maildb/ingest/orchestrator.py
+++ b/src/maildb/ingest/orchestrator.py
@@ -77,10 +77,10 @@ def backfill_source_account(pool: ConnectionPool, *, account: str) -> dict[str, 
 
     Idempotent: re-running it inserts another (empty) imports row but
     updates zero email rows. Never overwrites previously-tagged emails.
+    Also mirrors the tagging into the email_accounts join table.
     """
     migration_id = uuid4()
     with pool.connection() as conn:
-        # Insert the synthetic import row so we can FK rows to it.
         conn.execute(
             """INSERT INTO imports (id, source_account, source_file, status,
                                     started_at, completed_at)
@@ -94,6 +94,15 @@ def backfill_source_account(pool: ConnectionPool, *, account: str) -> dict[str, 
             {"id": migration_id, "acct": account},
         )
         rows_updated = cur.rowcount
+        # Mirror into the join table so account-scoped queries see the
+        # backfilled rows without waiting for the next init_db.
+        conn.execute(
+            """INSERT INTO email_accounts (email_id, source_account, import_id)
+               SELECT id, source_account, import_id FROM emails
+               WHERE source_account = %(acct)s AND import_id = %(id)s
+               ON CONFLICT DO NOTHING""",
+            {"id": migration_id, "acct": account},
+        )
         conn.execute(
             """UPDATE imports
                SET status = 'completed', completed_at = now(),

--- a/src/maildb/ingest/parse.py
+++ b/src/maildb/ingest/parse.py
@@ -25,7 +25,14 @@ INSERT INTO emails (
     %(sender_domain)s, %(recipients)s, %(date)s, %(body_text)s, %(body_html)s,
     %(has_attachment)s, %(attachments)s, %(labels)s, %(in_reply_to)s, %(references)s,
     %(source_account)s, %(import_id)s
-) ON CONFLICT (message_id) DO NOTHING
+) ON CONFLICT (message_id) DO UPDATE SET thread_id = emails.thread_id
+RETURNING id
+"""
+
+INSERT_EMAIL_ACCOUNT_SQL = """
+INSERT INTO email_accounts (email_id, source_account, import_id)
+VALUES (%(email_id)s, %(source_account)s, %(import_id)s)
+ON CONFLICT (email_id, source_account) DO NOTHING
 """
 
 INSERT_ATTACHMENT_SQL = """
@@ -177,12 +184,27 @@ def _process_single_chunk(
             try:
                 conn.execute("SAVEPOINT row_insert")
                 cur = conn.execute(INSERT_EMAIL_SQL, row)
-                conn.execute("RELEASE SAVEPOINT row_insert")
-                if cur.rowcount > 0:
+                result = cur.fetchone()
+                # ON CONFLICT DO UPDATE is a no-op write that always returns
+                # the id — the existing row's id on conflict, or the newly
+                # inserted id otherwise.
+                existing_id = result[0] if result else row["id"]
+                if existing_id == row["id"]:
                     inserted += 1
                     inserted_email_ids.add(row["id"])
                 else:
                     skipped += 1
+                # Tag with this ingest's account, idempotent per (email, account).
+                if source_account is not None and import_id is not None:
+                    conn.execute(
+                        INSERT_EMAIL_ACCOUNT_SQL,
+                        {
+                            "email_id": existing_id,
+                            "source_account": source_account,
+                            "import_id": import_id,
+                        },
+                    )
+                conn.execute("RELEASE SAVEPOINT row_insert")
             except Exception:
                 conn.execute("ROLLBACK TO SAVEPOINT row_insert")
                 logger.warning(

--- a/src/maildb/maildb.py
+++ b/src/maildb/maildb.py
@@ -196,7 +196,10 @@ class MailDB:
             )
             params["max_recipients"] = max_recipients
         if account is not None:
-            conditions.append("source_account = %(account)s")
+            conditions.append(
+                "EXISTS (SELECT 1 FROM email_accounts ea "
+                "WHERE ea.email_id = emails.id AND ea.source_account = %(account)s)"
+            )
             params["account"] = account
 
         return conditions, params
@@ -438,7 +441,10 @@ class MailDB:
             exclude_outbound = ""
 
         if account is not None:
-            account_cond = "AND source_account = %(account)s"
+            account_cond = (
+                "AND EXISTS (SELECT 1 FROM email_accounts ea "
+                "WHERE ea.email_id = emails.id AND ea.source_account = %(account)s)"
+            )
             params["account"] = account
         else:
             account_cond = ""
@@ -525,17 +531,21 @@ class MailDB:
         return rows, total
 
     def accounts(self) -> list[AccountSummary]:
-        """Summarize email counts per source_account."""
+        """Summarize email counts per source_account.
+
+        Sourced from the email_accounts join table, so a message that was
+        ingested under multiple accounts counts for each.
+        """
         sql = """
             SELECT
-                source_account,
-                COUNT(*)                  AS email_count,
-                MIN(date)                 AS first_date,
-                MAX(date)                 AS last_date,
-                COUNT(DISTINCT import_id) AS import_count
-            FROM emails
-            WHERE source_account IS NOT NULL
-            GROUP BY source_account
+                ea.source_account,
+                COUNT(DISTINCT ea.email_id) AS email_count,
+                MIN(e.date)                 AS first_date,
+                MAX(e.date)                 AS last_date,
+                COUNT(DISTINCT ea.import_id) AS import_count
+            FROM email_accounts ea
+            JOIN emails e ON e.id = ea.email_id
+            GROUP BY ea.source_account
             ORDER BY email_count DESC
         """
         rows = _query_dicts(self._pool, sql)
@@ -778,7 +788,10 @@ class MailDB:
                 conditions.append("e.sender_domain = %(sender_domain)s")
                 params["sender_domain"] = sender_domain
             if account is not None:
-                conditions.append("e.source_account = %(account)s")
+                conditions.append(
+                    "EXISTS (SELECT 1 FROM email_accounts ea "
+                    "WHERE ea.email_id = e.id AND ea.source_account = %(account)s)"
+                )
                 params["account"] = account
 
             where = " AND ".join(conditions)
@@ -810,7 +823,10 @@ class MailDB:
                 conditions.append("e.date < %(before)s")
                 params["before"] = before
             if account is not None:
-                conditions.append("e.source_account = %(account)s")
+                conditions.append(
+                    "EXISTS (SELECT 1 FROM email_accounts ea "
+                    "WHERE ea.email_id = e.id AND ea.source_account = %(account)s)"
+                )
                 params["account"] = account
 
             if recipient:
@@ -943,7 +959,10 @@ class MailDB:
             conditions.append("date < %(before)s")
             params["before"] = before
         if account is not None:
-            conditions.append("source_account = %(account)s")
+            conditions.append(
+                "EXISTS (SELECT 1 FROM email_accounts ea "
+                "WHERE ea.email_id = emails.id AND ea.source_account = %(account)s)"
+            )
             params["account"] = account
         # Recipient count filters
         rcpt_conditions, rcpt_params = self._build_filters(
@@ -1011,7 +1030,10 @@ class MailDB:
             conditions.append("date >= %(after)s")
             params["after"] = after
         if account is not None:
-            conditions.append("source_account = %(account)s")
+            conditions.append(
+                "EXISTS (SELECT 1 FROM email_accounts ea "
+                "WHERE ea.email_id = emails.id AND ea.source_account = %(account)s)"
+            )
             params["account"] = account
         where = " AND ".join(conditions) if conditions else "TRUE"
         having_participant = ""

--- a/src/maildb/maildb.py
+++ b/src/maildb/maildb.py
@@ -82,6 +82,7 @@ class MailDB:
             model_name=self._config.embedding_model,
             dimensions=self._config.embedding_dimensions,
         )
+        self._effective_user_emails_cache: list[str] | None = None
 
     @classmethod
     def _from_pool(
@@ -99,6 +100,7 @@ class MailDB:
             model_name=instance._config.embedding_model,
             dimensions=instance._config.embedding_dimensions,
         )
+        instance._effective_user_emails_cache = None
         return instance
 
     def init_db(self) -> None:
@@ -352,17 +354,39 @@ class MailDB:
 
     # --- Advanced query methods ---
 
+    def _effective_user_emails(self) -> list[str]:
+        """Merge configured user_emails with every account we've ingested.
+
+        Configured addresses keep their relative order (env-first).
+        Ingested accounts from `imports` fill in anything the config missed.
+        Deduplicated.
+        """
+        if self._effective_user_emails_cache is not None:
+            return self._effective_user_emails_cache
+        with self._pool.connection() as conn:
+            cur = conn.execute("SELECT DISTINCT source_account FROM imports")
+            ingested = [r[0] for r in cur.fetchall() if r[0]]
+        seen: set[str] = set()
+        merged: list[str] = []
+        for addr in (*self._config.user_emails, *ingested):
+            if addr and addr not in seen:
+                seen.add(addr)
+                merged.append(addr)
+        self._effective_user_emails_cache = merged
+        return merged
+
     def _identity_addresses(self, account: str | None) -> list[str]:
         """Return the addresses that represent 'you' for identity-aware queries.
 
         If `account` is provided, returns just that single address.
-        Otherwise returns the configured user_emails list.
-        Raises if neither is available.
+        Otherwise returns the effective user_emails list (config + imports).
+        Raises if neither config nor imports yields anything.
         """
         if account is not None:
             return [account]
-        if self._config.user_emails:
-            return list(self._config.user_emails)
+        identities = self._effective_user_emails()
+        if identities:
+            return identities
         msg = "user_emails must be configured (or pass account=...) for this method"
         raise ValueError(msg)
 

--- a/src/maildb/schema_indexes.sql
+++ b/src/maildb/schema_indexes.sql
@@ -13,5 +13,7 @@ CREATE INDEX IF NOT EXISTS idx_email_source_account ON emails (source_account);
 CREATE INDEX IF NOT EXISTS idx_email_import_id ON emails (import_id);
 CREATE INDEX IF NOT EXISTS idx_imports_source_account ON imports (source_account);
 CREATE INDEX IF NOT EXISTS idx_imports_started_at ON imports (started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_email_accounts_source_account ON email_accounts (source_account);
+CREATE INDEX IF NOT EXISTS idx_email_accounts_import_id ON email_accounts (import_id);
 -- HNSW index created separately after embed phase:
 -- CREATE INDEX IF NOT EXISTS idx_email_embedding ON emails USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);

--- a/src/maildb/schema_tables.sql
+++ b/src/maildb/schema_tables.sql
@@ -77,3 +77,11 @@ CREATE TABLE IF NOT EXISTS email_attachments (
     filename        TEXT NOT NULL,
     PRIMARY KEY (email_id, attachment_id)
 );
+
+CREATE TABLE IF NOT EXISTS email_accounts (
+    email_id       UUID NOT NULL REFERENCES emails(id) ON DELETE CASCADE,
+    source_account TEXT NOT NULL,
+    import_id      UUID NOT NULL REFERENCES imports(id),
+    first_seen_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (email_id, source_account)
+);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,7 @@ def _clean_emails(request) -> Iterator[None]:  # type: ignore[no-untyped-def]
         conn.execute("DELETE FROM email_attachments")
         conn.execute("DELETE FROM attachments")
         conn.execute("DELETE FROM ingest_tasks")
+        conn.execute("DELETE FROM email_accounts")
         conn.execute("DELETE FROM emails")
         conn.execute("DELETE FROM imports")
         conn.commit()
@@ -98,13 +99,14 @@ def multi_account_seed(test_pool):  # type: ignore[no-untyped-def]
             ("<cross-2@example.com>", "thread-cross", "carol@example.com", "b@example.com", iid_b),
         ]
         for mid, tid, sender, acct, iid in rows:
+            eid = uuid4()
             conn.execute(
                 """INSERT INTO emails (id, message_id, thread_id, sender_address,
                        sender_domain, date, source_account, import_id, created_at)
                    VALUES (%(id)s, %(mid)s, %(tid)s, %(sender)s, %(domain)s,
                        now(), %(acct)s, %(iid)s, now())""",
                 {
-                    "id": uuid4(),
+                    "id": eid,
                     "mid": mid,
                     "tid": tid,
                     "sender": sender,
@@ -113,24 +115,32 @@ def multi_account_seed(test_pool):  # type: ignore[no-untyped-def]
                     "iid": iid,
                 },
             )
+            conn.execute(
+                "INSERT INTO email_accounts (email_id, source_account, import_id) "
+                "VALUES (%(eid)s, %(acct)s, %(iid)s)",
+                {"eid": eid, "acct": acct, "iid": iid},
+            )
 
-        # Duplicate message_id — second insert no-ops via ON CONFLICT.
-        # Insert in A first so A wins.
+        # Same message_id ingested by both accounts — emails row is de-duped,
+        # but email_accounts gets one row per account (true multi-account).
+        dup_eid = uuid4()
         conn.execute(
             """INSERT INTO emails (id, message_id, thread_id, sender_address,
                    date, source_account, import_id, created_at)
                VALUES (%(id)s, '<dup@example.com>', 't-dup', 'x@example.com',
                    now(), 'a@example.com', %(iid)s, now())
-               ON CONFLICT (message_id) DO NOTHING""",
-            {"id": uuid4(), "iid": iid_a},
+               ON CONFLICT (message_id) DO UPDATE SET thread_id = emails.thread_id
+               RETURNING id""",
+            {"id": dup_eid, "iid": iid_a},
         )
-        conn.execute(
-            """INSERT INTO emails (id, message_id, thread_id, sender_address,
-                   date, source_account, import_id, created_at)
-               VALUES (%(id)s, '<dup@example.com>', 't-dup', 'x@example.com',
-                   now(), 'b@example.com', %(iid)s, now())
-               ON CONFLICT (message_id) DO NOTHING""",
-            {"id": uuid4(), "iid": iid_b},
-        )
+        dup_eid = conn.execute(
+            "SELECT id FROM emails WHERE message_id = '<dup@example.com>'"
+        ).fetchone()[0]
+        for acct, iid in [("a@example.com", iid_a), ("b@example.com", iid_b)]:
+            conn.execute(
+                "INSERT INTO email_accounts (email_id, source_account, import_id) "
+                "VALUES (%(eid)s, %(acct)s, %(iid)s) ON CONFLICT DO NOTHING",
+                {"eid": dup_eid, "acct": acct, "iid": iid},
+            )
         conn.commit()
     return {"iid_a": iid_a, "iid_b": iid_b}

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -126,6 +126,10 @@ def test_init_db_tightens_source_account_when_no_nulls(test_pool):
 def test_init_db_leaves_nullable_when_some_nulls(test_pool):
     with test_pool.connection() as conn:
         conn.execute("ALTER TABLE emails ALTER COLUMN source_account DROP NOT NULL")
+        conn.execute("DELETE FROM email_attachments")
+        conn.execute("DELETE FROM attachments")
+        conn.execute("DELETE FROM ingest_tasks")
+        conn.execute("DELETE FROM email_accounts")
         conn.execute("DELETE FROM emails")
         conn.execute(
             "INSERT INTO emails (id, message_id, thread_id) "
@@ -142,3 +146,92 @@ def test_init_db_leaves_nullable_when_some_nulls(test_pool):
             "WHERE table_name = 'emails' AND column_name = 'source_account'"
         )
         assert cur.fetchone()[0] == "YES"
+
+
+def test_email_accounts_table_exists(test_pool) -> None:  # type: ignore[no-untyped-def]
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'email_accounts' ORDER BY column_name"
+        )
+        cols = {row[0] for row in cur.fetchall()}
+    assert cols == {"email_id", "source_account", "import_id", "first_seen_at"}
+
+
+def test_email_accounts_primary_key_on_email_id_source_account(test_pool) -> None:  # type: ignore[no-untyped-def]
+    """Same (email_id, source_account) cannot appear twice; different accounts can."""
+    iid_a = uuid4()
+    iid_b = uuid4()
+    eid = uuid4()
+    with test_pool.connection() as conn:
+        for iid, acct in [(iid_a, "a@example.com"), (iid_b, "b@example.com")]:
+            conn.execute(
+                "INSERT INTO imports (id, source_account, source_file, status) "
+                "VALUES (%(id)s, %(acct)s, 't', 'completed')",
+                {"id": iid, "acct": acct},
+            )
+        conn.execute(
+            "INSERT INTO emails (id, message_id, thread_id, source_account, import_id) "
+            "VALUES (%(id)s, '<pk@example.com>', 't', 'a@example.com', %(iid)s)",
+            {"id": eid, "iid": iid_a},
+        )
+        # Two distinct accounts → two rows OK.
+        conn.execute(
+            "INSERT INTO email_accounts (email_id, source_account, import_id) "
+            "VALUES (%(eid)s, 'a@example.com', %(iid)s)",
+            {"eid": eid, "iid": iid_a},
+        )
+        conn.execute(
+            "INSERT INTO email_accounts (email_id, source_account, import_id) "
+            "VALUES (%(eid)s, 'b@example.com', %(iid)s)",
+            {"eid": eid, "iid": iid_b},
+        )
+        conn.commit()
+
+        cur = conn.execute(
+            "SELECT count(*) FROM email_accounts WHERE email_id = %(eid)s",
+            {"eid": eid},
+        )
+        assert cur.fetchone()[0] == 2
+
+
+def test_indexes_for_email_accounts(test_pool) -> None:  # type: ignore[no-untyped-def]
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE tablename = 'email_accounts' "
+            "AND indexname IN ('idx_email_accounts_source_account', 'idx_email_accounts_import_id')"
+        )
+        names = {row[0] for row in cur.fetchall()}
+    assert names == {"idx_email_accounts_source_account", "idx_email_accounts_import_id"}
+
+
+def test_init_db_backfills_email_accounts_from_emails(test_pool) -> None:  # type: ignore[no-untyped-def]
+    """Rows with legacy emails.source_account get mirrored into email_accounts."""
+    iid = uuid4()
+    eid = uuid4()
+    with test_pool.connection() as conn:
+        conn.execute("DELETE FROM email_accounts")
+        conn.execute("DELETE FROM emails")
+        conn.execute("DELETE FROM imports")
+        conn.execute(
+            "INSERT INTO imports (id, source_account, source_file, status) "
+            "VALUES (%(id)s, 'legacy@example.com', 't', 'completed')",
+            {"id": iid},
+        )
+        conn.execute(
+            """INSERT INTO emails (id, message_id, thread_id, source_account, import_id)
+               VALUES (%(id)s, '<legacy@example.com>', 't', 'legacy@example.com', %(iid)s)""",
+            {"id": eid, "iid": iid},
+        )
+        conn.commit()
+
+    init_db(test_pool)
+
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT source_account, import_id FROM email_accounts WHERE email_id = %(eid)s",
+            {"eid": eid},
+        )
+        rows = cur.fetchall()
+    assert rows == [("legacy@example.com", iid)]

--- a/tests/integration/test_maildb.py
+++ b/tests/integration/test_maildb.py
@@ -1389,3 +1389,88 @@ def test_import_history_returns_records(test_pool, test_settings):
     a_only = db.import_history(account="a@example.com")
     assert len(a_only) == 2
     assert all(r.source_account == "a@example.com" for r in a_only)
+
+
+def test_effective_user_emails_merges_config_and_imports(test_pool, test_settings) -> None:  # type: ignore[no-untyped-def]
+    """user_emails auto-derived from imports table when env is unset.
+
+    Config-configured identities win ordering; ingested accounts fill in
+    anything the env missed. Explicit account= calls still narrow to one.
+    """
+    config = test_settings.model_copy()
+    config.user_emails = []  # Pretend no env config.
+    db = MailDB._from_pool(test_pool, config=config)
+
+    # No ingested accounts yet → unreplied should raise.
+    with pytest.raises(ValueError, match="user_emails must be configured"):
+        db.unreplied()
+
+    with test_pool.connection() as conn:
+        conn.execute(
+            "INSERT INTO imports (id, source_account, source_file, status) "
+            "VALUES (%(id)s, 'a@example.com', 't', 'completed')",
+            {"id": uuid4()},
+        )
+        conn.execute(
+            "INSERT INTO imports (id, source_account, source_file, status) "
+            "VALUES (%(id)s, 'b@example.com', 't', 'completed')",
+            {"id": uuid4()},
+        )
+        conn.commit()
+
+    # Fresh MailDB picks up ingested accounts without any config.
+    db = MailDB._from_pool(test_pool, config=config)
+    identities = db._identity_addresses(None)
+    assert set(identities) == {"a@example.com", "b@example.com"}
+
+
+def test_effective_user_emails_config_takes_priority_in_order(test_pool, test_settings) -> None:  # type: ignore[no-untyped-def]
+    """Configured identities appear first, ingested ones fill in the rest."""
+    config = test_settings.model_copy()
+    config.user_emails = ["alias@example.com"]
+    with test_pool.connection() as conn:
+        conn.execute(
+            "INSERT INTO imports (id, source_account, source_file, status) "
+            "VALUES (%(id)s, 'a@example.com', 't', 'completed')",
+            {"id": uuid4()},
+        )
+        conn.commit()
+
+    db = MailDB._from_pool(test_pool, config=config)
+    identities = db._identity_addresses(None)
+    # Configured alias first, ingested appended.
+    assert identities == ["alias@example.com", "a@example.com"]
+
+
+def test_effective_user_emails_explicit_account_ignores_derived(test_pool, test_settings) -> None:  # type: ignore[no-untyped-def]
+    """Passing account= narrows to that address regardless of env/imports."""
+    config = test_settings.model_copy()
+    config.user_emails = ["alias@example.com"]
+    with test_pool.connection() as conn:
+        conn.execute(
+            "INSERT INTO imports (id, source_account, source_file, status) "
+            "VALUES (%(id)s, 'a@example.com', 't', 'completed')",
+            {"id": uuid4()},
+        )
+        conn.commit()
+
+    db = MailDB._from_pool(test_pool, config=config)
+    identities = db._identity_addresses("only@example.com")
+    assert identities == ["only@example.com"]
+
+
+def test_effective_user_emails_dedupes_overlap(test_pool, test_settings) -> None:  # type: ignore[no-untyped-def]
+    """Address present in both config and imports is returned once."""
+    config = test_settings.model_copy()
+    config.user_emails = ["a@example.com"]
+    with test_pool.connection() as conn:
+        conn.execute(
+            "INSERT INTO imports (id, source_account, source_file, status) "
+            "VALUES (%(id)s, 'a@example.com', 't', 'completed')",
+            {"id": uuid4()},
+        )
+        conn.commit()
+
+    db = MailDB._from_pool(test_pool, config=config)
+    identities = db._identity_addresses(None)
+    assert identities == ["a@example.com"]

--- a/tests/integration/test_maildb.py
+++ b/tests/integration/test_maildb.py
@@ -1208,12 +1208,23 @@ def test_find_filters_by_account(test_pool, test_settings):
         for n, (iid, acct) in enumerate(
             [(iid_a, "a@example.com"), (iid_a, "a@example.com"), (iid_b, "b@example.com")]
         ):
+            eid = uuid4()
             conn.execute(
                 """INSERT INTO emails (id, message_id, thread_id, subject, sender_address,
                        date, source_account, import_id, created_at)
                    VALUES (%(id)s, %(mid)s, 't', 'T', 'x@example.com',
                        now(), %(acct)s, %(iid)s, now())""",
-                {"id": uuid4(), "mid": f"<find-acct-{n}@example.com>", "acct": acct, "iid": iid},
+                {
+                    "id": eid,
+                    "mid": f"<find-acct-{n}@example.com>",
+                    "acct": acct,
+                    "iid": iid,
+                },
+            )
+            conn.execute(
+                "INSERT INTO email_accounts (email_id, source_account, import_id) "
+                "VALUES (%(eid)s, %(acct)s, %(iid)s)",
+                {"eid": eid, "acct": acct, "iid": iid},
             )
         conn.commit()
 
@@ -1240,13 +1251,19 @@ def test_mention_search_filters_by_account(test_pool, test_settings):
         for n, (iid, acct) in enumerate(
             [(iid_a, "a@example.com"), (iid_a, "a@example.com"), (iid_b, "b@example.com")]
         ):
+            eid = uuid4()
             conn.execute(
                 """INSERT INTO emails (id, message_id, thread_id, subject, sender_address,
                        date, body_text, source_account, import_id, created_at)
                    VALUES (%(id)s, %(mid)s, 't', 'T', 'x@example.com',
                        now(), 'budget meeting next quarter',
                        %(acct)s, %(iid)s, now())""",
-                {"id": uuid4(), "mid": f"<ms-acct-{n}@example.com>", "acct": acct, "iid": iid},
+                {"id": eid, "mid": f"<ms-acct-{n}@example.com>", "acct": acct, "iid": iid},
+            )
+            conn.execute(
+                "INSERT INTO email_accounts (email_id, source_account, import_id) "
+                "VALUES (%(eid)s, %(acct)s, %(iid)s)",
+                {"eid": eid, "acct": acct, "iid": iid},
             )
         conn.commit()
 
@@ -1277,18 +1294,24 @@ def test_top_contacts_scoped_by_account(test_pool, test_settings):
             ("alice@x.com", "a@example.com", iid_a),
             ("bob@y.com", "b@example.com", iid_b),
         ]:
+            eid = uuid4()
             conn.execute(
                 """INSERT INTO emails (id, message_id, thread_id, sender_address,
                        date, source_account, import_id, created_at)
                    VALUES (%(id)s, %(mid)s, 't', %(sender)s,
                        now(), %(acct)s, %(iid)s, now())""",
                 {
-                    "id": uuid4(),
+                    "id": eid,
                     "mid": f"<topc-{uuid4()}@x>",
                     "sender": sender,
                     "acct": acct,
                     "iid": iid,
                 },
+            )
+            conn.execute(
+                "INSERT INTO email_accounts (email_id, source_account, import_id) "
+                "VALUES (%(eid)s, %(acct)s, %(iid)s)",
+                {"eid": eid, "acct": acct, "iid": iid},
             )
         conn.commit()
 
@@ -1313,20 +1336,32 @@ def test_long_threads_scoped_by_account(test_pool, test_settings):
             )
         # Account A has a thread of 6 messages; B has a thread of 2.
         for n in range(6):
+            eid = uuid4()
             conn.execute(
                 """INSERT INTO emails (id, message_id, thread_id, sender_address,
                        date, source_account, import_id, created_at)
                    VALUES (%(id)s, %(mid)s, 'long-A', 'x@example.com',
                        now(), 'a@example.com', %(iid)s, now())""",
-                {"id": uuid4(), "mid": f"<lt-A-{n}@x>", "iid": iid_a},
+                {"id": eid, "mid": f"<lt-A-{n}@x>", "iid": iid_a},
+            )
+            conn.execute(
+                "INSERT INTO email_accounts (email_id, source_account, import_id) "
+                "VALUES (%(eid)s, 'a@example.com', %(iid)s)",
+                {"eid": eid, "iid": iid_a},
             )
         for n in range(2):
+            eid = uuid4()
             conn.execute(
                 """INSERT INTO emails (id, message_id, thread_id, sender_address,
                        date, source_account, import_id, created_at)
                    VALUES (%(id)s, %(mid)s, 'long-B', 'y@example.com',
                        now(), 'b@example.com', %(iid)s, now())""",
-                {"id": uuid4(), "mid": f"<lt-B-{n}@x>", "iid": iid_b},
+                {"id": eid, "mid": f"<lt-B-{n}@x>", "iid": iid_b},
+            )
+            conn.execute(
+                "INSERT INTO email_accounts (email_id, source_account, import_id) "
+                "VALUES (%(eid)s, 'b@example.com', %(iid)s)",
+                {"eid": eid, "iid": iid_b},
             )
         conn.commit()
 
@@ -1350,11 +1385,17 @@ def test_accounts_returns_summary(test_pool, test_settings):
         for n, (acct, iid) in enumerate(
             [("a@example.com", iid_a)] * 3 + [("b@example.com", iid_b)] * 2
         ):
+            eid = uuid4()
             conn.execute(
                 """INSERT INTO emails (id, message_id, thread_id, source_account,
                        import_id, date, created_at)
                    VALUES (%(id)s, %(mid)s, 't', %(acct)s, %(iid)s, now(), now())""",
-                {"id": uuid4(), "mid": f"<acc-{n}@x>", "acct": acct, "iid": iid},
+                {"id": eid, "mid": f"<acc-{n}@x>", "acct": acct, "iid": iid},
+            )
+            conn.execute(
+                "INSERT INTO email_accounts (email_id, source_account, import_id) "
+                "VALUES (%(eid)s, %(acct)s, %(iid)s)",
+                {"eid": eid, "acct": acct, "iid": iid},
             )
         conn.commit()
 

--- a/tests/integration/test_multi_account_queries.py
+++ b/tests/integration/test_multi_account_queries.py
@@ -25,16 +25,36 @@ def test_get_thread_returns_cross_account_messages(test_pool, test_settings, mul
     assert {e.source_account for e in thread} == {"a@example.com", "b@example.com"}
 
 
-def test_deduplication_first_import_wins(test_pool, test_settings, multi_account_seed):
-    """Duplicate message_id keeps the first import's source_account."""
+def test_duplicate_emails_surface_under_both_accounts(
+    test_pool, test_settings, multi_account_seed
+):
+    """Same message_id ingested by A then B is visible in both account-scoped queries.
+
+    The emails row is de-duplicated on message_id (ON CONFLICT DO UPDATE
+    no-op), but email_accounts carries one row per (email_id, source_account)
+    so account-scoped finds return the message from either side.
+    """
     with test_pool.connection() as conn:
+        # emails table de-duplicates.
+        cur = conn.execute("SELECT count(*) FROM emails WHERE message_id = '<dup@example.com>'")
+        assert cur.fetchone()[0] == 1
+        # email_accounts has one row per account.
         cur = conn.execute(
-            "SELECT count(*), array_agg(source_account) FROM emails "
-            "WHERE message_id = '<dup@example.com>'"
+            """SELECT ea.source_account
+               FROM email_accounts ea
+               JOIN emails e ON e.id = ea.email_id
+               WHERE e.message_id = '<dup@example.com>'
+               ORDER BY ea.source_account"""
         )
-        count, accounts = cur.fetchone()
-    assert count == 1
-    assert accounts == ["a@example.com"]
+        accounts = [r[0] for r in cur.fetchall()]
+    assert accounts == ["a@example.com", "b@example.com"]
+
+    # And the query surface reflects that: find(account=B) returns the dup.
+    db = _db(test_pool, test_settings)
+    b_results, _ = db.find(account="b@example.com", limit=100)
+    assert "<dup@example.com>" in {e.message_id for e in b_results}
+    a_results, _ = db.find(account="a@example.com", limit=100)
+    assert "<dup@example.com>" in {e.message_id for e in a_results}
 
 
 def test_find_no_account_returns_all(test_pool, test_settings, multi_account_seed):
@@ -50,9 +70,10 @@ def test_accounts_summary(test_pool, test_settings, multi_account_seed):
     summaries = db.accounts()
     by_acct = {s.source_account: s for s in summaries}
     assert set(by_acct) == {"a@example.com", "b@example.com"}
-    # A has 4 emails (a-1, a-2, cross-1, dup), B has 2 (b-1, cross-2)
+    # A has 4 emails (a-1, a-2, cross-1, dup), B has 3 (b-1, cross-2, dup
+    # — the duplicate is attributed to both accounts via email_accounts).
     assert by_acct["a@example.com"].email_count == 4
-    assert by_acct["b@example.com"].email_count == 2
+    assert by_acct["b@example.com"].email_count == 3
 
 
 def test_import_history_filters_by_account(test_pool, test_settings, multi_account_seed):
@@ -77,20 +98,32 @@ def test_unreplied_scoped_by_account(test_pool, test_settings):
                 {"id": iid, "acct": acct},
             )
         # Inbound to A: one unreplied from alice.
+        eid_a = uuid4()
         conn.execute(
             """INSERT INTO emails (id, message_id, thread_id, sender_address,
                    date, source_account, import_id, created_at)
                VALUES (%(id)s, '<u-A@ex.com>', 'unrep-A', 'alice@ex.com',
                    now(), 'a@example.com', %(iid)s, now())""",
-            {"id": uuid4(), "iid": iid_a},
+            {"id": eid_a, "iid": iid_a},
+        )
+        conn.execute(
+            "INSERT INTO email_accounts (email_id, source_account, import_id) "
+            "VALUES (%(eid)s, 'a@example.com', %(iid)s)",
+            {"eid": eid_a, "iid": iid_a},
         )
         # Inbound to B: one unreplied from bob.
+        eid_b = uuid4()
         conn.execute(
             """INSERT INTO emails (id, message_id, thread_id, sender_address,
                    date, source_account, import_id, created_at)
                VALUES (%(id)s, '<u-B@ex.com>', 'unrep-B', 'bob@ex.com',
                    now(), 'b@example.com', %(iid)s, now())""",
-            {"id": uuid4(), "iid": iid_b},
+            {"id": eid_b, "iid": iid_b},
+        )
+        conn.execute(
+            "INSERT INTO email_accounts (email_id, source_account, import_id) "
+            "VALUES (%(eid)s, 'b@example.com', %(iid)s)",
+            {"eid": eid_b, "iid": iid_b},
         )
         conn.commit()
 

--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -282,6 +282,39 @@ def test_run_pipeline_adopts_orphan_running_import(test_pool, test_settings, tmp
     assert rows[0][1] == "completed"
 
 
+def test_run_pipeline_same_mbox_two_accounts_creates_join_rows(test_pool, test_settings, tmp_path):
+    """Ingesting the same mbox under two different accounts produces one
+    emails row per message but two email_accounts rows per message.
+    """
+    mbox = FIXTURES / "sample.mbox"
+    common = dict(  # noqa: C408
+        mbox_path=mbox,
+        database_url=test_settings.database_url,
+        attachment_dir=tmp_path / "attachments",
+        tmp_dir=tmp_path / "chunks",
+        chunk_size_bytes=50 * 1024 * 1024,
+        parse_workers=2,
+        skip_embed=True,
+    )
+    run_pipeline(source_account="a@example.com", **common)
+    # Wipe parse tasks so the second account reprocesses every chunk.
+    reset_pipeline(test_pool, phase="parse")
+    run_pipeline(source_account="b@example.com", **common)
+
+    with test_pool.connection() as conn:
+        cur = conn.execute("SELECT count(*) FROM emails")
+        email_count = cur.fetchone()[0]
+        cur = conn.execute("SELECT count(*) FROM email_accounts")
+        ea_count = cur.fetchone()[0]
+        cur = conn.execute(
+            "SELECT count(DISTINCT email_id) FROM email_accounts "
+            "WHERE source_account = 'b@example.com'"
+        )
+        b_tagged = cur.fetchone()[0]
+    assert ea_count == email_count * 2  # Every email tagged under both.
+    assert b_tagged == email_count
+
+
 def test_run_pipeline_force_new_import(test_pool, test_settings, tmp_path):
     """force_new_import=True bypasses resume and creates a fresh import row."""
     mbox = FIXTURES / "sample.mbox"

--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -216,7 +216,11 @@ def test_run_pipeline_writes_imports_row_and_stamps_emails(test_pool, test_setti
 
 
 def test_re_running_ingest_creates_new_import_but_zero_emails(test_pool, test_settings, tmp_path):
-    """Idempotent ingest: second run inserts zero emails but logs a new import row."""
+    """Idempotent ingest: second run inserts zero emails but logs a new import row.
+
+    The first run completes, so the resume-by-key lookup finds no
+    'running' row for the second invocation — it creates a new one.
+    """
     common_kwargs = dict(  # noqa: C408
         mbox_path=FIXTURES / "sample.mbox",
         database_url=test_settings.database_url,
@@ -243,3 +247,67 @@ def test_re_running_ingest_creates_new_import_but_zero_emails(test_pool, test_se
         count, total_skipped = cur.fetchone()
         assert count == 2
         assert total_skipped > 0, "Second import should have recorded skipped duplicates"
+
+
+def test_run_pipeline_adopts_orphan_running_import(test_pool, test_settings, tmp_path):
+    """An orphaned status='running' row is resumed, not duplicated."""
+    mbox = FIXTURES / "sample.mbox"
+    orphan_id = uuid4()
+    with test_pool.connection() as conn:
+        conn.execute(
+            """INSERT INTO imports (id, source_account, source_file, status)
+               VALUES (%(id)s, 'resume@example.com', %(file)s, 'running')""",
+            {"id": orphan_id, "file": str(mbox)},
+        )
+        conn.commit()
+
+    run_pipeline(
+        mbox_path=mbox,
+        database_url=test_settings.database_url,
+        attachment_dir=tmp_path / "attachments",
+        tmp_dir=tmp_path / "chunks",
+        chunk_size_bytes=50 * 1024 * 1024,
+        parse_workers=2,
+        skip_embed=True,
+        source_account="resume@example.com",
+    )
+
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT id, status FROM imports WHERE source_account = 'resume@example.com'"
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1  # Orphan adopted, not duplicated.
+    assert rows[0][0] == orphan_id
+    assert rows[0][1] == "completed"
+
+
+def test_run_pipeline_force_new_import(test_pool, test_settings, tmp_path):
+    """force_new_import=True bypasses resume and creates a fresh import row."""
+    mbox = FIXTURES / "sample.mbox"
+    orphan_id = uuid4()
+    with test_pool.connection() as conn:
+        conn.execute(
+            """INSERT INTO imports (id, source_account, source_file, status)
+               VALUES (%(id)s, 'force@example.com', %(file)s, 'running')""",
+            {"id": orphan_id, "file": str(mbox)},
+        )
+        conn.commit()
+
+    run_pipeline(
+        mbox_path=mbox,
+        database_url=test_settings.database_url,
+        attachment_dir=tmp_path / "attachments",
+        tmp_dir=tmp_path / "chunks",
+        chunk_size_bytes=50 * 1024 * 1024,
+        parse_workers=2,
+        skip_embed=True,
+        source_account="force@example.com",
+        force_new_import=True,
+    )
+
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT count(*) FROM imports WHERE source_account = 'force@example.com'"
+        )
+        assert cur.fetchone()[0] == 2  # Orphan left alone; new row created.


### PR DESCRIPTION
Rebased onto latest main (the original multi-account work from PR #34 is already there). This PR adds the three follow-ups discussed in code review:

- **#37 — Auto-derive user_emails from imports table** (dcbf386). Identity-aware queries (\`unreplied\`, \`top_contacts\`) now work out-of-the-box against any ingested account. Env var is merged on top for overrides/aliases. Cached per \`MailDB\` instance.
- **#38 — Resume in-progress imports by (source_account, source_file)** (ca75d0f). \`run_pipeline\` adopts an existing \`status='running'\` row instead of minting a new UUID on every restart. Collapses \`imports\` churn from interrupted-then-resumed ingests. Adds \`--force-new-import\` CLI flag for forensic overrides.
- **#36 — email_accounts join table** (d72b6a3). Same \`message_id\` ingested under multiple accounts now surfaces under every account. \`emails\` stays globally unique (no body/embedding duplication), attribution lives in a new \`email_accounts\` join. \`init_db\` backfills from legacy \`emails.source_account\`. All \`account=\` query filters switch to \`EXISTS\` on the join.

## Test plan

- [x] \`uv run just check\` passes (fmt, lint, mypy, 338 tests — up from 325 on main)
- [x] New integration tests:
  - \`test_run_pipeline_adopts_orphan_running_import\` — orphan row driven to completed
  - \`test_run_pipeline_force_new_import\` — \`--force-new-import\` bypasses resume
  - \`test_run_pipeline_same_mbox_two_accounts_creates_join_rows\` — N emails, 2N join rows
  - \`test_duplicate_emails_surface_under_both_accounts\` — replaces \`test_deduplication_first_import_wins\`
  - \`test_email_accounts_*\` — schema, PK, indexes, \`init_db\` backfill
  - \`test_effective_user_emails_*\` — config merge, priority, dedup
- [ ] Manual: \`uv run maildb ingest run <mbox> --account a@x.com\` then same file with \`--account b@x.com\` → verify \`maildb ingest status\` shows two accounts and \`accounts\` MCP tool reflects both counts

Supersedes #35 (that branch was rebased from an outdated local main and ended up with a dirty merge state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)