### PR TITLE
fix(deps): vendor surya MPS .max() crash fix until upstream releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ htmlcov/
 # Ingest artifacts
 attachments/
 ingest_tmp/
+*.log
 
 # Allow test fixtures that share the "attachments" directory name
 !tests/fixtures/attachments/

--- a/justfile
+++ b/justfile
@@ -24,3 +24,8 @@ test-cov:
     uv run pytest --cov --cov-report=term-missing
 
 check: fmt lint test
+
+# Apply (or revert / check status of) the vendored surya MPS .max() fix.
+# Required after `uv sync` reinstalls surya-ocr until upstream PR #493 ships.
+patch-surya *ARGS="apply":
+    uv run python scripts/surya_mps_patch.py {{ARGS}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,13 @@ max-complexity = 12
 "src/maildb/ingest/process_attachments.py" = ["S608"]  # selector_sql is internal-only; not user-supplied
 "src/maildb/ingest/orchestrator.py" = ["C901"]  # pipeline orchestration is inherently sequential
 "tests/fixtures/*.py" = ["INP001"]  # fixture scripts, not packages
+"scripts/**/*.py" = [
+    "T201",    # print is fine in CLI tools
+    "INP001",  # scripts/ is intentionally not a package
+    "N818",    # local Exception subclasses don't need 'Error' suffix
+    "PLC0415", # lazy imports are intentional (heavy ML deps)
+    "S603",    # subprocess input is internal, not user-supplied
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["maildb"]

--- a/scripts/patches/surya-mps-fix.patch
+++ b/scripts/patches/surya-mps-fix.patch
@@ -1,0 +1,153 @@
+diff --git a/surya/common/surya/__init__.py b/surya/common/surya/__init__.py
+index a32e3b26..8ddad9d2 100644
+--- a/surya/common/surya/__init__.py
++++ b/surya/common/surya/__init__.py
+@@ -15,7 +15,7 @@
+ from surya.common.surya.decoder import SuryaDecoderModel
+ from surya.common.surya.embedder import SimpleTokenEmbedder
+ from surya.common.surya.encoder import SuryaEncoderModel
+-from surya.common.util import pad_to_batch_size, pad_to_batch_size_repeat
++from surya.common.util import pad_to_batch_size, pad_to_batch_size_repeat, safe_max_item
+ from surya.common.xla import get_nearest_pad
+ from surya.settings import settings
+ 
+@@ -639,8 +639,8 @@ def get_image_embeddings(
+         max_batch_size: int | None = None,
+     ):
+         # embed all images with the vision encoder after they have already been tiled and flattened into a single batch
+-        unpadded_max_grid_size = (
+-            (grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2]).max().item()
++        unpadded_max_grid_size = safe_max_item(
++            grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2]
+         )
+         max_grid_size = get_nearest_pad(
+             unpadded_max_grid_size,
+diff --git a/surya/common/surya/encoder/__init__.py b/surya/common/surya/encoder/__init__.py
+index 8cbf5041..2c29c444 100644
+--- a/surya/common/surya/encoder/__init__.py
++++ b/surya/common/surya/encoder/__init__.py
+@@ -8,6 +8,7 @@
+ 
+ from surya.common.pretrained import SuryaPreTrainedModel
+ from surya.common.surya.encoder.config import SuryaEncoderConfig
++from surya.common.util import safe_max_item
+ from surya.common.xla import get_nearest_pad
+ from surya.logging import get_logger
+ from surya.settings import settings
+@@ -307,7 +308,7 @@ def forward(
+         v = v.squeeze(0)
+         cu_seqlens = cu_seqlens.squeeze(0)
+ 
+-        max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
++        max_seqlen = safe_max_item(cu_seqlens[1:] - cu_seqlens[:-1])
+         attn_output = flash_attn_varlen_func(
+             q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen
+         ).reshape(bsz, seq_length, -1)
+@@ -435,7 +436,7 @@ def unpack_qkv_with_mask(self, q, k, v, cu_seqlens):
+         head_dim = q.shape[2]
+ 
+         seq_lengths = cu_seqlens[1:] - cu_seqlens[:-1]  # Keep as tensor
+-        max_seq_len = seq_lengths.max().item()  # Use .max() on tensor
++        max_seq_len = safe_max_item(seq_lengths)
+ 
+         if settings.FOUNDATION_STATIC_CACHE:
+             # Pad max_seq_len to the nearest multiple for compilation
+diff --git a/surya/common/surya/flash_attn_utils.py b/surya/common/surya/flash_attn_utils.py
+index c8aefe35..95b2d244 100644
+--- a/surya/common/surya/flash_attn_utils.py
++++ b/surya/common/surya/flash_attn_utils.py
+@@ -22,9 +22,10 @@ def _get_unpad_data(attention_mask: torch.Tensor) -> tuple[torch.Tensor, torch.T
+         max_seqlen_in_batch (`int`):
+             Maximum sequence length in batch.
+     """
++    from surya.common.util import safe_max_item
+     seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
+     indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
+-    max_seqlen_in_batch = seqlens_in_batch.max().item()
++    max_seqlen_in_batch = safe_max_item(seqlens_in_batch)
+     cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
+     return (
+         indices,
+diff --git a/surya/common/util.py b/surya/common/util.py
+index 4d7b4bea..f55f54e7 100644
+--- a/surya/common/util.py
++++ b/surya/common/util.py
+@@ -8,6 +8,23 @@
+ from surya.common.polygon import PolygonBox
+ 
+ 
++def safe_max_item(tensor: torch.Tensor) -> int:
++    """Compute tensor.max().item() safely across all backends.
++
++    On MPS (Apple Silicon), the `.max()` kernel can produce incorrect
++    out-of-bounds indices for certain tensor shapes, causing
++    ``torch.AcceleratorError``.  Moving the (small) tensor to CPU before
++    reduction avoids the buggy kernel with negligible overhead.
++
++    On CUDA and CPU the tensor is used as-is.
++
++    See: https://github.com/datalab-to/surya/issues/490
++    """
++    if tensor.device.type == "mps":
++        return tensor.cpu().max().item()
++    return tensor.max().item()
++
++
+ def clean_boxes(boxes: List[PolygonBox]) -> List[PolygonBox]:
+     new_boxes = []
+     for box_obj in boxes:
+diff --git a/surya/foundation/cache/dynamic_ops.py b/surya/foundation/cache/dynamic_ops.py
+index 168092f3..11605800 100644
+--- a/surya/foundation/cache/dynamic_ops.py
++++ b/surya/foundation/cache/dynamic_ops.py
+@@ -259,8 +259,9 @@ def decode_attention_mask_update(
+             non_full_current_lens = current_lens[non_full_mask]
+             non_full_valid_tokens = num_valid_tokens[non_full_mask]
+ 
++            from surya.common.util import safe_max_item
+             max_valid_tokens = (
+-                non_full_valid_tokens.max().item()
++                safe_max_item(non_full_valid_tokens)
+                 if len(non_full_valid_tokens) > 0
+                 else 0
+             )
+@@ -353,7 +354,8 @@ def _decode_update(
+             text_token_counts + cache_text_start,
+         )
+ 
+-        max_tokens = num_valid_tokens.max().item()
++        from surya.common.util import safe_max_item
++        max_tokens = safe_max_item(num_valid_tokens)
+         offsets = torch.arange(max_tokens, device=device).unsqueeze(0)  # [1, max_T]
+         valid_mask = offsets < num_valid_tokens.unsqueeze(1)  # [B, max_T]
+         src_indices = (seq_len - num_valid_tokens).unsqueeze(1) + offsets  # [B, max_T]
+diff --git a/surya/foundation/cache/static_ops.py b/surya/foundation/cache/static_ops.py
+index 0b9ee242..69caec87 100644
+--- a/surya/foundation/cache/static_ops.py
++++ b/surya/foundation/cache/static_ops.py
+@@ -128,7 +128,8 @@ def _prefill_update(
+     def decode_attention_mask_update(
+         self, num_valid_tokens: torch.Tensor, cache_idxs: List[int]
+     ):
+-        max_valid_tokens = num_valid_tokens.max().item()
++        from surya.common.util import safe_max_item
++        max_valid_tokens = safe_max_item(num_valid_tokens)
+         if max_valid_tokens == 0:
+             # If no valid tokens, we don't need to update the attention mask
+             return
+diff --git a/surya/ocr_error/model/encoder.py b/surya/ocr_error/model/encoder.py
+index cac1c507..d0d0ffc0 100644
+--- a/surya/ocr_error/model/encoder.py
++++ b/surya/ocr_error/model/encoder.py
+@@ -26,9 +26,10 @@
+ 
+ 
+ def _get_unpad_data(attention_mask):
++    from surya.common.util import safe_max_item
+     seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
+     indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
+-    max_seqlen_in_batch = seqlens_in_batch.max().item()
++    max_seqlen_in_batch = safe_max_item(seqlens_in_batch)
+     cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
+     return (
+         indices,

--- a/scripts/surya_mps_patch.py
+++ b/scripts/surya_mps_patch.py
@@ -1,0 +1,140 @@
+"""Apply / revert / status the surya MPS .max() crash fix locally.
+
+Vendors the diff from https://github.com/datalab-to/surya/pull/493 against
+the surya-ocr install in the active virtualenv. Necessary because the fix
+hasn't shipped in any tagged release yet (latest published surya-ocr is
+0.17.1 as of this writing).
+
+Usage:
+    uv run python scripts/surya_mps_patch.py status
+    uv run python scripts/surya_mps_patch.py apply
+    uv run python scripts/surya_mps_patch.py revert
+
+The script is idempotent. `apply` is a no-op if already applied; `revert`
+is a no-op if not applied. Re-run `apply` after any `uv sync` that
+reinstalls surya-ocr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from importlib import metadata
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PATCH_FILE = REPO_ROOT / "scripts" / "patches" / "surya-mps-fix.patch"
+SENTINEL = "def safe_max_item("  # added by the patch in surya/common/util.py
+
+
+def surya_root() -> Path:
+    """Path to the installed surya package (parent of `surya/`).
+
+    `patch -p1` is run from this directory because the diff paths are
+    `surya/common/...` (one leading component to strip).
+    """
+    files = metadata.files("surya-ocr")
+    if files is None:
+        msg = "surya-ocr is not installed in this environment"
+        raise SystemExit(msg)
+    for f in files:
+        if str(f).startswith("surya/__init__.py"):
+            # f is relative to site-packages
+            return f.locate().resolve().parent.parent
+    msg = "could not locate surya/__init__.py inside surya-ocr's metadata"
+    raise SystemExit(msg)
+
+
+def is_applied(root: Path) -> bool:
+    util = root / "surya" / "common" / "util.py"
+    if not util.exists():
+        return False
+    return SENTINEL in util.read_text(encoding="utf-8")
+
+
+def cmd_status() -> int:
+    root = surya_root()
+    applied = is_applied(root)
+    print(f"surya install:  {root}")
+    print(f"surya version:  {metadata.version('surya-ocr')}")
+    print(f"patch source:   {PATCH_FILE.relative_to(REPO_ROOT)}")
+    print(f"patch applied:  {'YES' if applied else 'NO'}")
+    return 0 if applied else 1
+
+
+def _run_patch(root: Path, *extra: str) -> subprocess.CompletedProcess:
+    cmd = ["patch", "-p1", "-i", str(PATCH_FILE), *extra]
+    return subprocess.run(cmd, cwd=root, check=False, capture_output=True, text=True)
+
+
+def cmd_apply() -> int:
+    root = surya_root()
+    if is_applied(root):
+        print("already applied; nothing to do")
+        return 0
+
+    # Dry run first to catch context mismatches before touching files
+    dry = _run_patch(root, "--dry-run")
+    if dry.returncode != 0:
+        print("patch dry-run failed (surya version may have moved):", file=sys.stderr)
+        print(dry.stdout, file=sys.stderr)
+        print(dry.stderr, file=sys.stderr)
+        return 2
+
+    real = _run_patch(root)
+    if real.returncode != 0:
+        print("patch apply failed:", file=sys.stderr)
+        print(real.stdout, file=sys.stderr)
+        print(real.stderr, file=sys.stderr)
+        return 2
+
+    if not is_applied(root):
+        print("patch returned 0 but sentinel not found — aborting", file=sys.stderr)
+        return 3
+    print("applied surya MPS fix to", root)
+    return 0
+
+
+def cmd_revert() -> int:
+    root = surya_root()
+    if not is_applied(root):
+        print("patch is not applied; nothing to do")
+        return 0
+
+    real = _run_patch(root, "-R")
+    if real.returncode != 0:
+        print("patch revert failed:", file=sys.stderr)
+        print(real.stdout, file=sys.stderr)
+        print(real.stderr, file=sys.stderr)
+        return 2
+
+    if is_applied(root):
+        print("patch reported success but sentinel still present", file=sys.stderr)
+        return 3
+    print("reverted surya MPS fix from", root)
+    return 0
+
+
+def main() -> int:
+    if not shutil.which("patch"):
+        print("the `patch` binary is required", file=sys.stderr)
+        return 4
+    if not PATCH_FILE.exists():
+        print(f"patch file missing: {PATCH_FILE}", file=sys.stderr)
+        return 4
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=["status", "apply", "revert"])
+    args = parser.parse_args()
+
+    return {
+        "status": cmd_status,
+        "apply": cmd_apply,
+        "revert": cmd_revert,
+    }[args.action]()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_marker_with_patch.py
+++ b/scripts/test_marker_with_patch.py
@@ -1,0 +1,119 @@
+"""Run Marker against a CSV of known-failed PDFs and report what changed.
+
+Reads (id, storage_path, reason) rows, calls maildb's existing
+extract_markdown wrapper around Marker once per file, prints a per-file
+verdict (ok / same-error / new-error / timeout) plus a summary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import signal
+import sys
+import time
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--csv", required=True, type=Path)
+    p.add_argument("--attachment-dir", required=True, type=Path)
+    p.add_argument("--timeout-s", default=300, type=int)
+    return p.parse_args()
+
+
+class Timeout(Exception):
+    pass
+
+
+def _alarm(_s, _f):
+    raise Timeout
+
+
+def main() -> int:
+    args = parse_args()
+
+    print("loading marker…", file=sys.stderr)
+    from maildb.ingest.extraction import extract_markdown
+
+    rows: list[dict[str, str]] = []
+    with args.csv.open() as f:
+        rows.extend(csv.DictReader(f))
+
+    results: list[dict] = []
+    for i, row in enumerate(rows, 1):
+        path = args.attachment_dir / row["storage_path"]
+        prior_reason = row.get("reason", "")
+        print(f"[{i}/{len(rows)}] id={row['id']} {row['filename'][:60]}", file=sys.stderr)
+        old = signal.signal(signal.SIGALRM, _alarm)
+        signal.alarm(args.timeout_s)
+        t0 = time.monotonic()
+        try:
+            r = extract_markdown(path, content_type="application/pdf")
+            elapsed = time.monotonic() - t0
+            results.append(
+                {
+                    "id": row["id"],
+                    "verdict": "ok",
+                    "elapsed_s": round(elapsed, 1),
+                    "out_kb": len(r.markdown.encode("utf-8")) // 1024,
+                    "prior_reason": prior_reason[:60],
+                    "new_error": "",
+                }
+            )
+            print(f"   → ok  {elapsed:.1f}s  out_kb={len(r.markdown) // 1024}", file=sys.stderr)
+        except Timeout:
+            results.append(
+                {
+                    "id": row["id"],
+                    "verdict": "timeout",
+                    "elapsed_s": float(args.timeout_s),
+                    "out_kb": 0,
+                    "prior_reason": prior_reason[:60],
+                    "new_error": f"timeout {args.timeout_s}s",
+                }
+            )
+            print("   → TIMEOUT", file=sys.stderr)
+        except Exception as exc:
+            elapsed = time.monotonic() - t0
+            err = f"{type(exc).__name__}: {str(exc)[:200]}"
+            same = "out of bounds" in str(exc).lower() and "out of bounds" in prior_reason.lower()
+            results.append(
+                {
+                    "id": row["id"],
+                    "verdict": "same-error" if same else "new-error",
+                    "elapsed_s": round(elapsed, 1),
+                    "out_kb": 0,
+                    "prior_reason": prior_reason[:60],
+                    "new_error": err[:120],
+                }
+            )
+            print(f"   → {('SAME' if same else 'NEW')}  {err[:100]}", file=sys.stderr)
+        finally:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, old)
+
+    print("\n# Patch test results\n")
+    print("| id | verdict | elapsed_s | out_kb | prior_reason | new_error |")
+    print("|---|---|---|---|---|---|")
+    for r in results:
+        print(
+            f"| {r['id']} | {r['verdict']} | {r['elapsed_s']} | {r['out_kb']} | "
+            f"{r['prior_reason']} | {r['new_error']} |"
+        )
+
+    n = len(results)
+    counts = {
+        v: sum(1 for r in results if r["verdict"] == v)
+        for v in ("ok", "same-error", "new-error", "timeout")
+    }
+    print(
+        f"\nTotal: {n}  ok={counts['ok']}  same-error={counts['same-error']}  "
+        f"new-error={counts['new-error']}  timeout={counts['timeout']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Vendors [datalab-to/surya PR #493](https://github.com/datalab-to/surya/pull/493) (Apple Silicon MPS `.max()` kernel crash fix) under `scripts/patches/surya-mps-fix.patch`. Latest published `surya-ocr` is 0.17.1; the fix isn't in any tagged release yet.
- Adds `scripts/surya_mps_patch.py` (apply | revert | status — idempotent) and a `just patch-surya` justfile target so the workflow survives `uv sync` cycles.
- Adds `scripts/test_marker_with_patch.py` — a repeatable verification harness used to validate the fix.
- Per-file ruff ignores for `scripts/**/*.py` (T201/INP001/N818/PLC0415/S603 — script-CLI conventions).
- `.gitignore` `*.log` (runtime artifacts).

## Why

The Surya MPS bug accounts for **6,470 of 6,479 (99.9%) of `failed` attachments** in the dev DB — concentrated in PDFs (4,513), DOCX (728), XLSX (409), images, etc. Investigation, root-cause, and upstream status are all in #55.

## Validation

Smoke-tested with the patch applied against 10 PDFs that previously failed with the surya out-of-bounds class:

| metric | result |
|---|---|
| previously hit surya \`index out of bounds\` (10/10) | **0 recur** |
| extracted within 300s | **8 / 10** |
| hit my test script's 300s wall-clock cap | 2 / 10 |

The two timeouts are large multi-page docs (9MB DigiCert guide; a 49-page levy PDF) — not a marker bug, just need a longer per-doc budget on the eventual production retry.

## Operational notes

- Apply to the active venv: \`just patch-surya\` (or \`just patch-surya status\` / \`revert\`).
- Re-run after every \`uv sync\` that reinstalls \`surya-ocr\`.
- When upstream cuts a release including PR #493: drop the patch directory + script, bump the \`surya-ocr\` pin, remove the justfile target.

## Test plan
- [x] \`just patch-surya status\` → applied=YES after \`apply\`, applied=NO after \`revert\`, idempotent on re-run.
- [x] \`uv run just check\` — ruff fmt/lint, mypy clean, 446/447 tests pass.
- [x] 10 known-failed PDFs no longer raise the surya out-of-bounds error with patch applied.
- [ ] After merge: \`just patch-surya\` then \`maildb process_attachments retry --extract-timeout 600\` to drain the surya-bug backlog (~6,000 rows).

## Known pre-existing failure
\`tests/integration/test_process_attachments_e2e.py::test_e2e_pdf_extraction_and_search\` fails on \`main\` (and on commit 42fda60, before #54) — unrelated to this PR. Worth a separate investigation; this PR's scope is just the surya fix.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)