### PR TITLE
fix(cli): default --retry-failed off to stop re-claim livelock

### DIFF
--- a/src/maildb/cli.py
+++ b/src/maildb/cli.py
@@ -325,7 +325,12 @@ _BUCKET_TO_CONTENT_TYPES: dict[str, list[str]] = {
 def process_run(
     workers: int = typer.Option(1, "--workers", help="Parallel workers."),
     retry_failed: bool = typer.Option(
-        True, "--retry-failed/--no-retry-failed", help="Re-process rows with status='failed'."
+        False,
+        "--retry-failed/--no-retry-failed",
+        help="Re-claim rows with status='failed' within the same session. Default off — "
+        "previously-failed rows (including timeouts) stay failed until explicitly retried "
+        "via `process_attachments retry`. Avoids the livelock where a failed row is "
+        "immediately re-claimed by the same worker.",
     ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Report selection count without processing."


### PR DESCRIPTION
## Problem
When a row hits the extract timeout and gets marked \`failed\`, \`_claim_row\` immediately re-picks the same row (retry_failed=True includes failed rows; ORDER BY attachment_id puts the just-failed low-id row at the top). The outlier then loops forever every ~300s, blocking the worker.

## Fix
Flip \`--retry-failed\` default to False on \`process_attachments run\`. Previously-failed rows require an explicit \`process_attachments retry\` (which has \`--timeouts-only\` to re-run just timeouts with a bigger ceiling).

## Test Plan
- [x] 437 tests passing, ruff + mypy clean
- [ ] Rerun production worker sweep; confirm no re-claim of freshly-failed rows