### PR TITLE
fix(supervisor): per-worker claim ownership + process-group kill

### DIFF
--- a/src/maildb/ingest/process_attachments.py
+++ b/src/maildb/ingest/process_attachments.py
@@ -8,9 +8,12 @@ mid-run (watchdog reclaims 'extracting' rows older than the threshold).
 
 from __future__ import annotations
 
+import contextlib
 import multiprocessing as mp
+import os
 import signal
 import time
+import uuid
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -240,8 +243,15 @@ def _claim_row(
     retry_failed: bool,
     selector_sql: str = "",
     selector_params: dict[str, Any] | None = None,
+    claimed_by: str | None = None,
 ) -> int | None:
-    """Atomically move one row to 'extracting' and return its attachment_id."""
+    """Atomically move one row to 'extracting' and return its attachment_id.
+
+    ``claimed_by`` tags the row with the caller's identifier so that a
+    supervisor watching for stuck rows can scope to its own worker only —
+    without it, parallel supervisors race and mass-mark each other's
+    in-flight rows as hard-timeout (see issue #59).
+    """
     states = "('pending','failed')" if retry_failed else "('pending')"
     sql = f"""
         WITH claimed AS (
@@ -253,12 +263,16 @@ def _claim_row(
              FOR UPDATE SKIP LOCKED
         )
         UPDATE attachment_contents
-           SET status = 'extracting', extracted_at = now(), reason = NULL
+           SET status = 'extracting',
+               extracted_at = now(),
+               reason = NULL,
+               claimed_by = %(claimed_by)s
          WHERE attachment_id IN (SELECT attachment_id FROM claimed)
         RETURNING attachment_id
     """
+    params = {"claimed_by": claimed_by, **(selector_params or {})}
     with pool.connection() as conn:
-        cur = conn.execute(sql, selector_params or {})
+        cur = conn.execute(sql, params)
         row = cur.fetchone()
         conn.commit()
         return row[0] if row else None
@@ -364,6 +378,7 @@ def _claim_and_process_loop(
     selector_sql: str,
     selector_params: dict[str, Any] | None,
     extract_timeout_s: int = 0,
+    claimed_by: str | None = None,
 ) -> None:
     """Claim rows one at a time via SKIP LOCKED and process until none remain."""
     while True:
@@ -372,6 +387,7 @@ def _claim_and_process_loop(
             retry_failed=retry_failed,
             selector_sql=selector_sql,
             selector_params=selector_params,
+            claimed_by=claimed_by,
         )
         if attachment_id is None:
             return
@@ -394,6 +410,7 @@ def _subprocess_worker(
     selector_sql: str,
     selector_params: dict[str, Any] | None,
     extract_timeout_s: int = 0,
+    claimed_by: str | None = None,
 ) -> None:
     """Subprocess entrypoint: build a fresh pool and run the claim loop.
 
@@ -401,7 +418,15 @@ def _subprocess_worker(
     is required because Marker's model init is not thread-safe — multiple threads
     hitting `create_model_dict()` concurrently produce meta-tensor errors. Process-
     level parallelism avoids that entirely at the cost of per-process startup time.
+
+    Calls ``os.setsid()`` first so that the supervisor can SIGKILL the entire
+    process group (this child plus any grandchildren marker/torch spawn). Without
+    that, each supervisor kill leaks the grandchildren as orphans (issue #59).
     """
