### PR TITLE
feat(dsl): emails_by_account virtual source for true multi-account attribution

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -356,7 +356,7 @@ The `query()` method exposes a JSON DSL for arbitrary structured queries that go
 }
 ```
 
-**Sources.** `from = "emails"` queries the table directly. `"sent_to"` expands recipients into one row per recipient address via a LATERAL join (adding `recipient_address`, `recipient_domain`, `recipient_type`). `"email_labels"` unnests the labels array (adding `label`).
+**Sources.** `from = "emails"` queries the table directly. `"sent_to"` expands recipients into one row per recipient address via a LATERAL join (adding `recipient_address`, `recipient_domain`, `recipient_type`). `"email_labels"` unnests the labels array (adding `label`). `"emails_by_account"` joins `emails` to `email_accounts`, producing one row per `(email, account)` pair and adding `account` (the source account address), `account_import_id` (the per-account import row), and `first_seen_at`. Use `emails_by_account` whenever true multi-account attribution matters — e.g., finding messages that exist in account B whether or not B was the first importer.
 
 **Safety.** All column names, operators, aggregate functions, and date-trunc precisions are validated against strict whitelists. All values are parameterized. A 5-second `statement_timeout` and 1,000-row hard cap are enforced server-side.
 
@@ -364,7 +364,7 @@ The `query()` method exposes a JSON DSL for arbitrary structured queries that go
 
 **Aggregates.** `count`, `count_distinct`, `min`, `max`, `sum`, `array_agg_distinct`.
 
-**Column whitelist on `emails`** includes `source_account` and `import_id`, so DSL queries can filter by the scalar "first seen" attribution. (True multi-account attribution via `email_accounts` is not yet exposed in the DSL — see §10.)
+**Column whitelist on `emails`** includes `source_account` and `import_id`, reflecting the scalar "first seen" attribution stored directly on the emails row. For true multi-account attribution (the same message appearing under every account that ingested it), use the `emails_by_account` source and filter on `account`.
 
 ### 6.6 MCP Server Layer
 
@@ -521,7 +521,6 @@ Delivered across the original multi-account implementation plus three follow-ups
 - **Multi-user support:** The current design is single-user (one person's email accounts). Multi-user support would require a `user_id` column and row-level security.
 - **Incremental embedding:** New messages ingested after the initial load should be embedded immediately at insert time, avoiding the need for batch backfills.
 - **Account auto-detection:** For Gmail Takeout mbox files, the source account could potentially be inferred from the file metadata or message headers, reducing the need to specify `--account` manually.
-- **DSL support for `email_accounts`:** The Tier 2 DSL currently exposes the scalar `emails.source_account` and `emails.import_id` columns, reflecting the "first seen" attribution. A follow-up could add `accounts` (a `jsonb` or array aggregate from `email_accounts`) or a new virtual source `emails_by_account` so DSL queries can filter by true multi-account attribution.
 - **Deprecating `emails.source_account` / `emails.import_id`:** Once all writers and readers use `email_accounts`, these columns and their indexes can be dropped. The current version keeps them for one release as a compatibility surface and a self-tightening invariant.
 - **Hybrid query planning:** `search()` currently runs structured filters and vector similarity in the same SQL statement, relying on PostgreSQL's planner to order them. A future enhancement could add explicit query planning based on selectivity statistics.
 - **Orphan-running-import reaper:** A process that crashes without reaching its exception handler leaves a `status='running'` imports row. The resume-by-key logic will adopt it on the next matching invocation, but a `maildb ingest reap --older-than 24h` command could close out long-idle rows explicitly.

--- a/src/maildb/dsl.py
+++ b/src/maildb/dsl.py
@@ -40,10 +40,23 @@ _SENT_TO_COLUMNS: set[str] = _EMAILS_COLUMNS | {
 
 _EMAIL_LABELS_COLUMNS: set[str] = _EMAILS_COLUMNS | {"label"}
 
+# emails_by_account exposes the email_accounts join: one row per
+# (email, account) pair. Use `account` (not `source_account`) for true
+# multi-account attribution and `account_import_id` / `first_seen_at`
+# for the per-account metadata. The scalar emails.source_account /
+# emails.import_id columns are still reachable but reflect only
+# first-seen attribution.
+_EMAILS_BY_ACCOUNT_COLUMNS: set[str] = _EMAILS_COLUMNS | {
+    "account",
+    "account_import_id",
+    "first_seen_at",
+}
+
 _SOURCE_COLUMNS: dict[str, set[str]] = {
     "emails": _EMAILS_COLUMNS,
     "sent_to": _SENT_TO_COLUMNS,
     "email_labels": _EMAIL_LABELS_COLUMNS,
+    "emails_by_account": _EMAILS_BY_ACCOUNT_COLUMNS,
 }
 
 # ---------------------------------------------------------------------------
@@ -136,9 +149,19 @@ WITH source AS (
     FROM emails e WHERE e.labels IS NOT NULL AND array_length(e.labels, 1) > 0
 )"""
 
+_EMAILS_BY_ACCOUNT_CTE = """\
+WITH source AS (
+    SELECT e.*, ea.source_account AS account,
+           ea.import_id AS account_import_id,
+           ea.first_seen_at
+    FROM emails e
+    JOIN email_accounts ea ON ea.email_id = e.id
+)"""
+
 _SOURCE_CTE: dict[str, str] = {
     "sent_to": _SENT_TO_CTE,
     "email_labels": _EMAIL_LABELS_CTE,
+    "emails_by_account": _EMAILS_BY_ACCOUNT_CTE,
 }
 
 

--- a/tests/integration/test_dsl.py
+++ b/tests/integration/test_dsl.py
@@ -11,6 +11,7 @@ import pytest
 from psycopg.rows import dict_row
 
 from maildb.dsl import parse_query
+from maildb.maildb import MailDB
 
 pytestmark = pytest.mark.integration
 
@@ -253,3 +254,107 @@ def test_default_body_preview(test_pool, seed_dsl) -> None:  # type: ignore[no-u
     assert len(rows) == 3
     # Default select should produce body_preview, not body_text
     assert "body_preview" in rows[0]
+
+
+def test_emails_by_account_surfaces_duplicate_under_both_accounts(
+    test_pool, test_settings, multi_account_seed
+) -> None:  # type: ignore[no-untyped-def]
+    """Cross-account duplicate (<dup@example.com>) is visible via either account.
+
+    This is the correctness fix from issue #40: filtering by account on the
+    plain `emails` source only returns the first-seen account; using the
+    new `emails_by_account` source returns both.
+    """
+    # Baseline: plain `emails` source filtered by source_account misses the dup
+    # for account B because emails.source_account reflects the first-import
+    # (account A) attribution.
+    rows_b_scalar = _execute_dsl(
+        test_pool,
+        {
+            "from": "emails",
+            "select": [{"field": "message_id"}],
+            "where": {"field": "source_account", "op": "eq", "value": "b@example.com"},
+            "limit": 100,
+        },
+    )
+    b_scalar_ids = {r["message_id"] for r in rows_b_scalar}
+    assert "<dup@example.com>" not in b_scalar_ids, (
+        "Baseline precondition: plain `emails` source does not surface the dup under B"
+    )
+
+    # New source: emails_by_account with account=B returns the dup.
+    rows_b_join = _execute_dsl(
+        test_pool,
+        {
+            "from": "emails_by_account",
+            "select": [{"field": "message_id"}, {"field": "account"}],
+            "where": {"field": "account", "op": "eq", "value": "b@example.com"},
+            "limit": 100,
+        },
+    )
+    b_join_ids = {r["message_id"] for r in rows_b_join}
+    assert "<dup@example.com>" in b_join_ids
+    # And the account column is correctly returned.
+    for r in rows_b_join:
+        assert r["account"] == "b@example.com"
+
+    # Account A also surfaces the dup — this is the cross-account property.
+    rows_a_join = _execute_dsl(
+        test_pool,
+        {
+            "from": "emails_by_account",
+            "select": [{"field": "message_id"}],
+            "where": {"field": "account", "op": "eq", "value": "a@example.com"},
+            "limit": 100,
+        },
+    )
+    a_join_ids = {r["message_id"] for r in rows_a_join}
+    assert "<dup@example.com>" in a_join_ids
+
+
+def test_emails_by_account_aggregation(test_pool, test_settings, multi_account_seed) -> None:  # type: ignore[no-untyped-def]
+    """Grouping by account via the join gives true per-account counts."""
+    rows = _execute_dsl(
+        test_pool,
+        {
+            "from": "emails_by_account",
+            "select": [
+                {"field": "account"},
+                {"count": "*", "as": "n"},
+            ],
+            "group_by": ["account"],
+            "order_by": [{"field": "n", "dir": "DESC"}],
+        },
+    )
+    by_account = {r["account"]: r["n"] for r in rows}
+    # From multi_account_seed: A gets 4 (a-1, a-2, cross-1, dup),
+    # B gets 3 (b-1, cross-2, dup).
+    assert by_account["a@example.com"] == 4
+    assert by_account["b@example.com"] == 3
+
+
+def test_emails_by_account_matches_find_account_filter(
+    test_pool, test_settings, multi_account_seed
+) -> None:  # type: ignore[no-untyped-def]
+    """The DSL emails_by_account source returns the same message_ids as
+    MailDB.find(account=...) — this is the whole point of the fix.
+    """
+    db = MailDB._from_pool(test_pool, config=test_settings)
+
+    # Via Tier 1 API (already correct — uses EXISTS on email_accounts).
+    tier1, _ = db.find(account="b@example.com", limit=100)
+    tier1_ids = {e.message_id for e in tier1}
+
+    # Via Tier 2 DSL (the fix).
+    dsl_rows = _execute_dsl(
+        test_pool,
+        {
+            "from": "emails_by_account",
+            "select": [{"field": "message_id"}],
+            "where": {"field": "account", "op": "eq", "value": "b@example.com"},
+            "limit": 100,
+        },
+    )
+    dsl_ids = {r["message_id"] for r in dsl_rows}
+
+    assert tier1_ids == dsl_ids

--- a/tests/unit/test_dsl.py
+++ b/tests/unit/test_dsl.py
@@ -339,6 +339,65 @@ class TestSources:
                 }
             )
 
+    def test_emails_by_account_has_cte(self) -> None:
+        sql, _ = parse_query({"from": "emails_by_account"})
+        assert "WITH source AS" in sql
+        assert "JOIN email_accounts" in sql
+        assert "FROM source" in sql
+
+    def test_emails_by_account_allows_account_column(self) -> None:
+        sql, params = parse_query(
+            {
+                "from": "emails_by_account",
+                "where": {"field": "account", "op": "eq", "value": "you@example.com"},
+            }
+        )
+        assert "account = %(__p0)s" in sql
+        assert params["__p0"] == "you@example.com"
+
+    def test_emails_by_account_allows_first_seen_at(self) -> None:
+        sql, _ = parse_query(
+            {
+                "from": "emails_by_account",
+                "where": {"field": "first_seen_at", "op": "gte", "value": "2025-01-01"},
+            }
+        )
+        assert "first_seen_at >= %(__p0)s" in sql
+
+    def test_emails_by_account_allows_account_import_id(self) -> None:
+        sql, _ = parse_query(
+            {
+                "from": "emails_by_account",
+                "where": {"field": "account_import_id", "op": "is_null", "value": False},
+            }
+        )
+        assert "account_import_id IS NOT NULL" in sql
+
+    def test_emails_by_account_exposes_email_columns(self) -> None:
+        """Every email column is still usable alongside the account columns."""
+        sql, _ = parse_query(
+            {
+                "from": "emails_by_account",
+                "where": {
+                    "and": [
+                        {"field": "account", "op": "eq", "value": "a@example.com"},
+                        {"field": "sender_domain", "op": "eq", "value": "stripe.com"},
+                    ]
+                },
+            }
+        )
+        assert "account = %(__p0)s" in sql
+        assert "sender_domain = %(__p1)s" in sql
+
+    def test_emails_source_rejects_account_column(self) -> None:
+        """'account' is only valid on emails_by_account, not on emails."""
+        with pytest.raises(ValueError, match="Unknown column"):
+            parse_query(
+                {
+                    "where": {"field": "account", "op": "eq", "value": "a@example.com"},
+                }
+            )
+
 
 # ---------------------------------------------------------------------------
 # build_where_clause public API


### PR DESCRIPTION
Fixes the only real correctness gap between the Tier 1 API and the Tier 2 DSL. Before this PR:

\`\`\`python
db.find(account=\"work@x.com\")      # surfaces cross-account duplicates ✓
db.query({                             # first-seen only ✗
    \"from\": \"emails\",
    \"where\": {\"field\": \"source_account\", \"eq\": \"work@x.com\"},
})
\`\`\`

Now the DSL has a dedicated source that mirrors the Tier 1 semantics:

\`\`\`python
db.query({
    \"from\": \"emails_by_account\",
    \"where\": {\"field\": \"account\", \"eq\": \"work@x.com\"},
})
\`\`\`

## Implementation

- New CTE: \`WITH source AS (SELECT e.*, ea.source_account AS account, ea.import_id AS account_import_id, ea.first_seen_at FROM emails e JOIN email_accounts ea ON ea.email_id = e.id)\`
- Registered in \`_SOURCE_CTE\` and \`_SOURCE_COLUMNS\` alongside \`sent_to\` / \`email_labels\`.
- Column named \`account\` (not \`source_account\`) to avoid name collision with the scalar column on the plain \`emails\` source. The scalar columns remain available for callers who legitimately want first-seen attribution.

## Tests

**Unit (no DB):** 6 new tests in \`tests/unit/test_dsl.py::TestSources\`:
- CTE shape (\`WITH source AS\` + \`JOIN email_accounts\`)
- \`account\` filter compiles to correct SQL
- \`first_seen_at\` and \`account_import_id\` reachable
- Email columns (\`sender_domain\` etc.) still usable alongside account filters
- \`account\` column rejected on the plain \`emails\` source

**Integration (multi_account_seed):** 3 new tests in \`tests/integration/test_dsl.py\`:
- Dup message surfaces under both accounts via \`emails_by_account\`; plain \`emails\` source with \`source_account=B\` does NOT surface it (asserts the old wrong behavior as baseline)
- Grouping by \`account\` produces correct per-account counts (A=4, B=3 from the seed fixture)
- DSL \`emails_by_account\` returns the same \`message_id\` set as \`MailDB.find(account=...)\`

All 347 tests pass; lint, format, and mypy clean.

DESIGN.md §6.5 updated to document the new source; the corresponding gap entry in §10 is removed.

Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)