### PR TITLE
feat(extraction): MarkItDown leg for ical/csv/xls/json/xml/vcard/pages (Tier 4 of #78)

### DIFF
--- a/docs/retrospectives/attachment-residuals-2026-05-03.md
+++ b/docs/retrospectives/attachment-residuals-2026-05-03.md
@@ -1,0 +1,321 @@
+# Attachment Drain — Residuals Report (Post Tier-1/2/3 Phase 2 Drain)
+
+**Date:** 2026-05-03
+**Drains covered:** Phase 1 (300s extract-timeout, 3h 52m) + Phase 2 (900s extract-timeout, 8h 00m)
+**Stack:** Tier 1 (Docling fallback + NUL sanitizer), Tier 2 (yield dashboard, MPS-discipline, tiny-image filter, smoke-marker, orphan detector), Tier 3 (per-run logs, --max-runtime ceiling)
+
+## Executive summary
+
+After the two-phase drain, **10,746 attachments are extracted, 790 are failed, 24,034 are skipped, 0 pending**. The 790 failed pool is dominated by one bucket — **681 mid-size PDFs / oversized images / large xlsx files that exceed the 900s extraction budget** (the "slow tail"). The remaining 109 are split across upstream surya MPS bugs (64), encrypted PDFs (25), 900s timeouts (13), and a handful of edge cases. The 24,034 skipped are intentionally unsupported content types — most of them outside Marker's scope by design (audio, calendar invites, archives, vcards), but some (csv, doc/xls legacy, octet-stream re-detection) are recoverable with modest engineering.
+
+## Final state
+
+| Status | Count | % of total |
+|---|---:|---:|
+| extracted | 10,746 | 30.2% |
+| skipped | 24,034 | 67.6% |
+| failed | **790** | **2.2%** |
+
+The on-disk size of the 790 failed pool is **1,813 MB** (~2.3 MB/file average — most are PDFs).
+
+---
+
+## 1. The 790 failed pool
+
+### Failure-class breakdown
+
+| Bucket | Count | % | Recoverable? | Notes |
+|---|---:|---:|---|---|
+| **deferred-slow-tail** | **681** | **86.2%** | yes, with more compute | Set by us at end of Phase 2; see §2 |
+| surya-mps-bug | 64 | 8.1% | upstream wait | unpatched call sites in surya |
+| pdf-encrypted | 25 | 3.2% | no | password-protected PDFs |
+| hard-timeout-900s | 13 | 1.6% | maybe (90 min budget) | tried twice, timed out at 900s |
+| embed-failed | 3 | 0.4% | trivial retry | Ollama hiccup on 1 chunk |
+| pptx-both-failed | 3 | 0.4% | format fix | Marker (no weasyprint) + Docling rejected |
+| other (corrupt PNG) | 1 | 0.1% | no | unidentifiable image |
+
+### Content-type distribution within failed
+
+| Content type | Count | Notes |
+|---|---:|---|
+| application/pdf | 744 | 643 deferred + 60 mps-bug + 25 encrypted + 13 timeout + 2 pptx-fail + 1 embed |
+| image/png | 15 | 12 deferred + 2 mps-bug + 1 corrupt |
+| image/jpeg | 12 | 8 deferred + 2 mps-bug + 2 misc |
+| xlsx | 17 | all deferred |
+| text/plain | 2 | both embed-failed |
+| pptx | 1 | both extractors failed |
+
+---
+
+## 2. Deferred slow-tail (681 rows) — deep dive
+
+### Composition
+
+| Type | Count | Median size |
+|---|---:|---:|
+| application/pdf | 643 | ~1 MB |
+| image/png + jpeg + jpg | 21 | ~1.5 MB |
+| xlsx | 17 | ~6.5 MB |
+
+### PDF page-count distribution (643 deferred PDFs, 24,830 total pages, mean 38.6/doc)
+
+```
+  1-5     pages   131  ##########
+  6-20    pages   256  ###################
+  21-50   pages   172  #############
+  51-100  pages    45  ###
+  101-200 pages    12
+  201-500 pages    22  #
+  500+    pages     5
+```
+
+**Key insight:** 87% of deferred PDFs have ≤50 pages. They are *not* mostly long documents — Surya is structurally slow on certain page content (image-heavy/scanned), not just on volume.
+
+### Bytes-per-page (proxy for scanned/image content)
+
+Sampled 200 each from deferred and extracted PDFs:
+
+| Set | p25 | p50 | p75 | p95 |
+|---|---:|---:|---:|---:|
+| deferred | 31,963 | 55,707 | **121,203** | **536,171** |
+| extracted | 35,663 | 53,624 | 82,172 | 343,755 |
+
+Tail of the deferred distribution is meaningfully heavier (p75 ~50% higher; p95 ~55% higher), consistent with a higher mix of scanned/image-heavy pages that drive Surya's per-page OCR cost up.
+
+### Top page-heavy deferred PDFs (the long-doc minority)
+
+| Pages | Size | Filename |
+|---:|---:|---|
+| 2,366 | 4.0 MB | Quick_Bill_Summary_11-1-2013.pdf |
+| 754 | 1.5 MB | 2014-06-30 Inv 608371 $76,061.12.PDF |
+| 569 | 1.1 MB | 2014-07-31 AISS Sterling Inv 612123 $56,797.43.pdf |
+| 569 | 1.1 MB | 2014-07-31 AISS Sterling Inv 612123 $56,797.43.PDF (dup) |
+| 568 | 1.1 MB | 2014-07-31 AISS Sterling Inv 612122 $57,344.99.PDF |
+| 322 | 8.2 MB | 635386ACR.pdf |
+| 322 | 8.2 MB | 635386ACL.pdf |
+| 314 | 1.2 MB | Postmates - Series E - Stock and Warrant Purchase Agreement |
+| 307 | 13.8 MB | Marked proof against 2_28 1_18 AM.pdf |
+| 307 | 13.8 MB | Showing all changes that went in today.pdf |
+| 307 | 13.8 MB | Full Clean.pdf |
+| 304 | 7.9 MB | 635386_DRSA_Clean with Banners.pdf |
+
+Cluster: SEC-style legal filings (Series E paperwork, S-1 redactions), long invoice batches, IPO / corporate finance documents.
+
+### Filename pattern clusters (deferred PDFs)
+
+| Pattern | Count | Notes |
+|---|---:|---|
+| pdf-other (no clear pattern) | 529 | the long tail |
+| legal-contract (NDA, SOW, contract, agreement) | 37 | usually scanned-then-signed |
+| report (analysis, report, summary) | 31 | mixed text + chart pages |
+| form/tax (W9, 1099, application) | 17 | scanned forms |
+| finance/receipt | 12 | invoices, statements |
+| deck/presentation | 7 | exported slide PDFs |
+| resume | 5 | |
+| marketing | 2 | |
+| scanned-from-device | 2 | only 2 explicit scanner names — the rest are scanned but named differently |
+
+### Deferred images (21) — almost all giant screenshots
+
+Heaviest 10 images by byte size:
+
+| Type | Pixels | Bytes | Pattern |
+|---|---|---:|---|
+| png | **3,300 × 2,550** | 4.0 MB | menu print export |
+| jpeg | 4,032 × 3,024 | 3.4 MB | iPhone photo |
+| png | 2,400 × **14,125** | 2.8 MB | full-page report screencap |
+| jpeg | 3,366 × 2,100 | 2.4 MB | photo |
+| jpg | 4,032 × 3,024 | 1.9 MB | iPhone photo |
+| png | **3,420 × 8,523** | 1.9 MB | chartio dashboard screenshot |
+| png | **3,420 × 8,478** | 1.9 MB | chartio dashboard screenshot |
+| png | **3,322 × 7,966** | 1.8 MB | chartio dashboard screenshot |
+| png | 2,400 × **10,025** | 1.6 MB | "real-time-by-queue" dashboard |
+| jpeg | 2,448 × 3,264 | 1.2 MB | photo |
+
+**Pattern:** the cluster of 4+ chartio/dashboard PNG screenshots with absurdly tall dimensions (8,000+ pixels of vertical pixels) is a known pathological case for Surya — the layout model walks the image line-by-line and never returns. Same effect explains the multi-page receipt scans and the giant menu PDF.
+
+### Deferred xlsx (17) — large operational spreadsheets
+
+All deferred xlsx files are 2.4–10.9 MB — these are *real* business spreadsheets, not tiny ones:
+
+- 7 are Postmates "operational-model 2014-2020 - <month> '<yy> CONFIDENTIAL" files (monthly model snapshots — multi-tab, formula-heavy)
+- 2 datadumps (3.9 MB and 2.4 MB)
+- 2 jobs/loss tracking tools
+- 6 misc (pricing scenarios, relationship maps, voucher data)
+
+**Hypothesis:** Docling can hit pathological slow-paths on multi-sheet spreadsheets with thousands of formulas / formatted ranges / pivot tables. Worth investigating before another retry pass.
+
+### Why the slow tail exists (root cause classification for the 681)
+
+| Pattern | Approx count | Mechanism |
+|---|---:|---|
+| Scanned/image-heavy mid-size PDFs | ~450 | Surya OCR slow on image pages; >900s on docs with 20-50 dense scanned pages |
+| Page-heavy legal docs (>200 pages) | ~40 | Volume — 200+ pages × multi-second per-page processing exceeds budget |
+| Pathologically tall PNG screenshots | ~10 | Surya layout model degenerate on extreme aspect ratios |
+| Large multi-tab xlsx | 17 | Docling pathological path on real-world business spreadsheets |
+| Mixed/normal PDFs (~50 page band) | ~120 | Borderline — most would complete at 1800s |
+| Long mystery tail | ~50 | Various; would need per-file investigation |
+
+---
+
+## 3. Other failure classes (109 rows)
+
+### surya-mps-bug (64) — wait for upstream
+
+```
+60 PDFs, 4 images. Median size 278 KB. Error:
+  marker: index 1 is out of bounds: 0, range 0 to 1
+  marker: index 8192 is out of bounds: 2, range 0 to 4560
+```
+
+These are residual MPS reduce-kernel bugs at PyTorch ops the `scripts/patches/surya-mps-fix.patch` does not cover (`argmax`, `gather`, `topk`, `take_along_dim`, etc.). PR #56 covered `.max().item()` only. They will refail on retry under the current patch.
+
+**Action:** Track issue #75 (surya MPS bug filing). When a new surya release ships with broader MPS fixes, retry these — historically this class drops from ~6,500 → 64 on patched call sites alone.
+
+### pdf-encrypted (25) — permanent skip
+
+```
+marker: Failed to load document (PDFium: Incorrect password error).
+```
+
+Median 258 KB. These are password-protected (legal counsel files, sealed filings, etc.). No path forward without per-file passwords.
+
+**Action:** Reclassify these as `skipped: encrypted` (separate from `failed`) for honesty. They are not a fix candidate.
+
+### hard-timeout-900s (13) — the slowest of the slow
+
+All PDFs, 400 KB – 7.8 MB. Filenames suggest long redacted business filings (`635386ACR.pdf`, `Marked_against_prior_submission.pdf`, restaurant LLC registrations, etc.). Same root cause as deferred but already given a 900s shot.
+
+**Action:** Group with the deferred-slow-tail for any future "huge timeout" retry pass.
+
+### embed-failed (3) — trivial retry
+
+| id | type | reason |
+|---|---|---|
+| 24612 | application/pdf | embed failed: 1/97 chunks |
+| 35313 | text/plain | embed failed: 1/7 chunks |
+| 35316 | text/plain | embed failed: 1/18 chunks |
+
+Each lost a single chunk on Ollama. Re-running these three in isolation should succeed.
+
+**Action:** Flip → pending, run a tiny retry. Cost: seconds.
+
+### pptx-both-failed (3) — true edge
+
+3 pptx files where Marker's PPTX→PDF leg failed (no weasyprint module) AND Docling rejected the file format. Likely corrupted .pptx or unsupported variants (Keynote-exported, very old PowerPoint).
+
+**Action:** Spot-check the 3 files manually. Likely permanent skip.
+
+### corrupt PNG (1)
+
+```
+id=8734  size=1163B  filename=core.views.api:JobFsmView.post.png
+marker: cannot identify image file
+```
+
+A 1 KB PNG named after a Python function — almost certainly a colon-delimited path-encoded artifact, not a real image. Permanent skip.
+
+---
+
+## 4. The 24,034 skipped pool — what's there, what's recoverable
+
+Listed by count, with assessment.
+
+| ctype | Count | Status | Recoverable how |
+|---|---:|---|---|
+| audio/mpeg + audio/x-mpeg-3 + audio/* | **12,665** | unsupported by Marker | Whisper transcription pipeline (separate concern) |
+| application/ics + text/calendar | **8,259** | unsupported by Marker | Trivial text parser (subject + date + description) — easy fix |
+| application/octet-stream | 1,705 | mystery | Re-detect MIME from magic bytes → route through new pipeline |
+| application/msword (.doc) | 602 | doc_legacy: needs LibreOffice | LibreOffice headless conversion (already noted as v2 work) |
+| application/zip + x-zip-compressed | 270 | unsupported | Recursive unpack + re-process inner files |
+| text/csv | 120 | unsupported by Marker | Trivial — read as text or parse as table |
+| application/vnd.ms-excel (.xls) | 79 | xls_legacy: needs LibreOffice | Same as .doc |
+| video/quicktime + video/mp4 | 49 | unsupported | Out of scope (or audio extraction → Whisper) |
+| empty extraction (image/png + jpeg) | 38 | tried, no text | These ARE image attachments where Marker correctly produced nothing (clip art, logos, signatures). Honest skip. |
+| application/x-iwork-keynote/pages | 27 | unsupported | Convert via Keynote/Pages export, niche |
+| application/json + xml | 19 | unsupported | Trivial text dump |
+| application/rtf | 14 | unsupported | LibreOffice or strip-and-text |
+| application/pgp-signature + pkcs7-signature + x-x509-ca-cert | 35 | crypto material | Permanent skip |
+| text/x-vcard + ms-tnef | 16 | unsupported | tnef is winmail.dat; could parse; vcards trivial text |
+| image/svg+xml + image/bmp | 12 | unsupported by Marker | SVG → text via parsing; bmp → convert to png first |
+| application/x-python | 5 | source code | Skip or trivially text-dump |
+| application/force-download | 8 | mystery (HTTP header artifact) | Re-detect MIME |
+| other low-count | ~10 | various | per-type assessment |
+
+**Coverage gaps that are cheap to close:**
+1. **csv (120)** + **json/xml (19)** + **rtf (14)** + **calendar (8,259)** — all readable as plain text with negligible engineering. **Total ~8,400 rows recoverable** if we add a "fallback: read-as-text" path for known text-shaped MIME types.
+2. **doc_legacy (602)** + **xls_legacy (79)** — LibreOffice headless route, marked as "not implemented in v1." Real engineering, ~2 days.
+3. **zip (270)** — recursive unpack: useful but introduces new edge cases (nested archives, malicious payloads). Smaller win.
+4. **octet-stream (1,705)** — many of these are actually .pdf, .docx, etc. that arrived without a Content-Type. Magic-byte sniffing on ingest would route them to Marker/Docling correctly. Possibly large win.
+5. **audio (12,665)** — Whisper integration is a major project (scope: GBs of weights, hours of compute). Out of scope for this report.
+
+---
+
+## 5. Recommended action paths (cost / yield)
+
+Sorted by yield-per-effort.
+
+### Cheap, high-yield
+
+| Action | Yield | Effort | Risk |
+|---|---:|---|---|
+| Read-as-text fallback for csv / json / xml / rtf / ical / calendar / vcard | **~8,400 rows** | small (~1 day) | low — text is text |
+| Re-detect octet-stream via magic bytes during ingest | up to ~1,000 rows | small (~½ day) | low — new ingest pass |
+| Retry the 3 embed-failed | 3 rows | trivial | none |
+
+### Medium
+
+| Action | Yield | Effort | Risk |
+|---|---:|---|---|
+| LibreOffice route for .doc / .xls (#43?) | **681 rows** | medium (~2 days) | medium — same supervisor model needed |
+| Investigate slow xlsx (17 deferred) — Docling pathological cases | 17 rows | medium | low — diagnostic work |
+| Recursive zip unpack | 270 rows + nested files | medium | medium — security surface |
+
+### Expensive but tractable
+
+| Action | Yield | Effort | Risk |
+|---|---:|---|---|
+| Larger-budget retry pass on deferred (1800s, 2-3 nights of 8h drains) | **~300–500 rows** | low engineering, ~24h compute | none |
+| Pre-filter giant aspect-ratio images, slice into chunks, re-OCR | 21 image rows | medium | low |
+| Pre-detect scanned PDFs, route through faster Tesseract path before Surya | possibly 200+ rows | medium-large | medium — new dependency |
+
+### Wait
+
+| Action | Yield | Effort | When |
+|---|---:|---|---|
+| Surya release with broader MPS patches | 64 rows | none, just pin-bump | watch issue #75 |
+
+### Permanent skip (reclassify as `skipped`, not `failed`)
+
+| Action | Count |
+|---|---:|
+| pdf-encrypted | 25 |
+| pptx-both-failed | 3 |
+| corrupt PNG | 1 |
+| **subtotal** | **29** |
+
+This would shrink the failed pool from 790 → 761 with no compute, just honest accounting.
+
+---
+
+## 6. Suggested first move
+
+If we want a single high-leverage next step, **the read-as-text fallback for csv/json/xml/rtf/ical/calendar** is the cleanest. It would:
+
+- Move ~8,400 rows from `skipped` to `extracted` in a single drain pass (1–3 hours)
+- Land as a tier-4 bundled PR (small surface, similar shape to Tier 1 Docling fallback)
+- Open the door for searchable calendar invites — operationally valuable, especially for `unreplied()` and `top_contacts()` correlation
+
+The **deferred-slow-tail (681)** is realistic but lower-leverage — heavy compute for moderate yield, and the surya MPS upstream fix may make some of these go faster on its own when it lands.
+
+The **LibreOffice .doc / .xls route** is the next-most-strategic but is real engineering; it would be the right thing to ship as Tier 5.
+
+---
+
+## Appendix: numbers used in this report
+
+Generated from the live database 2026-05-03 against `process_attachments` runs:
+- `20260502T193246Z-e3c8d7fe` (Phase 1, 300s, 3h 52m, +1,155 extracted)
+- `20260503T052113Z-4fe64e6d` (Phase 2, 900s, 8h 00m, +45 extracted, +13 failed, 681 reverted to pending then deferred)
+
+Final: extracted=10,746, failed=790, skipped=24,034.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "marker-pdf>=1.2.0",
     "tokenizers>=0.20",
     "docling>=2.92.0",
+    "markitdown[xls]>=0.1.5",
 ]
 
 [project.scripts]

--- a/scripts/spike_markitdown.py
+++ b/scripts/spike_markitdown.py
@@ -1,0 +1,122 @@
+"""Spike: try Microsoft MarkItDown on samples from our skipped attachment pool.
+
+Pulls one example per interesting content_type, runs MarkItDown over each,
+prints timing + markdown preview. Read-only — no DB writes.
+
+Run with:
+  uv run --with 'markitdown[all]' python scripts/spike_markitdown.py
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import psycopg
+
+# Content types worth testing. The residuals report's "read-as-text fallback"
+# bucket is the headline use case. doc_legacy/xls_legacy and zip are bonus.
+TARGETS = [
+    "text/calendar",
+    "application/ics",
+    "text/csv",
+    "application/json",
+    "application/xml",
+    "application/rtf",
+    "text/x-vcard",
+    "application/x-iwork-keynote-sffkey",
+    "application/x-iwork-pages-sffpages",
+    "application/zip",
+    "application/msword",  # doc_legacy — see if MarkItDown does it
+    "application/vnd.ms-excel",  # xls_legacy
+    "application/octet-stream",  # mystery bucket
+    "application/pgp-signature",  # likely ignored, sanity
+    "image/svg+xml",
+]
+
+ATTACHMENT_BASE = Path("~/maildb/attachments").expanduser()
+DSN = "postgresql://maildb@localhost:5432/maildb"
+
+
+@dataclass
+class Sample:
+    aid: int
+    content_type: str
+    filename: str
+    size: int
+    storage_path: str
+
+
+def fetch_samples() -> list[Sample]:
+    out: list[Sample] = []
+    with psycopg.connect(DSN) as conn:
+        for ct in TARGETS:
+            row = conn.execute(
+                """
+                SELECT a.id, a.content_type, a.filename, a.size, a.storage_path
+                FROM attachment_contents c
+                JOIN attachments a ON a.id = c.attachment_id
+                WHERE c.status = 'skipped' AND a.content_type = %s
+                ORDER BY a.size ASC
+                LIMIT 1
+                """,
+                (ct,),
+            ).fetchone()
+            if row is None:
+                continue
+            out.append(Sample(*row))
+    return out
+
+
+def run_one(md, sample: Sample) -> tuple[bool, float, str, str]:
+    """Returns (ok, elapsed_s, markdown, error_msg)."""
+    full = ATTACHMENT_BASE / sample.storage_path
+    t0 = time.perf_counter()
+    try:
+        result = md.convert(str(full))
+    except Exception as e:
+        elapsed = time.perf_counter() - t0
+        return False, elapsed, "", f"{type(e).__name__}: {e}"
+    elapsed = time.perf_counter() - t0
+    return True, elapsed, result.markdown or "", ""
+
+
+def main() -> None:
+    print("== MarkItDown spike on skipped attachments ==\n")
+    from markitdown import MarkItDown
+
+    md = MarkItDown()
+    samples = fetch_samples()
+    print(f"Found {len(samples)} samples across {len(TARGETS)} target types\n")
+
+    summary = []
+    for s in samples:
+        ok, elapsed, markdown, err = run_one(md, s)
+        chars = len(markdown)
+        status = "OK " if ok else "ERR"
+        print(f"--- {status} [{s.content_type}] {s.filename!r} ({s.size}B) ---")
+        print(f"    elapsed: {elapsed * 1000:.0f} ms   markdown: {chars} chars")
+        if not ok:
+            print(f"    error:   {err}")
+        else:
+            preview = markdown.replace("\n", "\n    ")[:600]
+            if not preview.strip():
+                preview = "<empty markdown>"
+            print(f"    preview:\n    {preview}")
+            if chars > 600:
+                print(f"    ... [truncated, {chars - 600} more chars]")
+        print()
+        summary.append((s.content_type, ok, elapsed, chars, err))
+
+    # Final compact table
+    print("\n== Summary ==")
+    print(f"{'content_type':<40s} {'ok':<4s} {'ms':>6s} {'chars':>7s}  notes")
+    for ct, ok, elapsed, chars, err in summary:
+        flag = "OK" if ok else "ERR"
+        note = err[:50] if not ok else ("empty" if chars == 0 else "")
+        print(f"{ct:<40s} {flag:<4s} {elapsed * 1000:>6.0f} {chars:>7d}  {note}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/maildb/cli.py
+++ b/src/maildb/cli.py
@@ -422,6 +422,15 @@ _BUCKET_TO_CONTENT_TYPES: dict[str, list[str]] = {
     ],
     "text": ["text/plain"],
     "html": ["text/html"],
+    # Tier 4 (#83): new MarkItDown-routed buckets. Mirrors the route map in
+    # extraction.py so `--only <bucket>` can target the new content types
+    # for drains and retries.
+    "calendar": ["text/calendar", "application/ics"],
+    "csv": ["text/csv"],
+    "json": ["application/json"],
+    "xml": ["application/xml"],
+    "vcard": ["text/x-vcard"],
+    "pages": ["application/x-iwork-pages-sffpages"],
 }
 
 

--- a/src/maildb/ingest/extraction.py
+++ b/src/maildb/ingest/extraction.py
@@ -7,13 +7,12 @@ and by the Marker dispatch below.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Final
+from pathlib import Path
+from typing import Final
 
 import structlog
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 logger = structlog.get_logger()
 
@@ -27,6 +26,13 @@ SUPPORTED: Final[set[str]] = {
     "text",
     "html",
     "image",
+    # Tier 4: routed through MarkItDown — content types Marker doesn't handle.
+    "calendar",
+    "csv",
+    "json",
+    "xml",
+    "vcard",
+    "pages",
 }
 
 _ROUTES: Final[dict[str, str]] = {
@@ -44,6 +50,14 @@ _ROUTES: Final[dict[str, str]] = {
     "image/gif": "image",
     "image/tiff": "image",
     "image/webp": "image",
+    # Tier 4: MarkItDown buckets.
+    "text/calendar": "calendar",
+    "application/ics": "calendar",
+    "text/csv": "csv",
+    "application/json": "json",
+    "application/xml": "xml",
+    "text/x-vcard": "vcard",
+    "application/x-iwork-pages-sffpages": "pages",
 }
 
 
@@ -65,6 +79,17 @@ class ExtractionResult:
 
 
 _OFFICE_BUCKETS: Final[frozenset[str]] = frozenset({"docx", "xlsx", "pptx"})
+
+_MARKITDOWN_BUCKETS: Final[frozenset[str]] = frozenset(
+    {"calendar", "csv", "json", "xml", "vcard", "pages", "xls_legacy"}
+)
+
+# Suffixes that need UTF-8 normalization before MarkItDown sees them — its
+# PlainTextConverter defaults to ASCII and crashes on common non-ASCII bytes
+# (e.g. UTF-8 smart quotes in calendar invites). See issue #82.
+_MARKITDOWN_TEXT_SUFFIXES: Final[frozenset[str]] = frozenset(
+    {".ics", ".vcs", ".vcf", ".csv", ".json", ".xml"}
+)
 
 # Below these thresholds an image is signature/icon-sized and won't yield useful OCR.
 # Skip them with an explicit reason rather than burning Marker time on an empty result.
@@ -111,6 +136,81 @@ def _marker_convert(path: Path) -> tuple[str, str]:
     rendered = converter(str(path))
     text, _, _ = text_from_rendered(rendered)
     return text, f"marker=={getattr(marker, '__version__', 'unknown')}"
+
+
+def _normalize_to_utf8_temp(path: Path) -> Path:
+    """Decode bytes as UTF-8 with errors='replace' and write to a temp file.
+
+    Workaround for MarkItDown PlainTextConverter ASCII default (#82) — files
+    containing common non-ASCII bytes (smart quotes, em-dashes) crash unless
+    pre-normalized. Invalid bytes become U+FFFD; valid UTF-8 round-trips.
+    Caller owns the returned path and must unlink when done.
+    """
+    import tempfile  # noqa: PLC0415
+
+    text = path.read_bytes().decode("utf-8", errors="replace")
+    fd, name = tempfile.mkstemp(suffix=path.suffix)
+    os.close(fd)
+    out = Path(name)
+    out.write_text(text, encoding="utf-8")
+    return out
+
+
+def _markitdown_run(file_path_str: str, *, force_charset: str | None = None) -> str:
+    """Invoke MarkItDown on a path string; isolated for test patching.
+
+    When ``force_charset`` is set, opens the file as a binary stream and
+    passes an explicit ``StreamInfo(charset=...)`` via ``convert_stream``.
+    This bypasses MarkItDown's auto-charset detection, which only samples
+    the first 4 KB of the file — a fatal heuristic for .ics exports where
+    30 KB of ASCII timezone metadata precedes the first non-ASCII byte
+    (#82). Mirrors the ``_marker_convert`` / ``_docling_convert`` wrapper
+    pattern so tests can mock the heavy import without bringing the dep
+    into scope.
+    """
+    from markitdown import (  # type: ignore[import-untyped]  # noqa: PLC0415
+        MarkItDown,
+        StreamInfo,
+    )
+
+    md = MarkItDown()
+    if force_charset is None:
+        return md.convert(file_path_str).markdown or ""
+    p = Path(file_path_str)
+    with p.open("rb") as f:
+        result = md.convert_stream(
+            f,
+            stream_info=StreamInfo(extension=p.suffix, charset=force_charset),
+        )
+    return result.markdown or ""
+
+
+def _markitdown_convert(path: Path) -> tuple[str, str]:
+    """Run MarkItDown on a single file; return (markdown, version_string).
+
+    Used for content types Marker doesn't natively handle (ical, csv, json,
+    xml, vcard, .pages, .xls). For text-shaped suffixes the file is UTF-8
+    normalized to a temp file *and* MarkItDown is forced to use UTF-8 for
+    decoding via an explicit ``StreamInfo`` — both are needed (#82). The
+    temp-file step substitutes U+FFFD for genuinely-invalid bytes; the
+    explicit charset bypasses the 4 KB-sample auto-detection that would
+    otherwise misclassify an ASCII-front-loaded ICS as ASCII.
+    """
+    from importlib.metadata import PackageNotFoundError, version  # noqa: PLC0415
+
+    if path.suffix.lower() in _MARKITDOWN_TEXT_SUFFIXES:
+        normalized = _normalize_to_utf8_temp(path)
+        try:
+            markdown = _markitdown_run(str(normalized), force_charset="utf-8")
+        finally:
+            normalized.unlink(missing_ok=True)
+    else:
+        markdown = _markitdown_run(str(path))
+    try:
+        ver = version("markitdown")
+    except PackageNotFoundError:
+        ver = "unknown"
+    return markdown, f"markitdown=={ver}"
 
 
 def _docling_convert(path: Path) -> tuple[str, str]:
@@ -161,13 +261,24 @@ def extract_markdown(path: Path, *, content_type: str | None) -> ExtractionResul
             extractor_version="passthrough==1",
         )
 
-    # Legacy .doc / .xls need LibreOffice pre-conversion. Defer to Marker for the
-    # rest — Marker handles PDF, DOCX, XLSX, PPTX, and images natively.
-    if bucket in ("doc_legacy", "xls_legacy"):
+    # Legacy .doc still needs LibreOffice pre-conversion (Tier 5 candidate);
+    # MarkItDown's UnsupportedFormatException on binary .doc means we can't
+    # route it through the Tier 4 leg.
+    if bucket == "doc_legacy":
         raise ExtractionFailedError(
-            f"{bucket}: legacy binary format requires LibreOffice pre-conversion "
+            "doc_legacy: legacy binary format requires LibreOffice pre-conversion "
             "(not implemented in v1)"
         )
+
+    # Tier 4 (#83): MarkItDown handles content types Marker doesn't —
+    # ical/csv/json/xml/vcard/.pages and notably .xls (which it converts to
+    # multi-sheet markdown tables natively).
+    if bucket in _MARKITDOWN_BUCKETS:
+        try:
+            markdown, ver = _markitdown_convert(path)
+        except Exception as exc:
+            raise ExtractionFailedError(f"markitdown: {exc}") from exc
+        return ExtractionResult(markdown=markdown, extractor_version=ver)
 
     if bucket == "image":
         reason = _too_small_to_extract(path)

--- a/src/maildb/ingest/extraction.py
+++ b/src/maildb/ingest/extraction.py
@@ -84,12 +84,25 @@ _MARKITDOWN_BUCKETS: Final[frozenset[str]] = frozenset(
     {"calendar", "csv", "json", "xml", "vcard", "pages", "xls_legacy"}
 )
 
-# Suffixes that need UTF-8 normalization before MarkItDown sees them — its
-# PlainTextConverter defaults to ASCII and crashes on common non-ASCII bytes
-# (e.g. UTF-8 smart quotes in calendar invites). See issue #82.
-_MARKITDOWN_TEXT_SUFFIXES: Final[frozenset[str]] = frozenset(
-    {".ics", ".vcs", ".vcf", ".csv", ".json", ".xml"}
+# Buckets whose content is text and needs the #82 workaround: UTF-8 byte
+# normalization plus an explicit StreamInfo(charset='utf-8') so MarkItDown
+# doesn't auto-classify ASCII-front-loaded files as ASCII and crash on the
+# first non-ASCII byte. Driven by bucket (not suffix) so MIME-routed files
+# without a matching extension still get the fix.
+_MARKITDOWN_TEXT_BUCKETS: Final[frozenset[str]] = frozenset(
+    {"calendar", "csv", "json", "xml", "vcard"}
 )
+
+# Canonical suffix per text bucket — used for the UTF-8-normalized temp file
+# (so MarkItDown's converter routing has a stable signal) and as the explicit
+# extension hint passed via StreamInfo. Independent of the input filename.
+_MARKITDOWN_BUCKET_SUFFIX: Final[dict[str, str]] = {
+    "calendar": ".ics",
+    "csv": ".csv",
+    "json": ".json",
+    "xml": ".xml",
+    "vcard": ".vcf",
+}
 
 # Below these thresholds an image is signature/icon-sized and won't yield useful OCR.
 # Skip them with an explicit reason rather than burning Marker time on an empty result.
@@ -138,35 +151,43 @@ def _marker_convert(path: Path) -> tuple[str, str]:
     return text, f"marker=={getattr(marker, '__version__', 'unknown')}"
 
 
-def _normalize_to_utf8_temp(path: Path) -> Path:
+def _normalize_to_utf8_temp(path: Path, *, suffix: str | None = None) -> Path:
     """Decode bytes as UTF-8 with errors='replace' and write to a temp file.
 
     Workaround for MarkItDown PlainTextConverter ASCII default (#82) — files
     containing common non-ASCII bytes (smart quotes, em-dashes) crash unless
     pre-normalized. Invalid bytes become U+FFFD; valid UTF-8 round-trips.
+    The temp-file suffix defaults to the input's suffix; callers can pass
+    ``suffix`` to override (used for MIME-routed files where the on-disk
+    filename doesn't reflect the actual content shape — PR #84 review fix).
     Caller owns the returned path and must unlink when done.
     """
     import tempfile  # noqa: PLC0415
 
     text = path.read_bytes().decode("utf-8", errors="replace")
-    fd, name = tempfile.mkstemp(suffix=path.suffix)
+    fd, name = tempfile.mkstemp(suffix=suffix or path.suffix)
     os.close(fd)
     out = Path(name)
     out.write_text(text, encoding="utf-8")
     return out
 
 
-def _markitdown_run(file_path_str: str, *, force_charset: str | None = None) -> str:
+def _markitdown_run(
+    file_path_str: str,
+    *,
+    force_charset: str | None = None,
+    force_extension: str | None = None,
+) -> str:
     """Invoke MarkItDown on a path string; isolated for test patching.
 
-    When ``force_charset`` is set, opens the file as a binary stream and
-    passes an explicit ``StreamInfo(charset=...)`` via ``convert_stream``.
-    This bypasses MarkItDown's auto-charset detection, which only samples
-    the first 4 KB of the file — a fatal heuristic for .ics exports where
-    30 KB of ASCII timezone metadata precedes the first non-ASCII byte
-    (#82). Mirrors the ``_marker_convert`` / ``_docling_convert`` wrapper
-    pattern so tests can mock the heavy import without bringing the dep
-    into scope.
+    When ``force_charset`` or ``force_extension`` is set, opens the file as
+    a binary stream and passes an explicit ``StreamInfo`` via
+    ``convert_stream``. The explicit charset bypasses MarkItDown's
+    4 KB-sample auto-detection (fatal for ASCII-front-loaded ICS — #82); the
+    explicit extension overrides the on-disk filename so MIME-routed files
+    pick the right converter (PR #84 review fix). Mirrors the
+    ``_marker_convert`` / ``_docling_convert`` wrapper pattern so tests can
+    mock the heavy import without bringing the dep into scope.
     """
     from markitdown import (  # type: ignore[import-untyped]  # noqa: PLC0415
         MarkItDown,
@@ -174,34 +195,45 @@ def _markitdown_run(file_path_str: str, *, force_charset: str | None = None) -> 
     )
 
     md = MarkItDown()
-    if force_charset is None:
+    if force_charset is None and force_extension is None:
         return md.convert(file_path_str).markdown or ""
     p = Path(file_path_str)
     with p.open("rb") as f:
         result = md.convert_stream(
             f,
-            stream_info=StreamInfo(extension=p.suffix, charset=force_charset),
+            stream_info=StreamInfo(
+                extension=force_extension or p.suffix,
+                charset=force_charset,
+            ),
         )
     return result.markdown or ""
 
 
-def _markitdown_convert(path: Path) -> tuple[str, str]:
+def _markitdown_convert(path: Path, bucket: str) -> tuple[str, str]:
     """Run MarkItDown on a single file; return (markdown, version_string).
 
     Used for content types Marker doesn't natively handle (ical, csv, json,
-    xml, vcard, .pages, .xls). For text-shaped suffixes the file is UTF-8
-    normalized to a temp file *and* MarkItDown is forced to use UTF-8 for
-    decoding via an explicit ``StreamInfo`` — both are needed (#82). The
-    temp-file step substitutes U+FFFD for genuinely-invalid bytes; the
-    explicit charset bypasses the 4 KB-sample auto-detection that would
-    otherwise misclassify an ASCII-front-loaded ICS as ASCII.
+    xml, vcard, .pages, .xls). Dispatch is by *bucket* — not by file suffix
+    — so MIME-routed attachments (e.g. ``content_type='text/calendar'`` with
+    a generic filename like ``invite.dat``) still receive the #82 workaround
+    (PR #84 review fix). For text buckets the file is UTF-8 normalized to a
+    temp file with the bucket-canonical suffix *and* MarkItDown is forced to
+    use UTF-8 via an explicit ``StreamInfo`` — both are needed: the temp-file
+    step substitutes U+FFFD for genuinely-invalid bytes; the explicit charset
+    bypasses the 4 KB-sample auto-detection that would otherwise misclassify
+    an ASCII-front-loaded ICS as ASCII.
     """
     from importlib.metadata import PackageNotFoundError, version  # noqa: PLC0415
 
-    if path.suffix.lower() in _MARKITDOWN_TEXT_SUFFIXES:
-        normalized = _normalize_to_utf8_temp(path)
+    if bucket in _MARKITDOWN_TEXT_BUCKETS:
+        forced_suffix = _MARKITDOWN_BUCKET_SUFFIX[bucket]
+        normalized = _normalize_to_utf8_temp(path, suffix=forced_suffix)
         try:
-            markdown = _markitdown_run(str(normalized), force_charset="utf-8")
+            markdown = _markitdown_run(
+                str(normalized),
+                force_charset="utf-8",
+                force_extension=forced_suffix,
+            )
         finally:
             normalized.unlink(missing_ok=True)
     else:
@@ -272,10 +304,12 @@ def extract_markdown(path: Path, *, content_type: str | None) -> ExtractionResul
 
     # Tier 4 (#83): MarkItDown handles content types Marker doesn't —
     # ical/csv/json/xml/vcard/.pages and notably .xls (which it converts to
-    # multi-sheet markdown tables natively).
+    # multi-sheet markdown tables natively). Bucket is passed through so the
+    # text-bucket workaround for #82 fires regardless of filename suffix
+    # (PR #84 review fix).
     if bucket in _MARKITDOWN_BUCKETS:
         try:
-            markdown, ver = _markitdown_convert(path)
+            markdown, ver = _markitdown_convert(path, bucket)
         except Exception as exc:
             raise ExtractionFailedError(f"markitdown: {exc}") from exc
         return ExtractionResult(markdown=markdown, extractor_version=ver)

--- a/tests/unit/test_cli_process.py
+++ b/tests/unit/test_cli_process.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from maildb.cli import app
@@ -92,6 +93,58 @@ def test_run_with_only_pdf(tmp_path):
     assert result.exit_code == 0
     kwargs = mock_run.call_args.kwargs
     assert "pdf" in str(kwargs["selector_params"].values())  # content_types list includes pdf MIME
+
+
+# --- PR #84 review fix: --only must accept the new Tier 4 buckets --------
+
+
+def test_cli_bucket_filter_includes_new_tier4_buckets():
+    """PR #84 review finding: extraction.SUPPORTED gained calendar/csv/json/
+    xml/vcard/pages but cli._BUCKET_TO_CONTENT_TYPES wasn't updated, so
+    --only on those buckets was rejected. Verify the mapping now covers them."""
+    from maildb.cli import _BUCKET_TO_CONTENT_TYPES  # noqa: PLC0415
+
+    assert {"calendar", "csv", "json", "xml", "vcard", "pages"} <= set(_BUCKET_TO_CONTENT_TYPES)
+    # Each bucket must list at least one MIME, and the MIMEs must be the
+    # canonical ones routed to that bucket in extraction.py.
+    assert "text/calendar" in _BUCKET_TO_CONTENT_TYPES["calendar"]
+    assert "application/ics" in _BUCKET_TO_CONTENT_TYPES["calendar"]
+    assert "text/csv" in _BUCKET_TO_CONTENT_TYPES["csv"]
+    assert "application/json" in _BUCKET_TO_CONTENT_TYPES["json"]
+    assert "application/xml" in _BUCKET_TO_CONTENT_TYPES["xml"]
+    assert "text/x-vcard" in _BUCKET_TO_CONTENT_TYPES["vcard"]
+    assert "application/x-iwork-pages-sffpages" in _BUCKET_TO_CONTENT_TYPES["pages"]
+
+
+@pytest.mark.parametrize(
+    ("only_bucket", "expected_mime"),
+    [
+        ("calendar", "text/calendar"),
+        ("csv", "text/csv"),
+        ("json", "application/json"),
+        ("xml", "application/xml"),
+        ("vcard", "text/x-vcard"),
+        ("pages", "application/x-iwork-pages-sffpages"),
+    ],
+)
+def test_run_with_only_new_tier4_bucket_dispatches(tmp_path, only_bucket: str, expected_mime: str):
+    """`--only <new_bucket>` must pass parameter validation and propagate the
+    correct content_types into selector_params (PR #84 review finding)."""
+    with (
+        patch("maildb.cli._build_process_pool") as mock_pool,
+        patch("maildb.cli.pa_run") as mock_run,
+    ):
+        pool_instance = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (0,)
+        pool_instance.connection.return_value.__enter__.return_value.execute.return_value = cursor
+        mock_pool.return_value = pool_instance
+        mock_run.return_value = {"extracted": 0, "failed": 0, "skipped": 0}
+        result = runner.invoke(app, ["process_attachments", "run", "--only", only_bucket])
+    assert result.exit_code == 0, f"--only {only_bucket} rejected: {result.stdout}"
+    kwargs = mock_run.call_args.kwargs
+    types = kwargs["selector_params"].get("content_types", [])
+    assert expected_mime in types
 
 
 def test_run_with_ids(tmp_path):

--- a/tests/unit/test_extraction.py
+++ b/tests/unit/test_extraction.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -12,9 +12,6 @@ from maildb.ingest.extraction import (
     extract_markdown,
     route_content_type,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 @pytest.mark.parametrize(
@@ -49,8 +46,8 @@ def test_supported_types_route_to_known_buckets(content_type, expected_bucket):
         "application/zip",
         "video/quicktime",
         "application/octet-stream",
-        "application/ics",
-        "application/json",
+        "application/rtf",
+        "image/svg+xml",
         "",
         None,
     ],
@@ -258,3 +255,209 @@ def test_extract_marker_success_for_office_does_not_call_docling(tmp_path: Path)
         result = extract_markdown(p, content_type=_DOCX)
     docling.assert_not_called()
     assert result.extractor_version.startswith("marker==")
+
+
+# --- Tier 4: MarkItDown integration (issue #83) ----------------------------
+
+_NEW_ROUTES = [
+    ("text/calendar", "calendar"),
+    ("application/ics", "calendar"),
+    ("text/csv", "csv"),
+    ("application/json", "json"),
+    ("application/xml", "xml"),
+    ("text/x-vcard", "vcard"),
+    ("application/x-iwork-pages-sffpages", "pages"),
+]
+
+
+@pytest.mark.parametrize(("content_type", "bucket"), _NEW_ROUTES)
+def test_new_text_buckets_route_correctly(content_type: str, bucket: str):
+    """The Tier 4 MIME types map to dedicated buckets so the CLI --only filter
+    and the yield-by-content-type dashboard can name them distinctly."""
+    assert route_content_type(content_type) == bucket
+
+
+def test_supported_includes_new_buckets():
+    """SUPPORTED is the contract for what extract_markdown can route. New
+    Tier 4 buckets must be in it so callers can opt-in via --only filters."""
+    assert {"calendar", "csv", "json", "xml", "vcard", "pages"} <= SUPPORTED
+
+
+_BUCKET_SUFFIXES = {
+    "calendar": ".ics",
+    "csv": ".csv",
+    "json": ".json",
+    "xml": ".xml",
+    "vcard": ".vcf",
+    "pages": ".pages",
+}
+
+
+@pytest.mark.parametrize(("content_type", "bucket"), _NEW_ROUTES)
+def test_extract_calls_markitdown_for_new_buckets(tmp_path: Path, content_type: str, bucket: str):
+    """For each Tier 4 bucket, extract_markdown dispatches to _markitdown_convert
+    and returns its output tagged with the markitdown version. Marker and
+    Docling are not consulted — these formats are MarkItDown's territory."""
+    p = tmp_path / f"sample{_BUCKET_SUFFIXES[bucket]}"
+    p.write_bytes(b"placeholder")
+    with (
+        patch(
+            "maildb.ingest.extraction._markitdown_convert",
+            return_value=("# md output", "markitdown==0.1.0"),
+        ) as md,
+        patch("maildb.ingest.extraction._marker_convert") as marker,
+        patch("maildb.ingest.extraction._docling_convert") as docling,
+    ):
+        result = extract_markdown(p, content_type=content_type)
+    md.assert_called_once()
+    marker.assert_not_called()
+    docling.assert_not_called()
+    assert result.markdown == "# md output"
+    assert result.extractor_version.startswith("markitdown==")
+
+
+def test_extract_calls_markitdown_for_xls_legacy(tmp_path: Path):
+    """application/vnd.ms-excel was previously raising 'not implemented in v1'.
+    Tier 4 routes it through MarkItDown (which natively converts .xls → markdown
+    tables in seconds) — the spike confirmed multi-sheet .xls files produce
+    clean tables, obsoleting the planned LibreOffice route."""
+    p = tmp_path / "report.xls"
+    p.write_bytes(b"\xd0\xcf\x11\xe0fake")  # OLE2 compound-document magic
+    with patch(
+        "maildb.ingest.extraction._markitdown_convert",
+        return_value=("## Sheet1\n| A | B |", "markitdown==0.1.0"),
+    ) as md:
+        result = extract_markdown(p, content_type="application/vnd.ms-excel")
+    md.assert_called_once()
+    assert "Sheet1" in result.markdown
+    assert result.extractor_version.startswith("markitdown==")
+
+
+def test_extract_doc_legacy_still_raises(tmp_path: Path):
+    """Regression: MarkItDown does not support binary .doc (returns
+    UnsupportedFormatException). doc_legacy must continue to raise so we
+    don't pretend to handle it; LibreOffice/antiword is a separate Tier 5."""
+    p = tmp_path / "old.doc"
+    p.write_bytes(b"\xd0\xcf\x11\xe0fake")
+    with (
+        patch("maildb.ingest.extraction._markitdown_convert") as md,
+        pytest.raises(ExtractionFailedError, match="doc_legacy"),
+    ):
+        extract_markdown(p, content_type="application/msword")
+    md.assert_not_called()
+
+
+def test_extract_markitdown_failure_surfaces_as_extraction_failed(tmp_path: Path):
+    """If MarkItDown raises, the error surfaces as ExtractionFailedError tagged
+    'markitdown:' so ops telemetry can distinguish it from marker:/docling:
+    failures and route follow-up actions accordingly."""
+    p = tmp_path / "thing.csv"
+    p.write_bytes(b"a,b\n1,2\n")
+    with (
+        patch(
+            "maildb.ingest.extraction._markitdown_convert",
+            side_effect=RuntimeError("boom"),
+        ),
+        pytest.raises(ExtractionFailedError, match="markitdown:"),
+    ):
+        extract_markdown(p, content_type="text/csv")
+
+
+# --- Tier 4: UTF-8 normalization workaround for #82 ------------------------
+
+
+def test_text_shaped_files_are_utf8_normalized_before_markitdown(tmp_path: Path):
+    """Regression for #82: text-shaped files (.ics/.vcf/.csv/.json/.xml) get
+    normalized to UTF-8 before MarkItDown sees them, so the converter chain's
+    PlainTextConverter (which defaults to ASCII) doesn't crash on common
+    non-ASCII bytes from real calendar exports."""
+    from maildb.ingest.extraction import _markitdown_convert  # noqa: PLC0415
+
+    p = tmp_path / "invite.ics"
+    # \xe2\x80\x99 is the UTF-8 right-single-quotation-mark — exact byte that
+    # crashes upstream.
+    p.write_bytes(b"BEGIN:VCALENDAR\r\nSUMMARY:Q3 \xe2\x80\x99 review\r\nEND:VCALENDAR\r\n")
+
+    captured_calls: list[tuple[str, str | None]] = []
+
+    def fake_run(path_str: str, *, force_charset: str | None = None) -> str:
+        captured_calls.append((path_str, force_charset))
+        # The file MarkItDown sees must decode cleanly as UTF-8.
+        text = Path(path_str).read_text(encoding="utf-8")
+        assert "Q3" in text
+        return "# normalized"
+
+    with patch("maildb.ingest.extraction._markitdown_run", side_effect=fake_run):
+        markdown, ver = _markitdown_convert(p)
+
+    assert markdown == "# normalized"
+    assert ver.startswith("markitdown==")
+    assert len(captured_calls) == 1, "_markitdown_run was not called once"
+    captured_path, captured_charset = captured_calls[0]
+    # MarkItDown sees a different (normalized) path than the input.
+    assert captured_path != str(p)
+    assert captured_path.endswith(".ics")
+    # And UTF-8 was forced explicitly — this is the production-bug-catching
+    # assertion that the byte-normalization alone was not.
+    assert captured_charset == "utf-8"
+    # The temp file is cleaned up after the call.
+    assert not Path(captured_path).exists()
+
+
+def test_binary_files_skip_utf8_normalization(tmp_path: Path):
+    """Binary formats (.xls, .pages) must NOT be UTF-8 normalized — decoding
+    and re-encoding bytes would corrupt the format. They pass through to
+    MarkItDown without forcing a charset."""
+    from maildb.ingest.extraction import _markitdown_convert  # noqa: PLC0415
+
+    p = tmp_path / "data.xls"
+    p.write_bytes(b"\xd0\xcf\x11\xe0fake")  # OLE2 magic, not valid UTF-8
+
+    captured_calls: list[tuple[str, str | None]] = []
+
+    def fake_run(path_str: str, *, force_charset: str | None = None) -> str:
+        captured_calls.append((path_str, force_charset))
+        return "# xls content"
+
+    with patch("maildb.ingest.extraction._markitdown_run", side_effect=fake_run):
+        _markitdown_convert(p)
+
+    assert captured_calls == [(str(p), None)]
+
+
+def test_markitdown_run_text_passes_explicit_utf8_streaminfo(tmp_path: Path):
+    """End-to-end against real MarkItDown: when force_charset='utf-8' is set,
+    a tiny ICS containing a non-ASCII byte parses without crashing — even
+    though auto-detection on small input might settle on ASCII. This is the
+    direct regression test for #82."""
+    from maildb.ingest.extraction import _markitdown_run  # noqa: PLC0415
+
+    p = tmp_path / "x.ics"
+    p.write_bytes(b"BEGIN:VCALENDAR\r\nSUMMARY:Q3 \xe2\x80\x99 review\r\nEND:VCALENDAR\r\n")
+    md = _markitdown_run(str(p), force_charset="utf-8")
+    assert "Q3" in md or "VCALENDAR" in md
+
+
+def test_normalize_to_utf8_temp_replaces_invalid_bytes(tmp_path: Path):
+    """The UTF-8 normalizer round-trips valid UTF-8 unchanged and substitutes
+    U+FFFD for genuinely invalid byte sequences (errors='replace' contract)."""
+    from maildb.ingest.extraction import _normalize_to_utf8_temp  # noqa: PLC0415
+
+    valid = tmp_path / "valid.ics"
+    valid.write_bytes("Q3 \u2019 review".encode())
+    out1 = _normalize_to_utf8_temp(valid)
+    try:
+        assert out1.read_text(encoding="utf-8") == "Q3 \u2019 review"
+    finally:
+        out1.unlink(missing_ok=True)
+
+    invalid = tmp_path / "bad.ics"
+    invalid.write_bytes(b"hello\xffworld")
+    out2 = _normalize_to_utf8_temp(invalid)
+    try:
+        text = out2.read_text(encoding="utf-8")
+        assert "hello" in text
+        assert "world" in text
+        assert "�" in text
+    finally:
+        out2.unlink(missing_ok=True)

--- a/tests/unit/test_extraction.py
+++ b/tests/unit/test_extraction.py
@@ -380,7 +380,12 @@ def test_text_shaped_files_are_utf8_normalized_before_markitdown(tmp_path: Path)
 
     captured_calls: list[tuple[str, str | None]] = []
 
-    def fake_run(path_str: str, *, force_charset: str | None = None) -> str:
+    def fake_run(
+        path_str: str,
+        *,
+        force_charset: str | None = None,
+        force_extension: str | None = None,
+    ) -> str:
         captured_calls.append((path_str, force_charset))
         # The file MarkItDown sees must decode cleanly as UTF-8.
         text = Path(path_str).read_text(encoding="utf-8")
@@ -388,7 +393,7 @@ def test_text_shaped_files_are_utf8_normalized_before_markitdown(tmp_path: Path)
         return "# normalized"
 
     with patch("maildb.ingest.extraction._markitdown_run", side_effect=fake_run):
-        markdown, ver = _markitdown_convert(p)
+        markdown, ver = _markitdown_convert(p, "calendar")
 
     assert markdown == "# normalized"
     assert ver.startswith("markitdown==")
@@ -415,12 +420,17 @@ def test_binary_files_skip_utf8_normalization(tmp_path: Path):
 
     captured_calls: list[tuple[str, str | None]] = []
 
-    def fake_run(path_str: str, *, force_charset: str | None = None) -> str:
+    def fake_run(
+        path_str: str,
+        *,
+        force_charset: str | None = None,
+        force_extension: str | None = None,
+    ) -> str:
         captured_calls.append((path_str, force_charset))
         return "# xls content"
 
     with patch("maildb.ingest.extraction._markitdown_run", side_effect=fake_run):
-        _markitdown_convert(p)
+        _markitdown_convert(p, "xls_legacy")
 
     assert captured_calls == [(str(p), None)]
 
@@ -436,6 +446,130 @@ def test_markitdown_run_text_passes_explicit_utf8_streaminfo(tmp_path: Path):
     p.write_bytes(b"BEGIN:VCALENDAR\r\nSUMMARY:Q3 \xe2\x80\x99 review\r\nEND:VCALENDAR\r\n")
     md = _markitdown_run(str(p), force_charset="utf-8")
     assert "Q3" in md or "VCALENDAR" in md
+
+
+# --- PR #84 review fix: dispatch by bucket, not by file suffix ------------
+
+
+def test_markitdown_convert_applies_workaround_for_mime_routed_files(tmp_path: Path):
+    """PR #84 review finding: the UTF-8 workaround was keyed on path.suffix,
+    but extract_markdown routes by MIME content_type. An attachment with
+    content_type='text/calendar' but a non-ICS filename (e.g. 'invite.dat')
+    skipped the workaround and crashed on the first non-ASCII byte. The fix
+    drives the workaround off the bucket regardless of input filename."""
+    from maildb.ingest.extraction import _markitdown_convert  # noqa: PLC0415
+
+    p = tmp_path / "invite.dat"  # deliberately wrong-shaped suffix
+    p.write_bytes(b"BEGIN:VCALENDAR\r\nSUMMARY:Q3 \xe2\x80\x99 review\r\nEND:VCALENDAR\r\n")
+
+    captured: list[tuple[str, str | None, str | None]] = []
+
+    def fake_run(
+        path_str: str,
+        *,
+        force_charset: str | None = None,
+        force_extension: str | None = None,
+    ) -> str:
+        captured.append((path_str, force_charset, force_extension))
+        return "# ok"
+
+    with patch("maildb.ingest.extraction._markitdown_run", side_effect=fake_run):
+        _markitdown_convert(p, "calendar")
+
+    assert len(captured) == 1
+    captured_path, charset, ext = captured[0]
+    # Temp file uses bucket-canonical suffix, not the misleading input suffix.
+    assert captured_path.endswith(".ics")
+    # Workaround applied regardless of input filename.
+    assert charset == "utf-8"
+    # Explicit extension passed to MarkItDown so converter routing is robust.
+    assert ext == ".ics"
+
+
+@pytest.mark.parametrize(
+    ("bucket", "expected_suffix"),
+    [
+        ("calendar", ".ics"),
+        ("csv", ".csv"),
+        ("json", ".json"),
+        ("xml", ".xml"),
+        ("vcard", ".vcf"),
+    ],
+)
+def test_markitdown_convert_uses_bucket_canonical_suffix_for_text_buckets(
+    tmp_path: Path, bucket: str, expected_suffix: str
+):
+    """For every text-shaped bucket, the workaround applies regardless of
+    input filename: temp file gets the canonical suffix, charset is forced
+    to utf-8, and extension is passed through to MarkItDown explicitly."""
+    from maildb.ingest.extraction import _markitdown_convert  # noqa: PLC0415
+
+    p = tmp_path / "wrongname.bin"
+    p.write_bytes(b"placeholder")
+
+    captured: list[tuple[str, str | None, str | None]] = []
+
+    def fake_run(
+        path_str: str,
+        *,
+        force_charset: str | None = None,
+        force_extension: str | None = None,
+    ) -> str:
+        captured.append((path_str, force_charset, force_extension))
+        return "# ok"
+
+    with patch("maildb.ingest.extraction._markitdown_run", side_effect=fake_run):
+        _markitdown_convert(p, bucket)
+
+    captured_path, charset, ext = captured[0]
+    assert captured_path.endswith(expected_suffix)
+    assert charset == "utf-8"
+    assert ext == expected_suffix
+
+
+def test_markitdown_convert_binary_buckets_unaffected(tmp_path: Path):
+    """Binary buckets (xls_legacy, pages) must continue to pass through to
+    MarkItDown without forcing charset or extension — the workaround would
+    corrupt their bytes."""
+    from maildb.ingest.extraction import _markitdown_convert  # noqa: PLC0415
+
+    p = tmp_path / "data.xls"
+    p.write_bytes(b"\xd0\xcf\x11\xe0fake")
+
+    captured: list[tuple[str, str | None, str | None]] = []
+
+    def fake_run(
+        path_str: str,
+        *,
+        force_charset: str | None = None,
+        force_extension: str | None = None,
+    ) -> str:
+        captured.append((path_str, force_charset, force_extension))
+        return "# ok"
+
+    with patch("maildb.ingest.extraction._markitdown_run", side_effect=fake_run):
+        _markitdown_convert(p, "xls_legacy")
+
+    assert captured == [(str(p), None, None)]
+
+
+def test_extract_markdown_passes_bucket_to_markitdown_convert(tmp_path: Path):
+    """extract_markdown invokes _markitdown_convert with the resolved bucket
+    so the suffix-independent workaround can fire correctly. Without this,
+    MIME-routed files skip the #82 workaround (PR #84 review finding)."""
+    p = tmp_path / "weird_name.dat"
+    p.write_bytes(b"placeholder")
+
+    captured: list[tuple[Path, str]] = []
+
+    def fake_convert(path: Path, bucket: str) -> tuple[str, str]:
+        captured.append((path, bucket))
+        return ("# md", "markitdown==0.1.0")
+
+    with patch("maildb.ingest.extraction._markitdown_convert", side_effect=fake_convert):
+        extract_markdown(p, content_type="text/calendar")
+
+    assert captured == [(p, "calendar")]
 
 
 def test_normalize_to_utf8_temp_replaces_invalid_bytes(tmp_path: Path):

--- a/uv.lock
+++ b/uv.lock
@@ -3,15 +3,20 @@ revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 
 [[package]]
@@ -276,6 +281,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
 ]
 
 [[package]]
@@ -738,6 +755,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "fsspec"
 version = "2026.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -892,6 +917,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
 ]
 
 [[package]]
@@ -1212,6 +1249,25 @@ wheels = [
 ]
 
 [[package]]
+name = "magika"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "numpy" },
+    { name = "onnxruntime", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
+    { name = "onnxruntime", version = "1.25.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e4/35c323beb3280482c94299d61626116856ac2d4ec16ecef50afc4fdd4291/magika-0.6.3-py3-none-any.whl", hash = "sha256:eda443d08006ee495e02083b32e51b98cb3696ab595a7d13900d8e2ef506ec9d", size = 2969474, upload-time = "2025-10-30T15:22:25.298Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/132b0d7cd51c02c39fd52658a5896276c30c8cc2fd453270b19db8c40f7e/magika-0.6.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:86901e64b05dde5faff408c9b8245495b2e1fd4c226e3393d3d2a3fee65c504b", size = 13358841, upload-time = "2025-10-30T15:22:27.413Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/03/5ed859be502903a68b7b393b17ae0283bf34195cfcca79ce2dc25b9290e7/magika-0.6.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:3d9661eedbdf445ac9567e97e7ceefb93545d77a6a32858139ea966b5806fb64", size = 15367335, upload-time = "2025-10-30T15:22:29.907Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/9e/f8ee7d644affa3b80efdd623a3d75865c8f058f3950cb87fb0c48e3559bc/magika-0.6.3-py3-none-win_amd64.whl", hash = "sha256:e57f75674447b20cab4db928ae58ab264d7d8582b55183a0b876711c2b2787f3", size = 12692831, upload-time = "2025-10-30T15:22:32.063Z" },
+]
+
+[[package]]
 name = "maildb"
 version = "0.1.0"
 source = { editable = "." }
@@ -1219,6 +1275,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "docling" },
     { name = "marker-pdf" },
+    { name = "markitdown", extra = ["xls"] },
     { name = "mcp" },
     { name = "ollama" },
     { name = "pgvector" },
@@ -1245,6 +1302,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "docling", specifier = ">=2.92.0" },
     { name = "marker-pdf", specifier = ">=1.2.0" },
+    { name = "markitdown", extras = ["xls"], specifier = ">=0.1.5" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "ollama", specifier = ">=0.4" },
     { name = "pgvector", specifier = ">=0.3" },
@@ -1330,6 +1388,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/bc/a9e72fd015f562b1f86c9dbc201c80365e7baf43d5aa616ba1c89453537f/marker_pdf-1.10.2.tar.gz", hash = "sha256:ce0fc839e11ad7519a576d254ca9d51a0f9454b9d7da02211f722b141317f9f1", size = 140056, upload-time = "2026-01-31T00:04:55.179Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/44/51f6a5673d4815fa6d8d355f4a7119cbd6d8ae2e3cb697c066a8012beb18/marker_pdf-1.10.2-py3-none-any.whl", hash = "sha256:f631737dd46d3927142b4b14c7b488962c5af278dc2c3ae7dc5b03a47f5909fb", size = 195706, upload-time = "2026-01-31T00:04:56.384Z" },
+]
+
+[[package]]
+name = "markitdown"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "charset-normalizer" },
+    { name = "defusedxml" },
+    { name = "magika" },
+    { name = "markdownify" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/93/3b93c291c99d09f64f7535ba74c1c6a3507cf49cffd38983a55de6f834b6/markitdown-0.1.5.tar.gz", hash = "sha256:4c956ff1528bf15e1814542035ec96e989206d19d311bb799f4df973ecafc31a", size = 45099, upload-time = "2026-02-20T19:45:23.886Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/8b/fd7e042455a829a1ede0bc8e9e3061aa6c7c4cf745385526ef62ff1b5a5b/markitdown-0.1.5-py3-none-any.whl", hash = "sha256:5180a9a841e20fc01c2c09dbc5d039638429bbebcdc2af1b2615c3c427840434", size = 63402, upload-time = "2026-02-20T19:45:27.195Z" },
+]
+
+[package.optional-dependencies]
+xls = [
+    { name = "pandas" },
+    { name = "xlrd" },
 ]
 
 [[package]]
@@ -1780,6 +1861,69 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "coloredlogs", marker = "sys_platform == 'win32'" },
+    { name = "flatbuffers", marker = "sys_platform == 'win32'" },
+    { name = "numpy", marker = "sys_platform == 'win32'" },
+    { name = "packaging", marker = "sys_platform == 'win32'" },
+    { name = "protobuf", marker = "sys_platform == 'win32'" },
+    { name = "sympy", marker = "sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/aabfdf91d013320aa2fc46cf43c88ca0182860ff15df872b4552254a9680/onnxruntime-1.20.1-cp312-cp312-win32.whl", hash = "sha256:bd386cc9ee5f686ee8a75ba74037750aca55183085bf1941da8efcfe12d5b120", size = 9814562, upload-time = "2024-11-21T00:49:15.453Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/80/76979e0b744307d488c79e41051117634b956612cc731f1028eb17ee7294/onnxruntime-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:19c2d843eb074f385e8bbb753a40df780511061a63f9def1b216bf53860223fb", size = 11331482, upload-time = "2024-11-21T00:49:19.412Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e0/50db43188ca1c945decaa8fc2a024c33446d31afed40149897d4f9de505f/onnxruntime-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:d30367df7e70f1d9fc5a6a68106f5961686d39b54d3221f760085524e8d38e16", size = 11331758, upload-time = "2024-11-21T00:49:31.417Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.25.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+]
+dependencies = [
+    { name = "flatbuffers", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
+    { name = "protobuf", marker = "sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/52/8b2a10e8dedf5d486332bc2b3bca0b1ed8049c0b9e4a5cced95413aadfdd/onnxruntime-1.25.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:66e52f7a30d1f780a34aa84d68a0a04d382d9f5b141884ecbf45b7566b9fbde9", size = 17770987, upload-time = "2026-04-27T22:00:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/87/a424d2867477c42ef8c60172709281120797f7b0f1fd33cc36b24329c825/onnxruntime-1.25.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5f41779f044d1ff75593df5c10a4d311bc82563687796d5218e2685b8f9da25", size = 15871829, upload-time = "2026-04-27T21:59:39.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/55/7819e64c515f17c86005447ede8122b974ca851255a94125e2119376f0f8/onnxruntime-1.25.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:905409e9eb2ef87f8226e073f56e71faf731c3e480ebd34952cf953730e4a4ff", size = 18024586, upload-time = "2026-04-27T22:00:05.359Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ee/db3ac55ef770347a926ac0f1317df0ab42c8bc604350833b30c7356bf936/onnxruntime-1.25.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e9d9b3b1694196bc3c5bc66f760a237a5e27d7688aaa2e2c9c0f66abd0486699", size = 17770761, upload-time = "2026-04-27T21:59:54.853Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9a/33225481a94a59906fce44e27ab12fc3bddd2aaecdc6160bd73341ca1aba/onnxruntime-1.25.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:311d29b943e46a55ca72ca1ea48d7815c993122bfc359f68215fddeb9583fff4", size = 15871542, upload-time = "2026-04-27T21:59:41.881Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/09/f20aac60f6fcf840543be54d4e9252cfeb7e8c2bb6d22477aaeb180e763e/onnxruntime-1.25.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98016a038b31160db23208706139fa3b99cd60bc1c5ffdade77aafd6a37a92ad", size = 18036960, upload-time = "2026-04-27T22:00:10.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/8a/3b65e7911eec86c125e3d6f43d690a6f68671500543c0390ecd6eb59b771/onnxruntime-1.25.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:03e800b3a4b48d9f3a2d23aacc4fa95486a3b406b14e51d1a9b8b6981d9adf9c", size = 15882935, upload-time = "2026-04-27T21:59:44.912Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/bb/410a760694f8ae7bbfc5fa81ccbeb7da241e6d520ee02a333a439cf462a2/onnxruntime-1.25.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd83ef5c10cfc051a1cb465db692d57b996a1bc75a2a97b161398e29cdbc47ff", size = 18021727, upload-time = "2026-04-27T22:00:13.846Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/aa/04530bd38e31e26970fa1212346d76cf81705dc16a8ee5e6f4fb24634c11/onnxruntime-1.25.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:395eb662c437fa2407f44266e4778b75bff261b17c2a6fef042421f9069f871d", size = 17773721, upload-time = "2026-04-27T21:59:59.24Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/7f/ec79ab5cece6a688c944a7fa214a8511d548b9d5142a15d1a3d730b705f1/onnxruntime-1.25.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ae85395f41b291ae3e61780ec5092640181d369ef6c268aa8141c478b509e69", size = 15875954, upload-time = "2026-04-27T21:59:49.394Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fe/20428215d822099ea2c1e3cf35c295cf1a58f467bf18b6c607597a39c18a/onnxruntime-1.25.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:828e1b12710fbedb6dfab5e7bae6f11563617cddf3c2e7e8d84c64de566a4a3a", size = 18038703, upload-time = "2026-04-27T22:00:16.199Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0e/6c507d1e65b2421fb44e241cbba577c7276792279485024fb1752b43f5c5/onnxruntime-1.25.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:06280b06604660595037f783c6d24bc70cbe5c6093975f194cd1482e77d450de", size = 15883298, upload-time = "2026-04-27T21:59:51.991Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4e/1c9df57496409dc86b320bd38f29ad7a34b7115e4f35b8fca44a827568a7/onnxruntime-1.25.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e79fd5ce7db10ebcc24e020e2ed0159476e69e2326b9b7828e5aadcf6184212", size = 18021249, upload-time = "2026-04-27T22:00:18.954Z" },
+]
+
+[[package]]
 name = "openai"
 version = "1.109.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2017,6 +2161,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
 ]
 
 [[package]]
@@ -2324,6 +2483,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/47/eda4904f715fb98561e34012826e883816945934a851745570521ec89520/pypdfium2-4.30.0-py3-none-win32.whl", hash = "sha256:ee2410f15d576d976c2ab2558c93d392a25fb9f6635e8dd0a8a3a5241b275e0e", size = 2775951, upload-time = "2024-05-09T18:33:10.567Z" },
     { url = "https://files.pythonhosted.org/packages/25/bd/56d9ec6b9f0fc4e0d95288759f3179f0fcd34b1a1526b75673d2f6d5196f/pypdfium2-4.30.0-py3-none-win_amd64.whl", hash = "sha256:90dbb2ac07be53219f56be09961eb95cf2473f834d01a42d901d13ccfad64b4c", size = 2892098, upload-time = "2024-05-09T18:33:13.107Z" },
     { url = "https://files.pythonhosted.org/packages/be/7a/097801205b991bc3115e8af1edb850d30aeaf0118520b016354cf5ccd3f6/pypdfium2-4.30.0-py3-none-win_arm64.whl", hash = "sha256:119b2969a6d6b1e8d55e99caaf05290294f2d0fe49c12a3f17102d01c441bd29", size = 2752118, upload-time = "2024-05-09T18:33:15.489Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
 ]
 
 [[package]]
@@ -3506,6 +3674,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "xlrd"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/5a/377161c2d3538d1990d7af382c79f3b2372e880b65de21b01b1a2b78691e/xlrd-2.0.2.tar.gz", hash = "sha256:08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9", size = 100167, upload-time = "2025-06-14T08:46:39.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/62/c8d562e7766786ba6587d09c5a8ba9f718ed3fa8af7f4553e8f91c36f302/xlrd-2.0.2-py2.py3-none-any.whl", hash = "sha256:ea762c3d29f4cca48d82df517b6d89fbce4db3107f9d78713e48cd321d5c9aa9", size = 96555, upload-time = "2025-06-14T08:46:37.766Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds Microsoft MarkItDown as a third extraction leg alongside Marker (primary) and Docling (office fallback). Targets text-shaped content types Marker doesn't natively support — the largest still-recoverable bucket per the May residuals analysis.
- Closes #83 (Tier 4 integration) and #82 (MarkItDown PlainTextConverter ASCII-default crash on non-ASCII .ics).
- Estimated yield: ~4,200–8,200 rows recovered after one drain pass over the matching `skipped` content.

## What changes

| Before this PR | After |
|---|---|
| `text/calendar` / `application/ics` → `skipped` (Marker doesn't handle) | → `calendar` bucket → MarkItDown (8,259 rows recoverable) |
| `application/vnd.ms-excel` → `failed` (`xls_legacy: not implemented in v1`) | → MarkItDown (multi-sheet markdown tables, 2–6s; **obsoletes the planned LibreOffice route**) |
| `text/csv` / `application/json` / `application/xml` / `text/x-vcard` / `application/x-iwork-pages-sffpages` → `skipped` | → respective buckets → MarkItDown |
| `application/msword` → `failed` (`doc_legacy: not implemented`) | unchanged — MarkItDown returns `UnsupportedFormatException` on binary .doc; LibreOffice/antiword route is a separate Tier 5 candidate |

## #82 root cause and fix

MarkItDown's charset auto-detection (`charset_normalizer.from_bytes(...).best()`) samples only the **first 4 KB** of the file. ICS exports typically have 30+ KB of pure-ASCII timezone metadata (`VTIMEZONE`, `RRULE`, etc.) before the first non-ASCII byte (smart quotes in event descriptions land at byte 29065 in the failing samples). The 4 KB sample is all-ASCII → detector returns `ascii` → full decode crashes at the first `0xe2` byte.

**Workaround in this PR (in `_markitdown_convert`):**
1. For text-shaped suffixes (`.ics/.vcs/.vcf/.csv/.json/.xml`), decode the bytes as UTF-8 with `errors='replace'` and write to a temp file. Genuinely-invalid bytes become `U+FFFD`; valid UTF-8 round-trips.
2. Open the temp as a binary stream and call `MarkItDown().convert_stream(f, stream_info=StreamInfo(extension=..., charset='utf-8'))` — the explicit `StreamInfo` bypasses the 4 KB-sample auto-detection.

Both steps are needed; the first handles real corruption, the second prevents the misclassification.

## Verification

End-to-end smoke against the two ICS files that crashed in the original Tier 4 spike (`scripts/spike_markitdown.py`):

```
id=  332 [OK] markitdown==0.1.5 →  30,466 chars  (was: UnicodeDecodeError at byte 29065)
id=  667 [OK] markitdown==0.1.5 →  30,613 chars  (was: UnicodeDecodeError at byte 29214)
id= 1082 [OK] markitdown==0.1.5 →  30,747 chars  (regression: still parses)
```

`uv run just check` clean: 529 passed, ruff + mypy clean.

12 new unit tests:
- Routing for the 7 new content types → correct buckets
- `SUPPORTED` includes the new bucket names
- `extract_markdown` invokes `_markitdown_convert` for each new bucket; Marker and Docling are not consulted
- `application/vnd.ms-excel` now succeeds via MarkItDown (was raising)
- `application/msword` continues to raise (no regression on .doc)
- MarkItDown failure surfaces as `ExtractionFailedError` tagged `markitdown:`
- `_markitdown_convert` passes `force_charset='utf-8'` for text-shaped files; binary files (`.xls`, `.pages`) skip the workaround
- `_normalize_to_utf8_temp` round-trips valid UTF-8 and substitutes `U+FFFD` for invalid bytes
- Real-MarkItDown smoke that asserts the explicit-charset path actually parses non-ASCII content (the test that *would have caught* the production bug if it had been in the original spike)

## Out of scope (intentional)

| Format | Why deferred |
|---|---|
| `application/msword` (.doc binary) | MarkItDown unsupported; needs LibreOffice / antiword. Tier 5. |
| `application/rtf` | MarkItDown emits raw `{\rtf1\ansi…}` source rather than parsing. Needs `striprtf`. |
| `application/x-iwork-keynote-sffkey` | MarkItDown lists zip contents, no slide text |
| `application/zip` | needs separate recursive-unpack logic |
| PDF via MarkItDown | native path is `pdfminer.six` text-layer only — no improvement over current Marker pipeline |

## Operational follow-up (separate PR / drain run)

Once this lands:

```sql
-- Flip matching skipped rows back to pending; one drain pass recovers them.
UPDATE attachment_contents
SET status = 'pending', reason = NULL, claimed_by = NULL
WHERE status = 'skipped'
  AND reason IN (
    'content_type ''text/calendar'' is not supported by Marker',
    'content_type ''application/ics'' is not supported by Marker',
    'content_type ''text/csv'' is not supported by Marker',
    'content_type ''application/json'' is not supported by Marker',
    'content_type ''application/xml'' is not supported by Marker',
    'content_type ''text/x-vcard'' is not supported by Marker',
    'content_type ''application/x-iwork-pages-sffpages'' is not supported by Marker',
    'xls_legacy: legacy binary format requires LibreOffice pre-conversion (not implemented in v1)'
  );
```

Then `maildb process_attachments run --workers 1 --extract-timeout 300 --max-runtime 28800`. These files are tiny; expect minutes-to-an-hour, not the multi-day drains we ran for PDFs.

## Test plan

- [x] `uv run just check` — 529 tests pass, ruff + mypy clean
- [x] Real-DB smoke: previously-failing ICS files now parse end-to-end via `_markitdown_convert`
- [x] `scripts/spike_markitdown.py` re-runnable against the live DB for ad-hoc validation
- [ ] Operational drain after merge — separate, observed via `maildb jobs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)