+    # Already a session leader (e.g. when invoked outside the supervisor) — fine.
+    with contextlib.suppress(OSError, PermissionError):
+        os.setsid()
+
     pool = ConnectionPool(conninfo=database_url, min_size=1, max_size=2, open=True)
     try:
         _claim_and_process_loop(
@@ -411,6 +436,7 @@ def _subprocess_worker(
             selector_sql=selector_sql,
             selector_params=selector_params,
             extract_timeout_s=extract_timeout_s,
+            claimed_by=claimed_by,
         )
     finally:
         pool.close()
@@ -620,17 +646,43 @@ def _mp_context() -> Any:
     return mp.get_context("spawn")
 
 
-def _find_stuck_extracting(pool: ConnectionPool, extract_timeout_s: int) -> list[int]:
-    """Return attachment_ids that have been in 'extracting' longer than the timeout."""
+def _find_stuck_extracting(
+    pool: ConnectionPool,
+    extract_timeout_s: int,
+    *,
+    claimed_by: str | None = None,
+) -> list[int]:
+    """Return attachment_ids stuck in 'extracting' beyond the timeout.
+
+    When ``claimed_by`` is provided, only rows tagged with that supervisor's
+    UUID are returned — preventing parallel supervisors from killing each
+    other's actively-running rows (issue #59).
+    """
+    where_claimed_by = "AND claimed_by = %s" if claimed_by is not None else ""
+    sql = (
+        "SELECT attachment_id FROM attachment_contents "
+        "WHERE status = 'extracting' "
+        "  AND extracted_at < now() - (%s || ' seconds')::interval "
+        f" {where_claimed_by} "
+        "ORDER BY attachment_id"
+    )
+    params: tuple[Any, ...] = (
+        (extract_timeout_s, claimed_by) if claimed_by is not None else (extract_timeout_s,)
+    )
     with pool.connection() as conn:
-        cur = conn.execute(
-            "SELECT attachment_id FROM attachment_contents "
-            "WHERE status = 'extracting' "
-            "  AND extracted_at < now() - (%s || ' seconds')::interval "
-            "ORDER BY attachment_id",
-            (extract_timeout_s,),
-        )
+        cur = conn.execute(sql, params)
         return [row[0] for row in cur.fetchall()]
+
+
+def _killpg_quietly(pid: int, sig: int = signal.SIGKILL) -> None:
+    """SIGKILL the process group named by ``pid`` (the worker's pgid after setsid).
+
+    Reaps grandchildren — direct ``Process.kill()`` only terminates the immediate
+    child, leaving torch/marker helper processes as orphans (issue #59). Swallows
+    the typical ``ProcessLookupError`` when the group has already exited.
+    """
+    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+        os.killpg(pid, sig)
 
 
 def _run_supervised_single_worker(
@@ -649,10 +701,19 @@ def _run_supervised_single_worker(
     Marker when it's deep in a PyTorch C extension, so a stuck document pins
     the whole retry forever. This supervisor spawns ``_subprocess_worker`` in
     a fresh process, polls the DB every few seconds for rows that have been
-    in ``extracting`` longer than ``extract_timeout_s``, SIGKILLs the child,
-    marks those rows ``failed`` with reason prefix ``hard-timeout:``, and
-    respawns a new worker. Exits cleanly when no more matching rows remain.
+    in ``extracting`` longer than ``extract_timeout_s``, SIGKILLs the child
+    (and its process group, to reap grandchildren), marks those rows ``failed``
+    with reason prefix ``hard-timeout:``, and respawns a new worker. Exits
+    cleanly when no more matching rows remain.
+
+    Each supervisor instance generates its own ``claimed_by`` UUID and only
+    kills rows tagged with that UUID — making it safe to run multiple
+    supervisors in parallel against the same DB without racing on shared
+    stuck-row detection (issue #59).
     """
+    supervisor_id = f"sup-{uuid.uuid4()}"
+    logger.info("supervisor_started", supervisor_id=supervisor_id)
+
     while True:
         remaining = _count_selected(
             pool,
@@ -673,6 +734,7 @@ def _run_supervised_single_worker(
                 "selector_sql": selector_sql,
                 "selector_params": selector_params,
                 "extract_timeout_s": 0,  # SIGALRM is ineffective; supervisor owns the clock
+                "claimed_by": supervisor_id,
             },
         )
         worker.start()
@@ -680,11 +742,17 @@ def _run_supervised_single_worker(
         killed = False
         while worker.is_alive():
             time.sleep(_SUPERVISOR_POLL_S)
-            stuck = _find_stuck_extracting(pool, extract_timeout_s)
+            stuck = _find_stuck_extracting(pool, extract_timeout_s, claimed_by=supervisor_id)
             if not stuck:
                 continue
-            logger.warning("killing_stuck_worker", stuck=stuck, timeout_s=extract_timeout_s)
+            logger.warning(
+                "killing_stuck_worker",
+                supervisor_id=supervisor_id,
+                stuck=stuck,
+                timeout_s=extract_timeout_s,
+            )
             worker.kill()
+            _killpg_quietly(worker.pid)  # reap grandchildren torch/marker spawned
             worker.join(timeout=10)
             for aid in stuck:
                 _set_status(

--- a/src/maildb/schema_tables.sql
+++ b/src/maildb/schema_tables.sql
@@ -98,8 +98,13 @@ CREATE TABLE IF NOT EXISTS attachment_contents (
     reason            TEXT,
     extracted_at      TIMESTAMPTZ,
     extraction_ms     INT,
-    extractor_version TEXT
+    extractor_version TEXT,
+    -- Supervisor UUID that claimed the row. Lets parallel supervisors distinguish
+    -- their own stuck workers from each other's in-flight rows.
+    claimed_by        TEXT
 );
+
+ALTER TABLE attachment_contents ADD COLUMN IF NOT EXISTS claimed_by TEXT;
 
 CREATE TABLE IF NOT EXISTS attachment_chunks (
     id             BIGSERIAL PRIMARY KEY,

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -302,6 +302,7 @@ def test_attachment_contents_table_exists(test_pool) -> None:  # type: ignore[no
         "extracted_at",
         "extraction_ms",
         "extractor_version",
+        "claimed_by",
     }
 
 

--- a/tests/unit/test_process_attachments.py
+++ b/tests/unit/test_process_attachments.py
@@ -340,18 +340,40 @@ def test_reembed_zero_vectors_marks_row_failed_on_persistent_error() -> None:
 # --- Supervised single-worker with hard-kill timeout -------------------------
 
 
-def test_find_stuck_extracting_returns_rows_past_timeout() -> None:
-    """SQL selects 'extracting' rows whose extracted_at is older than now-timeout."""
+def test_find_stuck_extracting_filters_by_claimed_by() -> None:
+    """SQL selects 'extracting' rows past the timeout AND owned by this supervisor only.
+
+    Without the ownership filter, parallel supervisors race and mass-mark each
+    other's actively-running rows as hard-timeout (issue #59).
+    """
     pool = MagicMock()
     cur = pool.connection.return_value.__enter__.return_value.execute.return_value
     cur.fetchall.return_value = [(42,), (99,)]
 
-    result = pa._find_stuck_extracting(pool, extract_timeout_s=300)
+    result = pa._find_stuck_extracting(pool, extract_timeout_s=300, claimed_by="sup-uuid-A")
 
     assert result == [42, 99]
-    sql = pool.connection.return_value.__enter__.return_value.execute.call_args.args[0]
+    call = pool.connection.return_value.__enter__.return_value.execute.call_args
+    sql, params = call.args
     assert "status = 'extracting'" in sql
     assert "extracted_at" in sql
+    assert "claimed_by" in sql
+    assert params[1] == "sup-uuid-A"
+
+
+def test_claim_row_writes_claimed_by() -> None:
+    """_claim_row tags the row with the supervisor's UUID so the matching
+    _find_stuck_extracting query can scope to its own work only."""
+    pool = MagicMock()
+    cur = pool.connection.return_value.__enter__.return_value.execute.return_value
+    cur.fetchone.return_value = (7,)
+
+    pa._claim_row(pool, retry_failed=True, claimed_by="sup-uuid-X")
+
+    call = pool.connection.return_value.__enter__.return_value.execute.call_args
+    sql, params = call.args
+    assert "claimed_by" in sql
+    assert params["claimed_by"] == "sup-uuid-X"
 
 
 def test_run_single_worker_with_timeout_uses_supervised_path() -> None:
@@ -451,6 +473,7 @@ def test_supervised_run_kills_and_marks_failed_on_stuck() -> None:
     fake_ctx = MagicMock()
     worker = MagicMock()
     worker.is_alive.return_value = True
+    worker.pid = 12345
     fake_ctx.Process.return_value = worker
 
     set_status = MagicMock()
@@ -459,6 +482,7 @@ def test_supervised_run_kills_and_marks_failed_on_stuck() -> None:
         patch.object(pa, "_find_stuck_extracting", side_effect=[[42], []]),
         patch.object(pa, "_mp_context", return_value=fake_ctx),
         patch.object(pa, "_set_status", set_status),
+        patch.object(pa, "_killpg_quietly") as killpg,
         patch.object(pa, "time") as tmod,
     ):
         tmod.sleep = MagicMock()
@@ -473,9 +497,58 @@ def test_supervised_run_kills_and_marks_failed_on_stuck() -> None:
         )
 
     worker.kill.assert_called_once()
+    killpg.assert_called_once_with(12345)  # process-group kill reaps grandchildren
     set_status.assert_called_once()
     args, kwargs = set_status.call_args
     assert args[1] == 42
     assert kwargs["status"] == "failed"
     assert kwargs["reason"].startswith("hard-timeout:")
     assert "300" in kwargs["reason"]
+
+
+def test_supervised_run_threads_unique_claimed_by_uuid() -> None:
+    """Supervisor generates a UUID once and passes the SAME value to:
+    - the spawned worker (so its claims tag the row with this id)
+    - _find_stuck_extracting (so it only sees rows it owns)
+
+    Without this, two supervisors race on shared stuck-row detection.
+    """
+    pool = MagicMock()
+    fake_ctx = MagicMock()
+    worker = MagicMock()
+    worker.is_alive.side_effect = [True, False]
+    worker.pid = 99
+    fake_ctx.Process.return_value = worker
+
+    find_stuck = MagicMock(return_value=[])
+    with (
+        patch.object(pa, "_count_selected", side_effect=[5, 0]),
+        patch.object(pa, "_find_stuck_extracting", find_stuck),
+        patch.object(pa, "_mp_context", return_value=fake_ctx),
+        patch.object(pa, "time") as tmod,
+    ):
+        tmod.sleep = MagicMock()
+        pa._run_supervised_single_worker(
+            pool,
+            attachment_dir=Path("/tmp"),
+            retry_failed=True,
+            selector_sql="",
+            selector_params={},
+            database_url="postgresql://x/y",
+            extract_timeout_s=300,
+        )
+
+    # Worker was given a claimed_by kwarg
+    process_kwargs = fake_ctx.Process.call_args.kwargs["kwargs"]
+    assert "claimed_by" in process_kwargs
+    sup_id = process_kwargs["claimed_by"]
+    assert sup_id  # non-empty
+
+    # _find_stuck_extracting was called with the SAME id
+    assert find_stuck.call_args.kwargs.get("claimed_by") == sup_id
+
+
+def test_killpg_quietly_swallows_lookup_errors() -> None:
+    """SIGKILL on a pgid that no longer exists should not raise."""
+    with patch("os.killpg", side_effect=ProcessLookupError):
+        pa._killpg_quietly(12345)  # must not raise


### PR DESCRIPTION
## Summary

- **Claim ownership**: each supervisor now generates a UUID, threads it through to its spawned worker which writes it on every claim (new \`claimed_by\` column). The supervisor's \`_find_stuck_extracting\` filter is scoped to that UUID, so parallel supervisors can't kill each other's actively-running rows.
- **Grandchild reaping**: the worker calls \`os.setsid()\` at entry so its pid becomes the process-group id. After \`Process.kill()\` the supervisor sends \`os.killpg(worker.pid, SIGKILL)\` to terminate the whole group — torch/marker helper processes don't leak as orphans.
- Idempotent schema migration adds the \`claimed_by TEXT\` column.

Investigation in #59. Both bugs caused real production damage in the 2026-04-21 dual-drain run (~5,705 false hard-timeouts + 152 zombie processes / ~38GB RAM leaked).

## Test plan
- [x] \`uv run just check\` — ruff fmt/lint, mypy, 467 tests pass.
- [x] New unit tests: \`_find_stuck_extracting\` filters by claimed_by; \`_claim_row\` writes claimed_by; supervisor threads same UUID to worker and stuck-finder; supervisor calls \`_killpg_quietly\` on stuck; \`_killpg_quietly\` swallows ProcessLookupError.
- [x] Updated integration test: \`attachment_contents\` schema includes \`claimed_by\`.
- [x] **Live smoke test** on the known-hang attachment 11 with 30s timeout:
  - claim happened at T+10s, claimed_by populated with supervisor UUID
  - kill happened at T+39s — exactly 30s after claim
  - row marked \`failed\` with reason \`hard-timeout: killed after 30s\`
  - **0 orphan multiprocessing.spawn processes after kill** (prior incident: 152)
  - process exited 0 (selector exhausted, no respawn)
- [ ] After merge: kick off the production drain again.

## Notes

- Multi-worker (\`workers > 1\`) ProcessPoolExecutor path still has its own issues; out of scope here. With this fix, running multiple \`workers=1\` supervisors in parallel is now safe.
- The fix is back-compatible: \`claimed_by=None\` everywhere it's optional, so existing in-process callers and tests need no changes.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)