### PR TITLE
feat: per-extraction timeout with queryable 'timed out' reason

### DIFF
--- a/src/maildb/cli.py
+++ b/src/maildb/cli.py
@@ -340,6 +340,12 @@ def process_run(
     ids: str | None = typer.Option(None, "--ids", help="Comma-separated attachment_ids."),
     min_size: int | None = typer.Option(None, "--min-size"),
     max_size: int | None = typer.Option(None, "--max-size"),
+    extract_timeout: int = typer.Option(
+        300,
+        "--extract-timeout",
+        help="Per-attachment wall-clock ceiling in seconds (0 disables). "
+        "Timed-out rows are marked failed with reason prefixed 'timed out after'.",
+    ),
 ) -> None:
     """Process pending (and optionally failed) attachments."""
     selector_sql_parts: list[str] = []
@@ -403,6 +409,7 @@ def process_run(
             selector_sql=selector_sql,
             selector_params=selector_params,
             database_url=settings.database_url,
+            extract_timeout_s=extract_timeout,
         )
         typer.echo(
             "Done. extracted={extracted} failed={failed} skipped={skipped}".format(**counts)
@@ -474,19 +481,33 @@ def process_status() -> None:
 @process_app.command("retry")
 def process_retry(
     workers: int = typer.Option(1, "--workers"),
+    extract_timeout: int = typer.Option(
+        300,
+        "--extract-timeout",
+        help="Per-attachment wall-clock ceiling in seconds (0 disables).",
+    ),
+    timeouts_only: bool = typer.Option(
+        False,
+        "--timeouts-only",
+        help="Retry only rows whose failure reason starts with 'timed out after'.",
+    ),
 ) -> None:
     """Re-process only rows with status='failed'."""
     pool = _build_process_pool()
     try:
         settings = Settings()
+        selector_sql = "AND status = 'failed'"
+        if timeouts_only:
+            selector_sql += " AND reason LIKE 'timed out after%%'"
         counts = pa_run(
             pool,
             attachment_dir=Path(settings.attachment_dir),
             workers=workers,
             retry_failed=True,
-            selector_sql="AND status = 'failed'",
+            selector_sql=selector_sql,
             selector_params={},
             database_url=settings.database_url,
+            extract_timeout_s=extract_timeout,
         )
         typer.echo(
             "Retry done. extracted={extracted} failed={failed} skipped={skipped}".format(**counts)

--- a/src/maildb/config.py
+++ b/src/maildb/config.py
@@ -28,6 +28,8 @@ class Settings(BaseSettings):
     ingest_workers: int = -1
     embed_workers: int = 4
     embed_batch_size: int = 50
+    # Per-attachment extraction wall-clock ceiling (seconds). 0 disables.
+    extract_timeout_s: int = 300
 
     # Debug logging
     debug_log: str = "~/.maildb/debug.log"

--- a/src/maildb/ingest/process_attachments.py
+++ b/src/maildb/ingest/process_attachments.py
@@ -8,10 +8,11 @@ mid-run (watchdog reclaims 'extracting' rows older than the threshold).
 
 from __future__ import annotations
 
+import signal
 import time
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 from psycopg_pool import ConnectionPool
@@ -20,6 +21,37 @@ from maildb.config import Settings
 from maildb.embeddings import EmbeddingClient
 from maildb.ingest.chunking import chunk_markdown
 from maildb.ingest.extraction import ExtractionFailedError, extract_markdown
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class ExtractionTimeoutError(Exception):
+    """Raised when extract_markdown exceeds its wall-clock budget."""
+
+
+def _run_with_timeout[R](seconds: int, fn: Callable[[], R]) -> R:
+    """Run ``fn`` and raise ExtractionTimeoutError if it doesn't return within ``seconds``.
+
+    Uses SIGALRM — must be called from the main thread of the calling process.
+    Because each subprocess worker is single-threaded here, that's fine. Passing
+    ``seconds <= 0`` disables the timeout.
+    """
+    if seconds <= 0:
+        return fn()
+
+    def _handler(_signum: int, _frame: object) -> None:
+        msg = f"timed out after {seconds}s"
+        raise ExtractionTimeoutError(msg)
+
+    old_handler = signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(seconds)
+    try:
+        return fn()
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old_handler)
+
 
 logger = structlog.get_logger()
 
@@ -214,13 +246,31 @@ def _claim_row(
         return row[0] if row else None
 
 
-def process_one(pool: ConnectionPool, attachment_id: int, *, attachment_dir: Path) -> None:
-    """Extract → chunk → embed → status for a single attachment row."""
+def process_one(
+    pool: ConnectionPool,
+    attachment_id: int,
+    *,
+    attachment_dir: Path,
+    extract_timeout_s: int = 0,
+) -> None:
+    """Extract → chunk → embed → status for a single attachment row.
+
+    ``extract_timeout_s`` caps the wall-clock time spent inside extract_markdown
+    per attachment; when exceeded the row is marked failed with a reason that
+    starts with ``"timed out after"`` so timeouts can be queried and retried
+    independently of other failures.
+    """
     att = _load_attachment(pool, attachment_id)
     file_path = attachment_dir / Path(att["storage_path"])
     t0 = time.monotonic()
     try:
-        result = extract_markdown(file_path, content_type=att["content_type"])
+        result = _run_with_timeout(
+            extract_timeout_s,
+            lambda: extract_markdown(file_path, content_type=att["content_type"]),
+        )
+    except ExtractionTimeoutError as exc:
+        _set_status(pool, attachment_id, status="failed", reason=str(exc))
+        return
     except ExtractionFailedError as exc:
         # Unsupported types are skipped; Marker errors are failures.
         if "not supported" in str(exc).lower() or "requires LibreOffice" in str(exc):
@@ -283,6 +333,7 @@ def _claim_and_process_loop(
     retry_failed: bool,
     selector_sql: str,
     selector_params: dict[str, Any] | None,
+    extract_timeout_s: int = 0,
 ) -> None:
     """Claim rows one at a time via SKIP LOCKED and process until none remain."""
     while True:
@@ -295,7 +346,12 @@ def _claim_and_process_loop(
         if attachment_id is None:
             return
         try:
-            process_one(pool, attachment_id, attachment_dir=attachment_dir)
+            process_one(
+                pool,
+                attachment_id,
+                attachment_dir=attachment_dir,
+                extract_timeout_s=extract_timeout_s,
+            )
         except Exception as exc:
             _set_status(pool, attachment_id, status="failed", reason=str(exc))
 
@@ -307,6 +363,7 @@ def _subprocess_worker(
     retry_failed: bool,
     selector_sql: str,
     selector_params: dict[str, Any] | None,
+    extract_timeout_s: int = 0,
 ) -> None:
     """Subprocess entrypoint: build a fresh pool and run the claim loop.
 
@@ -323,6 +380,7 @@ def _subprocess_worker(
             retry_failed=retry_failed,
             selector_sql=selector_sql,
             selector_params=selector_params,
+            extract_timeout_s=extract_timeout_s,
         )
     finally:
         pool.close()
@@ -337,6 +395,7 @@ def run(
     selector_sql: str = "",
     selector_params: dict[str, Any] | None = None,
     database_url: str | None = None,
+    extract_timeout_s: int = 0,
 ) -> dict[str, int]:
     """Process all matching pending/failed rows.
 
@@ -344,6 +403,11 @@ def run(
     - ``workers > 1`` spawns subprocesses via ``ProcessPoolExecutor``; each loads
       Marker and builds its own pool. Pass ``database_url`` so the children can
       reconnect; it's required when workers > 1.
+
+    ``extract_timeout_s`` caps wall-clock time per attachment inside
+    extract_markdown; 0 disables the cap. Timed-out rows are marked ``failed``
+    with a reason prefixed ``"timed out after "`` so they can be queried and
+    retried as a distinct group.
     """
     ensure_pending_rows(pool)
     _reclaim_stale(pool)
@@ -357,6 +421,7 @@ def run(
             retry_failed=retry_failed,
             selector_sql=selector_sql,
             selector_params=selector_params,
+            extract_timeout_s=extract_timeout_s,
         )
     else:
         if database_url is None:
@@ -371,6 +436,7 @@ def run(
                     retry_failed=retry_failed,
                     selector_sql=selector_sql,
                     selector_params=selector_params,
+                    extract_timeout_s=extract_timeout_s,
                 )
                 for _ in range(workers)
             ]

--- a/tests/unit/test_process_attachments.py
+++ b/tests/unit/test_process_attachments.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -83,3 +84,44 @@ def test_subprocess_worker_opens_fresh_pool_and_closes_it() -> None:
     )
     loop.assert_called_once()
     fake_pool.close.assert_called_once()
+
+
+def test_run_with_timeout_disabled_calls_fn_directly() -> None:
+    """Timeout=0 must skip signal setup entirely and return the function result."""
+    calls = []
+    result = pa._run_with_timeout(0, lambda: calls.append("x") or "ok")
+    assert result == "ok"
+    assert calls == ["x"]
+
+
+def test_run_with_timeout_raises_extraction_timeout_error() -> None:
+    """SIGALRM-based timeout: a sleep longer than the ceiling raises and includes the ceiling."""
+    with pytest.raises(pa.ExtractionTimeoutError, match="timed out after 1s"):
+        pa._run_with_timeout(1, lambda: time.sleep(3))
+
+
+def test_process_one_timeout_marks_row_failed_with_timeout_reason() -> None:
+    """When extract_markdown blows the budget, the row is failed with reason starting
+    with 'timed out after' — so ops can query and retry them as a group."""
+    pool = MagicMock()
+    load_ret = {
+        "id": 99,
+        "filename": "slow.pdf",
+        "content_type": "application/pdf",
+        "storage_path": "aa/bb/x",
+    }
+    set_status = MagicMock()
+    with (
+        patch.object(pa, "_load_attachment", return_value=load_ret),
+        patch.object(pa, "_set_status", set_status),
+        patch.object(
+            pa,
+            "_run_with_timeout",
+            side_effect=pa.ExtractionTimeoutError("timed out after 300s"),
+        ),
+    ):
+        pa.process_one(pool, 99, attachment_dir=Path("/tmp"), extract_timeout_s=300)
+    set_status.assert_called_once()
+    _, kwargs = set_status.call_args
+    assert kwargs["status"] == "failed"
+    assert kwargs["reason"].startswith("timed out after ")


### PR DESCRIPTION
## Summary
- Adds SIGALRM-based wall-clock ceiling around \`extract_markdown\` — default 300s, 0 disables.
- Timed-out rows set \`status='failed'\`, \`reason='timed out after Ns'\`.
- \`process_attachments retry --timeouts-only --extract-timeout 900\` lifts the cap and retries only those rows.
- Ops can query timeout-failures as a distinct group: \`WHERE reason LIKE 'timed out after%'\`.

## Context
First production run hit scanned/redacted PDFs that legitimately take 10-30+ min each in Marker. With workers=2, a pair of outliers stalled the sweep for 35+ min. A per-attachment budget keeps throughput predictable and makes the slow tail retriable with a bigger ceiling.

## Closes
#48

## Test Plan
- [x] 437 tests passing; ruff + mypy clean
- [x] 3 new unit tests: timeout disabled, timeout fires and raises, \`process_one\` translates timeout into a failed row with correct reason prefix
- [ ] Production: rerun sweep with \`--extract-timeout 300\` to confirm outliers don't wedge workers