### PR TITLE
fix(process_attachments): harden embed failures, reclassify empty extractions

### DIFF
--- a/src/maildb/cli.py
+++ b/src/maildb/cli.py
@@ -19,7 +19,15 @@ from maildb.ingest.orchestrator import (
     reset_pipeline,
     run_pipeline,
 )
-from maildb.ingest.process_attachments import run as pa_run
+from maildb.ingest.process_attachments import (
+    reembed_zero_vectors as pa_reembed_zero_vectors,
+)
+from maildb.ingest.process_attachments import (
+    run as pa_run,
+)
+from maildb.ingest.process_attachments import (
+    sweep_empty_extractions as pa_sweep_empty_extractions,
+)
 from maildb.pii import scrub_pii
 from maildb.server import mcp
 
@@ -517,6 +525,70 @@ def process_retry(
         typer.echo(
             "Retry done. extracted={extracted} failed={failed} skipped={skipped}".format(**counts)
         )
+    finally:
+        _close_pool(pool)
+
+
+def _count_zero_vector_chunks(pool: "ConnectionPool", dimensions: int) -> int:  # noqa: UP037
+    zero = "[" + ",".join(["0"] * dimensions) + "]"
+    with pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT count(*) FROM attachment_chunks WHERE embedding = %s::vector",
+            (zero,),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+
+def _count_empty_extractions(pool: "ConnectionPool") -> int:  # noqa: UP037
+    with pool.connection() as conn:
+        cur = conn.execute(
+            """
+            SELECT count(*) FROM attachment_contents ac
+             WHERE status = 'extracted'
+               AND NOT EXISTS (
+                   SELECT 1 FROM attachment_chunks ch WHERE ch.attachment_id = ac.attachment_id
+               )
+            """
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+
+@process_app.command("reembed")
+def process_reembed(
+    limit: int | None = typer.Option(
+        None, "--limit", help="Re-embed at most N zero-vector chunks."
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Report counts without writing."),
+) -> None:
+    """Re-embed zero-vector chunks and reclassify empty extractions.
+
+    Drains the backlog left by the prior _embed_chunks fallback that silently
+    stored zero-vector sentinels on Ollama failures. Also sweeps extracted rows
+    with no chunks to 'skipped' (reason='empty extraction').
+    """
+    pool = _build_process_pool()
+    try:
+        settings = Settings()
+        if dry_run:
+            n_zeros = _count_zero_vector_chunks(pool, settings.embedding_dimensions)
+            n_empty = _count_empty_extractions(pool)
+            typer.echo(
+                f"Would re-embed {n_zeros} zero-vector chunk(s) and "
+                f"reclassify {n_empty} empty extraction(s). (--dry-run)"
+            )
+            return
+
+        n_swept = pa_sweep_empty_extractions(pool)
+        stats = pa_reembed_zero_vectors(pool, limit=limit)
+        typer.echo(
+            "Reembed done. "
+            f"reembedded={stats['reembedded']} failed={stats['failed']} "
+            f"swept_empty={n_swept}"
+        )
+        if stats["reembedded"] > 0:
+            create_hnsw_index_attachment_chunks(pool)
     finally:
         _close_pool(pool)
 

--- a/src/maildb/ingest/process_attachments.py
+++ b/src/maildb/ingest/process_attachments.py
@@ -30,6 +30,14 @@ class ExtractionTimeoutError(Exception):
     """Raised when extract_markdown exceeds its wall-clock budget."""
 
 
+class EmbedFailedError(Exception):
+    """Raised when one or more chunks cannot be embedded after per-row retry.
+
+    Carries the count of chunks that failed so the reason stored on the row
+    is concise and queryable.
+    """
+
+
 def _run_with_timeout[R](seconds: int, fn: Callable[[], R]) -> R:
     """Run ``fn`` and raise ExtractionTimeoutError if it doesn't return within ``seconds``.
 
@@ -133,17 +141,16 @@ def _build_embedding_client() -> EmbeddingClient:
 def _embed_chunks(pool: ConnectionPool, chunks: list[dict[str, Any]]) -> None:
     """Embed chunks in batches and write vectors back to the DB.
 
-    On per-batch error, falls back to single-row embedding. Rows that
-    still fail get a zero-vector sentinel (same pattern the email embed
-    worker uses).
+    On per-batch error, falls back to per-row embedding. If any row still
+    fails, raises ``EmbedFailedError`` — callers are expected to treat the
+    whole attachment as failed rather than store zero-vector sentinels that
+    would poison semantic search.
     """
     if not chunks:
         return
 
     client = _build_embedding_client()
 
-    # Resolve chunk row IDs from DB — tests pass dicts built from Chunk objects
-    # that don't yet carry the bigserial id.
     attachment_id = chunks[0]["attachment_id"]
     with pool.connection() as conn:
         cur = conn.execute(
@@ -153,27 +160,37 @@ def _embed_chunks(pool: ConnectionPool, chunks: list[dict[str, Any]]) -> None:
         )
         rows = cur.fetchall()
 
+    failed_chunk_ids: list[int] = []
+
     for start in range(0, len(rows), _EMBED_BATCH_SIZE):
         batch = rows[start : start + _EMBED_BATCH_SIZE]
         ids = [r[0] for r in batch]
         texts = [r[2] for r in batch]
+        vectors: list[list[float] | None]
         try:
-            vectors = client.embed_batch(texts)
+            vectors = list(client.embed_batch(texts))
         except Exception:
             vectors = []
-            for t in texts:
+            for cid, t in zip(ids, texts, strict=True):
                 try:
                     vectors.append(client.embed(t))
                 except Exception:
-                    vectors.append([0.0] * client._dimensions)
+                    vectors.append(None)
+                    failed_chunk_ids.append(cid)
 
         with pool.connection() as conn:
             for cid, vec in zip(ids, vectors, strict=True):
+                if vec is None:
+                    continue
                 conn.execute(
                     "UPDATE attachment_chunks SET embedding = %s WHERE id = %s",
                     (str(vec), cid),
                 )
             conn.commit()
+
+    if failed_chunk_ids:
+        msg = f"{len(failed_chunk_ids)}/{len(rows)} chunks"
+        raise EmbedFailedError(msg)
 
 
 def _set_status(
@@ -290,6 +307,10 @@ def process_one(
         conn.commit()
 
     chunks = chunk_markdown(result.markdown)
+    if not chunks:
+        _set_status(pool, attachment_id, status="skipped", reason="empty extraction")
+        return
+
     chunk_rows: list[dict[str, Any]] = []
     with pool.connection() as conn:
         for c in chunks:
@@ -309,8 +330,16 @@ def process_one(
             chunk_rows.append({"attachment_id": attachment_id, **c.__dict__})
         conn.commit()
 
-    # Embed chunks via Ollama; tests monkeypatch _embed_chunks or _build_embedding_client.
-    _embed_chunks(pool, chunk_rows)
+    try:
+        _embed_chunks(pool, chunk_rows)
+    except EmbedFailedError as exc:
+        with pool.connection() as conn:
+            conn.execute(
+                "DELETE FROM attachment_chunks WHERE attachment_id = %s", (attachment_id,)
+            )
+            conn.commit()
+        _set_status(pool, attachment_id, status="failed", reason=f"embed failed: {exc}")
+        return
 
     # Write the on-disk markdown mirror.
     _write_markdown_mirror(attachment_dir, att["storage_path"], result.markdown)
@@ -449,3 +478,95 @@ def run(
             if status in counts:
                 counts[status] = n
     return counts
+
+
+def sweep_empty_extractions(pool: ConnectionPool) -> int:
+    """Reclassify ``status='extracted'`` rows that have zero chunks as ``skipped``.
+
+    These are rows where extraction succeeded but produced no usable text (e.g.
+    scanned images with no OCR output, empty PDFs). Leaving them as ``extracted``
+    with no chunks misrepresents coverage in status reports. Idempotent.
+    """
+    with pool.connection() as conn:
+        cur = conn.execute(
+            """
+            UPDATE attachment_contents
+               SET status = 'skipped', reason = 'empty extraction'
+             WHERE status = 'extracted'
+               AND NOT EXISTS (
+                   SELECT 1 FROM attachment_chunks ch
+                    WHERE ch.attachment_id = attachment_contents.attachment_id
+               )
+            """
+        )
+        conn.commit()
+        return cur.rowcount
+
+
+def _zero_vector_literal(dimensions: int) -> str:
+    """pgvector text representation of an all-zero vector."""
+    return "[" + ",".join(["0"] * dimensions) + "]"
+
+
+def reembed_zero_vectors(
+    pool: ConnectionPool,
+    *,
+    limit: int | None = None,
+) -> dict[str, int]:
+    """Re-embed chunks whose stored vector is the all-zero sentinel.
+
+    The prior fallback in ``_embed_chunks`` silently stamped zero vectors when
+    Ollama errored; this drains that backlog. Single-row embed only.
+    On persistent per-chunk failure, the containing ``attachment_contents`` row
+    is marked ``failed`` with reason ``embed failed: ...`` and its chunks dropped,
+    mirroring ``process_one`` semantics.
+
+    Returns ``{"reembedded": int, "failed": int}``.
+    """
+    client = _build_embedding_client()
+    zero = _zero_vector_literal(client._dimensions)
+
+    sql = (
+        "SELECT id, attachment_id, text FROM attachment_chunks "
+        "WHERE embedding = %s::vector ORDER BY attachment_id, chunk_index"
+    )
+    params: tuple[Any, ...] = (zero,)
+    if limit is not None:
+        sql += " LIMIT %s"
+        params = (zero, limit)
+
+    with pool.connection() as conn:
+        cur = conn.execute(sql, params)
+        rows = cur.fetchall()
+
+    stats = {"reembedded": 0, "failed": 0}
+    failed_attachments: set[int] = set()
+    for chunk_id, attachment_id, text in rows:
+        if attachment_id in failed_attachments:
+            continue
+        try:
+            vec = client.embed(text)
+        except Exception as exc:
+            failed_attachments.add(attachment_id)
+            with pool.connection() as conn:
+                conn.execute(
+                    "DELETE FROM attachment_chunks WHERE attachment_id = %s",
+                    (attachment_id,),
+                )
+                conn.commit()
+            _set_status(
+                pool,
+                attachment_id,
+                status="failed",
+                reason=f"embed failed: {type(exc).__name__}: {exc}",
+            )
+            stats["failed"] += 1
+            continue
+        with pool.connection() as conn:
+            conn.execute(
+                "UPDATE attachment_chunks SET embedding = %s WHERE id = %s",
+                (str(vec), chunk_id),
+            )
+            conn.commit()
+        stats["reembedded"] += 1
+    return stats

--- a/tests/unit/test_cli_process.py
+++ b/tests/unit/test_cli_process.py
@@ -15,6 +15,7 @@ def test_process_attachments_help_lists_subcommands():
     assert "run" in result.output
     assert "status" in result.output
     assert "retry" in result.output
+    assert "reembed" in result.output
 
 
 def test_process_attachments_run_passes_workers_and_retry(tmp_path):
@@ -146,6 +147,44 @@ def test_process_attachments_retry_runs_only_failed(tmp_path):
     assert kwargs["retry_failed"] is True
     # selector_sql should filter to status='failed' only
     assert "status = 'failed'" in kwargs["selector_sql"]
+
+
+def test_process_attachments_reembed_dry_run_reports_counts_and_does_not_write():
+    with (
+        patch("maildb.cli._build_process_pool") as mock_pool,
+        patch("maildb.cli._count_zero_vector_chunks", return_value=42),
+        patch("maildb.cli._count_empty_extractions", return_value=5),
+        patch("maildb.cli.pa_sweep_empty_extractions") as mock_sweep,
+        patch("maildb.cli.pa_reembed_zero_vectors") as mock_reembed,
+    ):
+        mock_pool.return_value = object()
+        result = runner.invoke(app, ["process_attachments", "reembed", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "42" in result.output
+    assert "5" in result.output
+    mock_sweep.assert_not_called()
+    mock_reembed.assert_not_called()
+
+
+def test_process_attachments_reembed_runs_sweep_and_reembed():
+    with (
+        patch("maildb.cli._build_process_pool") as mock_pool,
+        patch("maildb.cli.pa_sweep_empty_extractions", return_value=3) as mock_sweep,
+        patch(
+            "maildb.cli.pa_reembed_zero_vectors",
+            return_value={"reembedded": 10, "failed": 1},
+        ) as mock_reembed,
+        patch("maildb.cli.create_hnsw_index_attachment_chunks") as mock_idx,
+    ):
+        mock_pool.return_value = object()
+        result = runner.invoke(app, ["process_attachments", "reembed", "--limit", "100"])
+    assert result.exit_code == 0, result.output
+    assert "reembedded=10" in result.output
+    assert "failed=1" in result.output
+    assert "swept_empty=3" in result.output
+    mock_sweep.assert_called_once()
+    mock_reembed.assert_called_once_with(mock_pool.return_value, limit=100)
+    mock_idx.assert_called_once()
 
 
 def test_process_attachments_status_shows_per_content_type_throughput():

--- a/tests/unit/test_process_attachments.py
+++ b/tests/unit/test_process_attachments.py
@@ -125,3 +125,213 @@ def test_process_one_timeout_marks_row_failed_with_timeout_reason() -> None:
     _, kwargs = set_status.call_args
     assert kwargs["status"] == "failed"
     assert kwargs["reason"].startswith("timed out after ")
+
+
+def _fake_extract_result(markdown: str = "# hello\n\nworld"):
+    m = MagicMock()
+    m.markdown = markdown
+    m.extractor_version = "test-v1"
+    return m
+
+
+def test_embed_chunks_raises_when_all_retries_fail() -> None:
+    """If single-row retry also fails, _embed_chunks raises EmbedFailedError
+    rather than silently writing zero-vector sentinels."""
+    pool = MagicMock()
+    conn = pool.connection.return_value.__enter__.return_value
+    cur = conn.execute.return_value
+    # Two chunks pre-inserted and read back for embed
+    cur.fetchall.return_value = [(1, 0, "chunk a"), (2, 1, "chunk b")]
+
+    client = MagicMock()
+    client._dimensions = 768
+    client.embed_batch.side_effect = RuntimeError("ollama down")
+    client.embed.side_effect = RuntimeError("ollama still down")
+
+    with (
+        patch.object(pa, "_build_embedding_client", return_value=client),
+        pytest.raises(pa.EmbedFailedError),
+    ):
+        pa._embed_chunks(pool, [{"attachment_id": 42}])
+
+
+def test_embed_chunks_success_writes_real_vectors() -> None:
+    """Happy path: real vectors get written, no exception."""
+    pool = MagicMock()
+    conn = pool.connection.return_value.__enter__.return_value
+    cur = conn.execute.return_value
+    cur.fetchall.return_value = [(1, 0, "a"), (2, 1, "b")]
+
+    client = MagicMock()
+    client._dimensions = 3
+    client.embed_batch.return_value = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+    with patch.object(pa, "_build_embedding_client", return_value=client):
+        pa._embed_chunks(pool, [{"attachment_id": 42}])
+
+    # No zero-vector writes
+    written = [c.args for c in conn.execute.call_args_list if "UPDATE" in c.args[0]]
+    assert written, "expected UPDATE statements"
+    for _sql, params in written:
+        assert "[0.0, 0.0, 0.0]" not in params[0]
+
+
+def test_process_one_empty_markdown_marks_skipped() -> None:
+    """Extraction succeeded but produced no text → skipped with 'empty extraction',
+    no embed attempted."""
+    pool = MagicMock()
+    set_status = MagicMock()
+    embed = MagicMock()
+    with (
+        patch.object(
+            pa,
+            "_load_attachment",
+            return_value={
+                "id": 1,
+                "filename": "x.png",
+                "content_type": "image/png",
+                "storage_path": "a/x",
+            },
+        ),
+        patch.object(pa, "_run_with_timeout", return_value=_fake_extract_result("")),
+        patch.object(pa, "_set_status", set_status),
+        patch.object(pa, "_embed_chunks", embed),
+    ):
+        pa.process_one(pool, 1, attachment_dir=Path("/tmp"))
+    set_status.assert_called_once()
+    _, kwargs = set_status.call_args
+    assert kwargs["status"] == "skipped"
+    assert kwargs["reason"] == "empty extraction"
+    embed.assert_not_called()
+
+
+def test_process_one_markdown_produces_no_chunks_marks_skipped() -> None:
+    """Markdown present but chunker returns [] (e.g. whitespace-only) → skipped."""
+    pool = MagicMock()
+    set_status = MagicMock()
+    embed = MagicMock()
+    with (
+        patch.object(
+            pa,
+            "_load_attachment",
+            return_value={
+                "id": 1,
+                "filename": "x.pdf",
+                "content_type": "application/pdf",
+                "storage_path": "a/x",
+            },
+        ),
+        patch.object(pa, "_run_with_timeout", return_value=_fake_extract_result("   \n\n   ")),
+        patch.object(pa, "chunk_markdown", return_value=[]),
+        patch.object(pa, "_set_status", set_status),
+        patch.object(pa, "_embed_chunks", embed),
+    ):
+        pa.process_one(pool, 1, attachment_dir=Path("/tmp"))
+    set_status.assert_called_once()
+    _, kwargs = set_status.call_args
+    assert kwargs["status"] == "skipped"
+    assert kwargs["reason"] == "empty extraction"
+    embed.assert_not_called()
+
+
+def test_process_one_embed_failure_marks_failed_and_drops_chunks() -> None:
+    """If _embed_chunks raises EmbedFailedError, the row is marked failed with
+    reason prefix 'embed failed:' and chunks are deleted for clean retry."""
+    pool = MagicMock()
+    conn = pool.connection.return_value.__enter__.return_value
+    set_status = MagicMock()
+    with (
+        patch.object(
+            pa,
+            "_load_attachment",
+            return_value={
+                "id": 7,
+                "filename": "x.pdf",
+                "content_type": "application/pdf",
+                "storage_path": "a/x",
+            },
+        ),
+        patch.object(pa, "_run_with_timeout", return_value=_fake_extract_result("# h\n\nbody")),
+        patch.object(pa, "_embed_chunks", side_effect=pa.EmbedFailedError("ollama timeout")),
+        patch.object(pa, "_set_status", set_status),
+    ):
+        pa.process_one(pool, 7, attachment_dir=Path("/tmp"))
+    set_status.assert_called_once()
+    _, kwargs = set_status.call_args
+    assert kwargs["status"] == "failed"
+    assert kwargs["reason"].startswith("embed failed:")
+    # chunks deleted for this attachment (one DELETE before insert, one after failure)
+    delete_calls = [
+        c for c in conn.execute.call_args_list if "DELETE FROM attachment_chunks" in c.args[0]
+    ]
+    assert len(delete_calls) >= 2
+
+
+def test_sweep_empty_extractions_flips_rows_without_chunks() -> None:
+    """Sweep: status='extracted' with zero chunks → status='skipped', reason='empty extraction'."""
+    pool = MagicMock()
+    conn = pool.connection.return_value.__enter__.return_value
+    cur = conn.execute.return_value
+    cur.rowcount = 3
+
+    n = pa.sweep_empty_extractions(pool)
+
+    assert n == 3
+    sql = conn.execute.call_args_list[0].args[0]
+    assert "UPDATE attachment_contents" in sql
+    assert "status = 'skipped'" in sql
+    assert "'empty extraction'" in sql
+
+
+def test_reembed_zero_vectors_re_embeds_them() -> None:
+    """reembed_zero_vectors scans for zero-vector chunks, re-embeds each, and
+    updates the stored vector."""
+    pool = MagicMock()
+    conn = pool.connection.return_value.__enter__.return_value
+    # First query: find zero-vector chunks
+    find_cur = MagicMock()
+    find_cur.fetchall.return_value = [(101, 50, "chunk text one")]
+    # Subsequent UPDATEs
+    update_cur = MagicMock()
+    conn.execute.side_effect = [find_cur, update_cur]
+
+    client = MagicMock()
+    client._dimensions = 3
+    client.embed.return_value = [0.9, 0.1, 0.2]
+
+    with patch.object(pa, "_build_embedding_client", return_value=client):
+        stats = pa.reembed_zero_vectors(pool)
+
+    assert stats["reembedded"] == 1
+    assert stats["failed"] == 0
+    client.embed.assert_called_once_with("chunk text one")
+
+
+def test_reembed_zero_vectors_marks_row_failed_on_persistent_error() -> None:
+    """When embed raises for a chunk, its attachment_contents row is marked failed
+    with reason 'embed failed: …' and its chunks are dropped."""
+    pool = MagicMock()
+    conn = pool.connection.return_value.__enter__.return_value
+    find_cur = MagicMock()
+    find_cur.fetchall.return_value = [(101, 50, "chunk text one")]
+    # execute is called for: find → _set_status (inside failure path) → delete
+    conn.execute.side_effect = [find_cur] + [MagicMock() for _ in range(10)]
+
+    client = MagicMock()
+    client._dimensions = 3
+    client.embed.side_effect = RuntimeError("ollama dead")
+
+    set_status = MagicMock()
+    with (
+        patch.object(pa, "_build_embedding_client", return_value=client),
+        patch.object(pa, "_set_status", set_status),
+    ):
+        stats = pa.reembed_zero_vectors(pool)
+
+    assert stats["reembedded"] == 0
+    assert stats["failed"] == 1
+    set_status.assert_called_once()
+    args, kwargs = set_status.call_args
+    assert args[1] == 50  # attachment_id (positional)
+    assert kwargs["status"] == "failed"
+    assert kwargs["reason"].startswith("embed failed:")


### PR DESCRIPTION
## Summary

- `_embed_chunks` no longer stores zero-vector sentinels on embed failure. It raises `EmbedFailedError`; `process_one` catches, deletes the chunks, and marks the row `failed` with reason `embed failed: …` so it's retryable.
- Attachments whose extraction produces zero chunks are now `skipped` with `reason='empty extraction'` instead of misleadingly showing `extracted`.
- New `maildb process_attachments reembed` drains the backlog of zero-vector chunks and sweeps empty-extraction rows. Single-worker, supports `--limit` and `--dry-run`.

## Background

Post-run audit in the dev DB found 10,039 of 25,971 chunks (~39%) stored as zero vectors from the prior silent fallback, spanning 3,064 (~60%) of extracted rows. Details and acceptance criteria in #53.

## Test plan
- [x] `uv run just check` — ruff fmt/lint, mypy, full pytest (447 passed, 0 failures)
- [x] New unit tests: `_embed_chunks` raises on persistent failure; `process_one` handles empty-extraction, empty-chunk, and embed-failure paths; `sweep_empty_extractions` and `reembed_zero_vectors` behavior; CLI `reembed --dry-run` and default invocations.
- [ ] After merge: run `maildb process_attachments reembed --dry-run` on the dev DB, then without `--dry-run`, then verify the audit query returns 0 zero-vector chunks and 0 empty-extraction rows.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)