### PR TITLE
fix(process_attachments): ProcessPoolExecutor for multi-worker

### DIFF
--- a/src/maildb/cli.py
+++ b/src/maildb/cli.py
@@ -402,6 +402,7 @@ def process_run(
             retry_failed=retry_failed,
             selector_sql=selector_sql,
             selector_params=selector_params,
+            database_url=settings.database_url,
         )
         typer.echo(
             "Done. extracted={extracted} failed={failed} skipped={skipped}".format(**counts)
@@ -485,6 +486,7 @@ def process_retry(
             retry_failed=True,
             selector_sql="AND status = 'failed'",
             selector_params={},
+            database_url=settings.database_url,
         )
         typer.echo(
             "Retry done. extracted={extracted} failed={failed} skipped={skipped}".format(**counts)

--- a/src/maildb/ingest/process_attachments.py
+++ b/src/maildb/ingest/process_attachments.py
@@ -9,18 +9,17 @@ mid-run (watchdog reclaims 'extracting' rows older than the threshold).
 from __future__ import annotations
 
 import time
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import structlog
+from psycopg_pool import ConnectionPool
 
 from maildb.config import Settings
 from maildb.embeddings import EmbeddingClient
 from maildb.ingest.chunking import chunk_markdown
 from maildb.ingest.extraction import ExtractionFailedError, extract_markdown
-
-if TYPE_CHECKING:
-    from psycopg_pool import ConnectionPool
 
 logger = structlog.get_logger()
 
@@ -277,6 +276,58 @@ def process_one(pool: ConnectionPool, attachment_id: int, *, attachment_dir: Pat
     )
 
 
+def _claim_and_process_loop(
+    pool: ConnectionPool,
+    *,
+    attachment_dir: Path,
+    retry_failed: bool,
+    selector_sql: str,
+    selector_params: dict[str, Any] | None,
+) -> None:
+    """Claim rows one at a time via SKIP LOCKED and process until none remain."""
+    while True:
+        attachment_id = _claim_row(
+            pool,
+            retry_failed=retry_failed,
+            selector_sql=selector_sql,
+            selector_params=selector_params,
+        )
+        if attachment_id is None:
+            return
+        try:
+            process_one(pool, attachment_id, attachment_dir=attachment_dir)
+        except Exception as exc:
+            _set_status(pool, attachment_id, status="failed", reason=str(exc))
+
+
+def _subprocess_worker(
+    *,
+    database_url: str,
+    attachment_dir: Path,
+    retry_failed: bool,
+    selector_sql: str,
+    selector_params: dict[str, Any] | None,
+) -> None:
+    """Subprocess entrypoint: build a fresh pool and run the claim loop.
+
+    Each subprocess owns its own ConnectionPool and PyTorch runtime. The isolation
+    is required because Marker's model init is not thread-safe — multiple threads
+    hitting `create_model_dict()` concurrently produce meta-tensor errors. Process-
+    level parallelism avoids that entirely at the cost of per-process startup time.
+    """
+    pool = ConnectionPool(conninfo=database_url, min_size=1, max_size=2, open=True)
+    try:
+        _claim_and_process_loop(
+            pool,
+            attachment_dir=attachment_dir,
+            retry_failed=retry_failed,
+            selector_sql=selector_sql,
+            selector_params=selector_params,
+        )
+    finally:
+        pool.close()
+
+
 def run(
     pool: ConnectionPool,
     *,
@@ -285,40 +336,44 @@ def run(
     retry_failed: bool = True,
     selector_sql: str = "",
     selector_params: dict[str, Any] | None = None,
+    database_url: str | None = None,
 ) -> dict[str, int]:
-    """Process all matching pending/failed rows using N workers.
+    """Process all matching pending/failed rows.
 
-    For workers > 1 this uses threads, which is appropriate for the
-    mixed I/O + short GPU bursts Marker produces. Connection pool is
-    configured for concurrent access already.
+    - ``workers == 1`` runs in-process on the provided pool.
+    - ``workers > 1`` spawns subprocesses via ``ProcessPoolExecutor``; each loads
+      Marker and builds its own pool. Pass ``database_url`` so the children can
+      reconnect; it's required when workers > 1.
     """
     ensure_pending_rows(pool)
     _reclaim_stale(pool)
 
     counts = {"extracted": 0, "failed": 0, "skipped": 0}
 
-    def _worker() -> None:
-        while True:
-            attachment_id = _claim_row(
-                pool,
-                retry_failed=retry_failed,
-                selector_sql=selector_sql,
-                selector_params=selector_params,
-            )
-            if attachment_id is None:
-                return
-            try:
-                process_one(pool, attachment_id, attachment_dir=attachment_dir)
-            except Exception as exc:
-                _set_status(pool, attachment_id, status="failed", reason=str(exc))
-
     if workers <= 1:
-        _worker()
+        _claim_and_process_loop(
+            pool,
+            attachment_dir=attachment_dir,
+            retry_failed=retry_failed,
+            selector_sql=selector_sql,
+            selector_params=selector_params,
+        )
     else:
-        from concurrent.futures import ThreadPoolExecutor  # noqa: PLC0415
-
-        with ThreadPoolExecutor(max_workers=workers) as executor:
-            futures = [executor.submit(_worker) for _ in range(workers)]
+        if database_url is None:
+            msg = "database_url is required when workers > 1 (subprocesses need it to reconnect)"
+            raise ValueError(msg)
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            futures = [
+                executor.submit(
+                    _subprocess_worker,
+                    database_url=database_url,
+                    attachment_dir=attachment_dir,
+                    retry_failed=retry_failed,
+                    selector_sql=selector_sql,
+                    selector_params=selector_params,
+                )
+                for _ in range(workers)
+            ]
             for f in futures:
                 f.result()
 

--- a/tests/unit/test_process_attachments.py
+++ b/tests/unit/test_process_attachments.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from maildb.ingest import process_attachments as pa
+
+
+def test_run_rejects_multi_worker_without_database_url() -> None:
+    pool = MagicMock()
+    pool.connection.return_value.__enter__.return_value.execute.return_value.fetchall.return_value = []
+    with (
+        patch.object(pa, "ensure_pending_rows", return_value=0),
+        patch.object(pa, "_reclaim_stale", return_value=0),
+        pytest.raises(ValueError, match="database_url is required"),
+    ):
+        pa.run(pool, attachment_dir=Path("/tmp"), workers=2)
+
+
+def test_run_single_worker_runs_in_process() -> None:
+    """workers=1 must call the in-process claim loop, never spawn subprocesses."""
+    pool = MagicMock()
+    pool.connection.return_value.__enter__.return_value.execute.return_value.fetchall.return_value = []
+    with (
+        patch.object(pa, "ensure_pending_rows", return_value=0),
+        patch.object(pa, "_reclaim_stale", return_value=0),
+        patch.object(pa, "_claim_and_process_loop") as loop,
+        patch.object(pa, "ProcessPoolExecutor") as ppe,
+    ):
+        pa.run(pool, attachment_dir=Path("/tmp"), workers=1)
+    loop.assert_called_once()
+    ppe.assert_not_called()
+
+
+def test_run_multi_worker_uses_process_pool_executor() -> None:
+    """workers > 1 must dispatch through ProcessPoolExecutor, not threads."""
+    pool = MagicMock()
+    pool.connection.return_value.__enter__.return_value.execute.return_value.fetchall.return_value = []
+    executor = MagicMock()
+    executor.__enter__.return_value = executor
+    future = MagicMock()
+    future.result.return_value = None
+    executor.submit.return_value = future
+    with (
+        patch.object(pa, "ensure_pending_rows", return_value=0),
+        patch.object(pa, "_reclaim_stale", return_value=0),
+        patch.object(pa, "ProcessPoolExecutor", return_value=executor) as ppe,
+    ):
+        pa.run(
+            pool,
+            attachment_dir=Path("/tmp"),
+            workers=4,
+            database_url="postgresql://localhost/maildb",
+        )
+    ppe.assert_called_once_with(max_workers=4)
+    assert executor.submit.call_count == 4
+    # Each submit should pass the subprocess-safe entrypoint with database_url.
+    for call in executor.submit.call_args_list:
+        args, kwargs = call
+        assert args[0] is pa._subprocess_worker
+        assert kwargs["database_url"] == "postgresql://localhost/maildb"
+        assert kwargs["attachment_dir"] == Path("/tmp")
+
+
+def test_subprocess_worker_opens_fresh_pool_and_closes_it() -> None:
+    """The subprocess entrypoint must build its own pool and close it on exit."""
+    fake_pool = MagicMock()
+    with (
+        patch.object(pa, "ConnectionPool", return_value=fake_pool) as cp,
+        patch.object(pa, "_claim_and_process_loop") as loop,
+    ):
+        pa._subprocess_worker(
+            database_url="postgresql://localhost/maildb",
+            attachment_dir=Path("/tmp"),
+            retry_failed=True,
+            selector_sql="",
+            selector_params=None,
+        )
+    cp.assert_called_once_with(
+        conninfo="postgresql://localhost/maildb", min_size=1, max_size=2, open=True
+    )
+    loop.assert_called_once()
+    fake_pool.close.assert_called_once()


### PR DESCRIPTION
## Problem

First production run of \`process_attachments\` on multi-worker config produced:

- 809 of 810 PDFs failed with identical error: \`marker: Cannot copy out of meta tensor; no data!\`
- Root cause: Marker's surya model init (\`create_model_dict()\`) is not thread-safe. \`ThreadPoolExecutor\` workers step on each other's PyTorch lazy init.

## Fix

Switch \`workers > 1\` path to \`ProcessPoolExecutor\`. Each subprocess:

- Builds its own \`ConnectionPool\` (via \`database_url\` passed through)
- Loads its own Marker/PyTorch runtime, isolated from siblings
- Runs the existing \`SKIP LOCKED\` claim loop — no cross-process coordination needed

\`workers == 1\` path is unchanged (single in-process loop).

## Closes

Thread-safety of the original design; ref issue #48 (per-extraction timeout follow-up).

## Test Plan
- [x] 434 unit + integration tests passing; ruff + mypy clean
- [x] 4 new unit tests cover: missing \`database_url\` raises, workers=1 stays in-process, workers>1 goes through \`ProcessPoolExecutor\`, \`_subprocess_worker\` builds and closes pool
- [ ] Re-run Phase 3 worker sweep on production DB with the fix