### PR TITLE
fix(ingest): scope orchestrator phase checks to current import_id

### DIFF
--- a/src/maildb/ingest/orchestrator.py
+++ b/src/maildb/ingest/orchestrator.py
@@ -147,17 +147,31 @@ def run_pipeline(
 
     try:
         try:
+            # Adopt a still-running imports row or create one. The orchestrator's
+            # per-phase progress decisions all scope to this import_id so a
+            # prior account's completed tasks don't fool the planner into
+            # thinking the current run has nothing left to do.
+            import_id, _was_created = _resume_or_create_import(
+                pool,
+                source_account=source_account,
+                source_file=str(mbox_path),
+                force_new_import=force_new_import,
+            )
+            import_row_created = True
+
             # Phase 1: Split — may early-return via recursive restart.
-            # The imports row is NOT inserted yet: on restart, the recursive
-            # call will own its own row. This prevents orphaning the outer
-            # row in status='running' forever.
-            split_status = get_phase_status(pool, "split")
+            split_status = get_phase_status(pool, "split", import_id=import_id)
             if split_status["total"] > 0 and split_status["completed"] == 0:
                 logger.info("split_incomplete_restarting")
                 with pool.connection() as conn:
-                    conn.execute("DELETE FROM ingest_tasks WHERE phase IN ('split', 'parse')")
+                    conn.execute(
+                        "DELETE FROM ingest_tasks "
+                        "WHERE phase IN ('split', 'parse') AND import_id = %(id)s",
+                        {"id": import_id},
+                    )
                     conn.commit()
                 pool.close()
+                # The 'running' imports row stays; recursion will adopt it.
                 return run_pipeline(
                     mbox_path=mbox_path,
                     database_url=database_url,
@@ -174,17 +188,6 @@ def run_pipeline(
                     skip_embed=skip_embed,
                     force_new_import=False,
                 )
-
-            # Restart check passed — adopt a still-running row or create one.
-            # Once we have the import_id, we "own" it for this run, so
-            # any failure below should mark it failed.
-            import_id, _was_created = _resume_or_create_import(
-                pool,
-                source_account=source_account,
-                source_file=str(mbox_path),
-                force_new_import=force_new_import,
-            )
-            import_row_created = True
 
             if split_status["total"] == 0:
                 logger.info("phase_start", phase="split")
@@ -203,8 +206,8 @@ def run_pipeline(
                 logger.info("phase_complete", phase="split", chunks=len(chunks))
 
             # Phase 2: Parse
-            reset_failed_tasks(pool, phase="parse")
-            parse_status = get_phase_status(pool, "parse")
+            reset_failed_tasks(pool, phase="parse", import_id=import_id)
+            parse_status = get_phase_status(pool, "parse", import_id=import_id)
             if parse_status["pending"] > 0 or parse_status["in_progress"] > 0:
                 logger.info("phase_start", phase="parse", pending=parse_status["pending"])
                 drop_non_unique_indexes(pool)
@@ -226,7 +229,7 @@ def run_pipeline(
 
                 logger.info("phase_complete", phase="parse")
 
-            parse_status = get_phase_status(pool, "parse")
+            parse_status = get_phase_status(pool, "parse", import_id=import_id)
             if parse_status["failed"] > 0:
                 logger.error("parse_phase_has_permanent_failures", failed=parse_status["failed"])
                 msg = (
@@ -236,7 +239,7 @@ def run_pipeline(
                 raise RuntimeError(msg)  # noqa: TRY301
 
             # Phase 3: Index
-            index_status = get_phase_status(pool, "index")
+            index_status = get_phase_status(pool, "index", import_id=import_id)
             if index_status["completed"] == 0:
                 logger.info("phase_start", phase="index")
                 index_task = create_task(pool, phase="index", import_id=import_id)
@@ -250,7 +253,7 @@ def run_pipeline(
                 if unembedded > 0:
                     logger.info("phase_start", phase="embed", unembedded=unembedded)
 
-                    embed_status = get_phase_status(pool, "embed")
+                    embed_status = get_phase_status(pool, "embed", import_id=import_id)
                     if embed_status["in_progress"] == 0:
                         embed_task = create_task(pool, phase="embed", import_id=import_id)
                         task_id = embed_task["id"]

--- a/src/maildb/ingest/tasks.py
+++ b/src/maildb/ingest/tasks.py
@@ -96,36 +96,65 @@ def fail_task(pool: ConnectionPool, task_id: int, *, error: str) -> None:
         conn.commit()
 
 
-def reset_failed_tasks(pool: ConnectionPool, *, phase: str, max_retries: int = 3) -> int:
-    """Reset failed tasks with retries remaining back to pending. Returns count."""
+def reset_failed_tasks(
+    pool: ConnectionPool,
+    *,
+    phase: str,
+    max_retries: int = 3,
+    import_id: Any = None,
+) -> int:
+    """Reset failed tasks with retries remaining back to pending. Returns count.
+
+    If `import_id` is given, only that import's tasks are touched — required
+    when multiple accounts share the queue so a prior import's failures don't
+    get retried under the wrong account.
+    """
     with pool.connection() as conn, conn.cursor() as cur:
-        cur.execute(
-            """UPDATE ingest_tasks
-               SET status = 'pending', worker_id = NULL, error_message = NULL
-               WHERE phase = %(phase)s AND status = 'failed' AND retry_count < %(max_retries)s""",
-            {"phase": phase, "max_retries": max_retries},
+        sql = (
+            "UPDATE ingest_tasks "
+            "SET status = 'pending', worker_id = NULL, error_message = NULL "
+            "WHERE phase = %(phase)s AND status = 'failed' "
+            "AND retry_count < %(max_retries)s"
         )
+        params: dict[str, Any] = {"phase": phase, "max_retries": max_retries}
+        if import_id is not None:
+            sql += " AND import_id = %(import_id)s"
+            params["import_id"] = import_id
+        cur.execute(sql, params)
         conn.commit()
         return cur.rowcount
 
 
-def get_phase_status(pool: ConnectionPool, phase: str) -> dict[str, int]:
-    """Get counts by status for a phase."""
+def get_phase_status(
+    pool: ConnectionPool,
+    phase: str,
+    *,
+    import_id: Any = None,
+) -> dict[str, int]:
+    """Get counts by status for a phase.
+
+    If `import_id` is given, counts are scoped to that import only. Required
+    when the orchestrator is deciding whether the *current* import has work
+    left in a phase; otherwise prior imports' completed rows mask the answer.
+    """
     with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(
-            """SELECT
-                   count(*) FILTER (WHERE status = 'pending') AS pending,
-                   count(*) FILTER (WHERE status = 'in_progress') AS in_progress,
-                   count(*) FILTER (WHERE status = 'completed') AS completed,
-                   count(*) FILTER (WHERE status = 'failed') AS failed,
-                   count(*) AS total,
-                   coalesce(sum(messages_total), 0) AS messages_total,
-                   coalesce(sum(messages_inserted), 0) AS messages_inserted,
-                   coalesce(sum(messages_skipped), 0) AS messages_skipped,
-                   coalesce(sum(attachments_extracted), 0) AS attachments_extracted
-               FROM ingest_tasks
-               WHERE phase = %(phase)s""",
-            {"phase": phase},
+        sql = (
+            "SELECT "
+            "count(*) FILTER (WHERE status = 'pending') AS pending, "
+            "count(*) FILTER (WHERE status = 'in_progress') AS in_progress, "
+            "count(*) FILTER (WHERE status = 'completed') AS completed, "
+            "count(*) FILTER (WHERE status = 'failed') AS failed, "
+            "count(*) AS total, "
+            "coalesce(sum(messages_total), 0) AS messages_total, "
+            "coalesce(sum(messages_inserted), 0) AS messages_inserted, "
+            "coalesce(sum(messages_skipped), 0) AS messages_skipped, "
+            "coalesce(sum(attachments_extracted), 0) AS attachments_extracted "
+            "FROM ingest_tasks WHERE phase = %(phase)s"
         )
+        params: dict[str, Any] = {"phase": phase}
+        if import_id is not None:
+            sql += " AND import_id = %(import_id)s"
+            params["import_id"] = import_id
+        cur.execute(sql, params)
         row = cur.fetchone()
         return dict(row)  # type: ignore[arg-type]

--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -285,6 +285,10 @@ def test_run_pipeline_adopts_orphan_running_import(test_pool, test_settings, tmp
 def test_run_pipeline_same_mbox_two_accounts_creates_join_rows(test_pool, test_settings, tmp_path):
     """Ingesting the same mbox under two different accounts produces one
     emails row per message but two email_accounts rows per message.
+
+    Regression: the per-phase status checks must be scoped to the current
+    import_id, otherwise the second account's run sees the first run's
+    completed split/parse/index tasks and no-ops without ingesting.
     """
     mbox = FIXTURES / "sample.mbox"
     common = dict(  # noqa: C408
@@ -297,8 +301,8 @@ def test_run_pipeline_same_mbox_two_accounts_creates_join_rows(test_pool, test_s
         skip_embed=True,
     )
     run_pipeline(source_account="a@example.com", **common)
-    # Wipe parse tasks so the second account reprocesses every chunk.
-    reset_pipeline(test_pool, phase="parse")
+    # Second run, same mbox, different account — no reset_pipeline between.
+    # The orchestrator must detect this is a fresh import and execute every phase.
     run_pipeline(source_account="b@example.com", **common)
 
     with test_pool.connection() as conn:
@@ -311,8 +315,68 @@ def test_run_pipeline_same_mbox_two_accounts_creates_join_rows(test_pool, test_s
             "WHERE source_account = 'b@example.com'"
         )
         b_tagged = cur.fetchone()[0]
-    assert ea_count == email_count * 2  # Every email tagged under both.
-    assert b_tagged == email_count
+        cur = conn.execute(
+            "SELECT count(DISTINCT email_id) FROM email_accounts "
+            "WHERE source_account = 'a@example.com'"
+        )
+        a_tagged = cur.fetchone()[0]
+    assert email_count > 0, "sample.mbox should have produced rows"
+    assert a_tagged == email_count, "every email should be tagged under a@"
+    assert b_tagged == email_count, "every email should be tagged under b@"
+    assert ea_count == email_count * 2, "every email tagged under both accounts"
+
+
+def test_run_pipeline_two_accounts_two_mboxes_both_ingest(test_pool, test_settings, tmp_path):
+    """Two distinct mboxes under two distinct accounts both ingest fully.
+
+    This mirrors the real-world add-a-new-account scenario: an existing
+    DB with one account's import already completed, then a second account
+    runs against its own (different) mbox file. Both imports must produce
+    their own emails + email_accounts rows.
+    """
+    common = dict(  # noqa: C408
+        database_url=test_settings.database_url,
+        attachment_dir=tmp_path / "attachments",
+        tmp_dir=tmp_path / "chunks",
+        chunk_size_bytes=50 * 1024 * 1024,
+        parse_workers=2,
+        skip_embed=True,
+    )
+    # First mbox: the shared fixture. Second mbox: a copy with rewritten
+    # message-ids (and their references) so emails do not dedup across
+    # accounts. Every sample.mbox message-id starts with "<msg" so a
+    # single prefix-substitution gives disjoint ids.
+    mbox_a = FIXTURES / "sample.mbox"
+    mbox_b = tmp_path / "sample_b.mbox"
+    mbox_b.write_bytes(mbox_a.read_bytes().replace(b"<msg", b"<b-msg"))
+
+    run_pipeline(mbox_path=mbox_a, source_account="a@example.com", **common)
+    run_pipeline(mbox_path=mbox_b, source_account="b@example.com", **common)
+
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT count(*) FROM email_accounts WHERE source_account = 'a@example.com'"
+        )
+        a_count = cur.fetchone()[0]
+        cur = conn.execute(
+            "SELECT count(*) FROM email_accounts WHERE source_account = 'b@example.com'"
+        )
+        b_count = cur.fetchone()[0]
+        cur = conn.execute("SELECT count(*) FROM emails")
+        total_emails = cur.fetchone()[0]
+        cur = conn.execute(
+            "SELECT messages_inserted FROM imports WHERE source_account = 'a@example.com'"
+        )
+        a_inserted = cur.fetchone()[0]
+        cur = conn.execute(
+            "SELECT messages_inserted FROM imports WHERE source_account = 'b@example.com'"
+        )
+        b_inserted = cur.fetchone()[0]
+    assert a_count > 0, "account a should have email_accounts rows"
+    assert b_count > 0, "account b should have email_accounts rows"
+    assert a_count == b_count, "both mboxes have the same message count"
+    assert total_emails == a_count + b_count, "no dedup expected (distinct message_ids)"
+    assert a_inserted > 0 and b_inserted > 0, "imports rows reflect actual work"
 
 
 def test_run_pipeline_force_new_import(test_pool, test_settings, tmp_path):


### PR DESCRIPTION
## Summary

Multi-account ingest was effectively broken. A second `maildb ingest run` for a new account against a DB that already had a completed import would exit in microseconds with **0 messages ingested** — but still leave behind an empty `imports` row with status `completed`, making it look like it succeeded.

I caught this attempting to ingest a second mbox today (`splaice@gmail.com` on top of an existing `sean@postmates.com` corpus of 841K messages). The orchestrator no-op'd in 170 µs and produced this misleading imports row:

```
splaice@gmail.com  completed   messages_total=0  messages_inserted=0
```

## Root cause

`src/maildb/ingest/orchestrator.py:run_pipeline` decided whether each phase needed work by calling `get_phase_status(pool, phase)`, which queried `ingest_tasks` **with no `import_id` filter**. The prior `sean@postmates.com` import's completed split/parse/index tasks made every phase appear done:

- `split_status.total == 1` → split skipped (line 189)
- `parse_status.pending == 0` → parse skipped (line 208)
- `index_status.completed == 1` → index skipped (line 240)
- `count_unembedded(pool) == 0` → embed skipped (line 250)

The pipeline then finalized the (empty) imports row.

The schema and dedup join were already multi-account-ready (DESIGN.md §5, `email_accounts` with `(email_id, source_account)` unique constraint). Only the per-run scheduling logic was broken.

## Fix

- Reorder `run_pipeline` so `_resume_or_create_import` runs **before** the split-status check. The `import_id` is then available for every per-phase decision.
- Add an optional `import_id` keyword to `get_phase_status` and `reset_failed_tasks` in `src/maildb/ingest/tasks.py`. When provided, both filter on `import_id`.
- Pass `import_id=import_id` to every per-run `get_phase_status` / `reset_failed_tasks` call in the orchestrator.
- Scope the restart-branch's `DELETE FROM ingest_tasks WHERE phase IN ('split', 'parse')` to the current import_id only, so a restart no longer wipes another account's task history.

The recursion in the restart branch still works: the imports row stays `running`, the recursive call's `_resume_or_create_import` adopts the same id, and the just-cleared phase status sends the pipeline back through `split`. `count_unembedded` and `create_hnsw_index` remain global — those are correct as-is.

## Test changes

- **Replaces** `test_run_pipeline_same_mbox_two_accounts_creates_join_rows`. The original called `reset_pipeline(phase="parse")` between the two runs, which deletes all `emails` rows (via cascade in `_PHASE_CASCADE["parse"]`). The post-run assertion `ea_count == email_count * 2` then held trivially at `0 == 0`. The new version asserts non-zero counts and that both accounts have full attribution.
- **Adds** `test_run_pipeline_two_accounts_two_mboxes_both_ingest`. Two distinct mboxes (sample.mbox + a copy with rewritten message-ids) under two distinct accounts. Asserts both imports' `messages_inserted > 0` and `email_accounts` has rows for each account. This is the scenario that bit me in production.

## Test plan

- [x] `uv run just check` — 545 passed
- [x] Confirmed the new test fails before the fix and passes after
- [ ] Re-run the splaice@gmail.com ingest after merge; verify both accounts coexist