### PR TITLE
fix(ingest): reclaim stale tasks, scope claims to import, isolate chunk dirs

### DIFF
--- a/src/maildb/ingest/orchestrator.py
+++ b/src/maildb/ingest/orchestrator.py
@@ -2,20 +2,24 @@ from __future__ import annotations
 
 import os
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 from uuid import UUID, uuid4
 
 import structlog
 from psycopg_pool import ConnectionPool
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
 from maildb.ingest.embed import embed_worker
 from maildb.ingest.index import create_hnsw_index, drop_non_unique_indexes, run_index_phase
 from maildb.ingest.parse import process_chunk
 from maildb.ingest.split import split_mbox
-from maildb.ingest.tasks import complete_task, create_task, get_phase_status, reset_failed_tasks
+from maildb.ingest.tasks import (
+    complete_task,
+    create_task,
+    get_phase_status,
+    reset_failed_tasks,
+    reset_stale_in_progress,
+)
 
 logger = structlog.get_logger()
 
@@ -193,7 +197,9 @@ def run_pipeline(
                 logger.info("phase_start", phase="split")
                 split_task = create_task(pool, phase="split", import_id=import_id)
                 chunks = split_mbox(
-                    mbox_path, output_dir=tmp_dir, chunk_size_bytes=chunk_size_bytes
+                    mbox_path,
+                    output_dir=Path(tmp_dir) / str(import_id),
+                    chunk_size_bytes=chunk_size_bytes,
                 )
                 for chunk_path in chunks:
                     create_task(
@@ -207,6 +213,9 @@ def run_pipeline(
 
             # Phase 2: Parse
             reset_failed_tasks(pool, phase="parse", import_id=import_id)
+            reclaimed = reset_stale_in_progress(pool, phase="parse", import_id=import_id)
+            if reclaimed > 0:
+                logger.info("stale_tasks_reclaimed", phase="parse", count=reclaimed)
             parse_status = get_phase_status(pool, "parse", import_id=import_id)
             if parse_status["pending"] > 0 or parse_status["in_progress"] > 0:
                 logger.info("phase_start", phase="parse", pending=parse_status["pending"])
@@ -218,6 +227,7 @@ def run_pipeline(
                             process_chunk,
                             database_url=database_url,
                             attachment_dir=attachment_dir,
+                            import_id=import_id,
                         )
                         for _ in range(parse_workers)
                     ]
@@ -235,6 +245,16 @@ def run_pipeline(
                 msg = (
                     f"Parse phase has {parse_status['failed']} permanently failed tasks. "
                     "Fix errors and retry."
+                )
+                raise RuntimeError(msg)  # noqa: TRY301
+            if parse_status["in_progress"] > 0:
+                logger.error(
+                    "parse_phase_has_in_progress_tasks",
+                    in_progress=parse_status["in_progress"],
+                )
+                msg = (
+                    f"Parse phase has {parse_status['in_progress']} tasks still in progress "
+                    "after workers exited. Retry the import."
                 )
                 raise RuntimeError(msg)  # noqa: TRY301
 

--- a/src/maildb/ingest/parse.py
+++ b/src/maildb/ingest/parse.py
@@ -64,6 +64,7 @@ def process_chunk(
     *,
     database_url: str,
     attachment_dir: Path | str,
+    import_id: Any,
 ) -> int:
     """Claim and process chunks in a loop until no work remains. Returns chunks processed."""
     attachment_dir = Path(attachment_dir)
@@ -76,22 +77,22 @@ def process_chunk(
 
     try:
         while True:
-            claimed = claim_task(pool, phase="parse", worker_id=worker_id)
+            claimed = claim_task(pool, phase="parse", worker_id=worker_id, import_id=import_id)
             if claimed is None:
                 break
             task_id = claimed["id"]
             chunk_path = claimed["chunk_path"]
-            import_id = claimed["import_id"]
-            if import_id not in account_cache:
-                account_cache[import_id] = _lookup_source_account(pool, import_id)
-            source_account = account_cache[import_id]
+            task_import_id = claimed["import_id"]
+            if task_import_id not in account_cache:
+                account_cache[task_import_id] = _lookup_source_account(pool, task_import_id)
+            source_account = account_cache[task_import_id]
             try:
                 _process_single_chunk(
                     pool,
                     task_id,
                     chunk_path,
                     attachment_dir,
-                    import_id=import_id,
+                    import_id=task_import_id,
                     source_account=source_account,
                 )
                 chunks_processed += 1

--- a/src/maildb/ingest/split.py
+++ b/src/maildb/ingest/split.py
@@ -18,6 +18,9 @@ def split_mbox(
 ) -> list[Path]:
     """Split an mbox file into chunks of approximately chunk_size_bytes.
 
+    The caller must pass a per-import output_dir because this function clears
+    and recreates it before writing chunks.
+
     Returns list of chunk file paths.
     """
     mbox_path = Path(mbox_path)

--- a/src/maildb/ingest/tasks.py
+++ b/src/maildb/ingest/tasks.py
@@ -33,21 +33,25 @@ def claim_task(
     *,
     phase: str,
     worker_id: str,
+    import_id: Any = None,
 ) -> dict[str, Any] | None:
     """Atomically claim the next pending task for a phase. Returns None if no work."""
     with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(
-            """UPDATE ingest_tasks
+        sql = """UPDATE ingest_tasks
                SET status = 'in_progress', worker_id = %(worker_id)s, started_at = now()
                WHERE id = (
                    SELECT id FROM ingest_tasks
-                   WHERE phase = %(phase)s AND status = 'pending'
+                   WHERE phase = %(phase)s AND status = 'pending'"""
+        params: dict[str, Any] = {"phase": phase, "worker_id": worker_id}
+        if import_id is not None:
+            sql += " AND import_id = %(import_id)s"
+            params["import_id"] = import_id
+        sql += """
                    LIMIT 1
                    FOR UPDATE SKIP LOCKED
                )
-               RETURNING *""",
-            {"phase": phase, "worker_id": worker_id},
-        )
+               RETURNING *"""
+        cur.execute(sql, params)
         row = cur.fetchone()
         conn.commit()
         return dict(row) if row else None
@@ -121,6 +125,26 @@ def reset_failed_tasks(
             sql += " AND import_id = %(import_id)s"
             params["import_id"] = import_id
         cur.execute(sql, params)
+        conn.commit()
+        return cur.rowcount
+
+
+def reset_stale_in_progress(
+    pool: ConnectionPool,
+    *,
+    phase: str,
+    import_id: Any,
+) -> int:
+    """Reset in-progress tasks for one import back to pending. Returns count."""
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """UPDATE ingest_tasks
+               SET status = 'pending', worker_id = NULL, started_at = NULL
+               WHERE phase = %(phase)s
+                 AND status = 'in_progress'
+                 AND import_id = %(import_id)s""",
+            {"phase": phase, "import_id": import_id},
+        )
         conn.commit()
         return cur.rowcount
 

--- a/src/maildb/parsing.py
+++ b/src/maildb/parsing.py
@@ -243,7 +243,10 @@ def parse_message(msg: mailbox.mboxMessage) -> dict[str, Any] | None:
 def parse_mbox(mbox_path: Path | str) -> Iterator[dict[str, Any]]:
     """Parse all messages from an mbox file, yielding structured dictionaries."""
     mbox_path = Path(mbox_path)
-    mbox_file = mailbox.mbox(str(mbox_path))
+    if not mbox_path.exists():
+        message = f"Mbox file does not exist: {mbox_path}"
+        raise FileNotFoundError(message)
+    mbox_file = mailbox.mbox(str(mbox_path), create=False)
 
     for msg in mbox_file:
         try:

--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Future
 from pathlib import Path
 from uuid import uuid4
 
@@ -5,7 +6,7 @@ import pytest
 
 from maildb.ingest import orchestrator
 from maildb.ingest.orchestrator import count_unembedded, get_status, reset_pipeline, run_pipeline
-from maildb.ingest.tasks import complete_task, create_task
+from maildb.ingest.tasks import claim_task, complete_task, create_task
 
 FIXTURES = Path(__file__).parent.parent / "fixtures"
 
@@ -40,6 +41,112 @@ def test_run_pipeline_split_and_parse(test_pool, test_settings, tmp_path):
     with test_pool.connection() as conn:
         cur = conn.execute("SELECT count(*) FROM emails")
         assert cur.fetchone()[0] > 0
+
+
+def test_run_pipeline_reclaims_stale_parse_task(test_pool, test_settings, tmp_path):
+    mbox = FIXTURES / "sample.mbox"
+    import_id = uuid4()
+    with test_pool.connection() as conn:
+        conn.execute(
+            """INSERT INTO imports (id, source_account, source_file, status)
+               VALUES (%(id)s, 'stale@example.com', %(file)s, 'running')""",
+            {"id": import_id, "file": str(mbox)},
+        )
+        conn.commit()
+    split_task = create_task(test_pool, phase="split", import_id=import_id)
+    complete_task(test_pool, split_task["id"], messages_total=1)
+    parse_task = create_task(
+        test_pool,
+        phase="parse",
+        chunk_path=str(mbox),
+        import_id=import_id,
+    )
+    claimed = claim_task(
+        test_pool,
+        phase="parse",
+        worker_id="dead-worker",
+        import_id=import_id,
+    )
+    assert claimed["id"] == parse_task["id"]
+
+    run_pipeline(
+        mbox_path=mbox,
+        database_url=test_settings.database_url,
+        attachment_dir=tmp_path / "attachments",
+        tmp_dir=tmp_path / "chunks",
+        chunk_size_bytes=50 * 1024 * 1024,
+        parse_workers=1,
+        skip_embed=True,
+        source_account="stale@example.com",
+    )
+
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT status FROM ingest_tasks WHERE id = %(id)s",
+            {"id": parse_task["id"]},
+        )
+        assert cur.fetchone()[0] == "completed"
+        cur = conn.execute(
+            "SELECT count(*) FROM emails WHERE import_id = %(id)s", {"id": import_id}
+        )
+        assert cur.fetchone()[0] > 0
+        cur = conn.execute("SELECT status FROM imports WHERE id = %(id)s", {"id": import_id})
+        assert cur.fetchone()[0] == "completed"
+
+
+def test_run_pipeline_raises_when_parse_tasks_remain_in_progress(
+    test_pool, test_settings, tmp_path, monkeypatch
+):
+    class ClaimingExecutor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def submit(self, fn, **kwargs):
+            claim_task(
+                test_pool,
+                phase="parse",
+                worker_id="stalled-worker",
+                import_id=kwargs.get("import_id"),
+            )
+            future = Future()
+            future.set_result(0)
+            return future
+
+    mbox = FIXTURES / "sample.mbox"
+    import_id = uuid4()
+    with test_pool.connection() as conn:
+        conn.execute(
+            """INSERT INTO imports (id, source_account, source_file, status)
+               VALUES (%(id)s, 'stalled@example.com', %(file)s, 'running')""",
+            {"id": import_id, "file": str(mbox)},
+        )
+        conn.commit()
+    split_task = create_task(test_pool, phase="split", import_id=import_id)
+    complete_task(test_pool, split_task["id"], messages_total=1)
+    create_task(test_pool, phase="parse", chunk_path=str(mbox), import_id=import_id)
+    monkeypatch.setattr(orchestrator, "ProcessPoolExecutor", ClaimingExecutor)
+
+    with pytest.raises(RuntimeError, match="in progress"):
+        run_pipeline(
+            mbox_path=mbox,
+            database_url=test_settings.database_url,
+            attachment_dir=tmp_path / "attachments",
+            tmp_dir=tmp_path / "chunks",
+            chunk_size_bytes=50 * 1024 * 1024,
+            parse_workers=1,
+            skip_embed=True,
+            source_account="stalled@example.com",
+        )
+
+    with test_pool.connection() as conn:
+        cur = conn.execute("SELECT status FROM imports WHERE id = %(id)s", {"id": import_id})
+        assert cur.fetchone()[0] == "failed"
 
 
 def test_embed_resumes_after_completion(test_pool):

--- a/tests/integration/test_parse_worker.py
+++ b/tests/integration/test_parse_worker.py
@@ -5,9 +5,10 @@ from uuid import uuid4
 
 import pytest
 
+from maildb.ingest import tasks as ingest_tasks
 from maildb.ingest.orchestrator import run_pipeline
 from maildb.ingest.parse import process_chunk
-from maildb.ingest.tasks import create_task, get_phase_status
+from maildb.ingest.tasks import claim_task, create_task, get_phase_status
 
 FIXTURES = Path(__file__).parent.parent / "fixtures"
 
@@ -39,6 +40,7 @@ def test_process_chunk_inserts_emails(test_pool, test_settings, tmp_path):
     process_chunk(
         database_url=test_settings.database_url,
         attachment_dir=tmp_path / "attachments",
+        import_id=import_id,
     )
     with test_pool.connection() as conn:
         cur = conn.execute("SELECT count(*) FROM emails")
@@ -88,6 +90,7 @@ def test_process_chunk_skips_bad_rows(test_pool, test_settings, tmp_path):
     process_chunk(
         database_url=test_settings.database_url,
         attachment_dir=tmp_path / "attachments",
+        import_id=import_id,
     )
     status = get_phase_status(test_pool, "parse")
     assert status["completed"] == 1
@@ -108,9 +111,90 @@ def test_process_chunk_handles_failure(test_pool, test_settings, tmp_path):
     process_chunk(
         database_url=test_settings.database_url,
         attachment_dir=tmp_path / "attachments",
+        import_id=import_id,
     )
     status = get_phase_status(test_pool, "parse")
     assert status["failed"] == 1
+
+
+def test_claim_task_with_import_id_only_claims_that_import(test_pool):
+    import_a = _insert_import(test_pool, account="a@example.com")
+    import_b = _insert_import(test_pool, account="b@example.com")
+    task_a = create_task(
+        test_pool,
+        phase="parse",
+        chunk_path="/tmp/a.mbox",
+        import_id=import_a,
+    )
+    task_b = create_task(
+        test_pool,
+        phase="parse",
+        chunk_path="/tmp/b.mbox",
+        import_id=import_b,
+    )
+
+    claimed = claim_task(
+        test_pool,
+        phase="parse",
+        worker_id="worker-a",
+        import_id=import_a,
+    )
+
+    assert claimed is not None
+    assert claimed["id"] == task_a["id"]
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT status FROM ingest_tasks WHERE id = %(id)s",
+            {"id": task_b["id"]},
+        )
+        assert cur.fetchone()[0] == "pending"
+
+
+def test_reset_stale_in_progress_only_resets_given_import(test_pool):
+    import_a = _insert_import(test_pool, account="a@example.com")
+    import_b = _insert_import(test_pool, account="b@example.com")
+    stale_a = create_task(
+        test_pool,
+        phase="parse",
+        chunk_path="/tmp/a-stale.mbox",
+        import_id=import_a,
+    )
+    stale_b = create_task(
+        test_pool,
+        phase="parse",
+        chunk_path="/tmp/b-stale.mbox",
+        import_id=import_b,
+    )
+    pending_a = create_task(
+        test_pool,
+        phase="parse",
+        chunk_path="/tmp/a-pending.mbox",
+        import_id=import_a,
+    )
+    index_a = create_task(test_pool, phase="index", import_id=import_a)
+
+    claim_task(test_pool, phase="parse", worker_id="worker-a", import_id=import_a)
+    claim_task(test_pool, phase="parse", worker_id="worker-b", import_id=import_b)
+    claim_task(test_pool, phase="index", worker_id="worker-index", import_id=import_a)
+
+    count = ingest_tasks.reset_stale_in_progress(
+        test_pool,
+        phase="parse",
+        import_id=import_a,
+    )
+
+    assert count == 1
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT id, status, worker_id, started_at FROM ingest_tasks "
+            "WHERE id = ANY(%(ids)s) ORDER BY id",
+            {"ids": [stale_a["id"], stale_b["id"], pending_a["id"], index_a["id"]]},
+        )
+        rows = {row[0]: row[1:] for row in cur.fetchall()}
+    assert rows[stale_a["id"]] == ("pending", None, None)
+    assert rows[stale_b["id"]][0] == "in_progress"
+    assert rows[pending_a["id"]][0] == "pending"
+    assert rows[index_a["id"]][0] == "in_progress"
 
 
 def test_parse_increments_reference_count(test_pool, test_settings, tmp_path):

--- a/tests/unit/test_parsing.py
+++ b/tests/unit/test_parsing.py
@@ -16,6 +16,20 @@ def test_parse_mbox_yields_all_messages() -> None:
     assert len(messages) == 10
 
 
+def test_parse_mbox_missing_file_raises_without_creating(tmp_path: Path) -> None:
+    mbox_path = tmp_path / "missing.mbox"
+
+    try:
+        list(parse_mbox(mbox_path))
+    except FileNotFoundError as exc:
+        assert str(mbox_path) in str(exc)
+    else:
+        msg = "Expected parse_mbox to raise FileNotFoundError"
+        raise AssertionError(msg)
+
+    assert not mbox_path.exists()
+
+
 def test_parse_message_extracts_message_id() -> None:
     messages = list(parse_mbox(FIXTURES / "sample.mbox"))
     assert messages[0]["message_id"] == "msg001@example.com"


### PR DESCRIPTION
## Objective

Four resumability bugs from the 2026-06-10 deep review (HIGH: stale `in_progress` tasks finalize imports as completed with missing emails; MEDIUM: `claim_task` unscoped by import; `split_mbox` rmtrees the shared tmp dir; `parse_mbox` treats missing chunks as empty mailboxes).

## Change

- `tasks.py`: `claim_task` gains optional `import_id` scoping; new `reset_stale_in_progress()`.
- `orchestrator.py`: reclaim stale in_progress tasks before spawning parse workers; raise when tasks remain in_progress after the pool drains; per-import split output dir.
- `parse.py`: workers claim only their import's tasks.
- `parsing.py`: `mailbox.mbox(..., create=False)` + explicit `FileNotFoundError`.

## Acceptance criteria

- [x] Unit + integration tests pass (pipeline-level stale-reclaim test, claim-scoping test, in-progress gate test via stalled-executor monkeypatch, missing-chunk FileNotFoundError test)
- [x] `uv run just check` — exit 0
- [x] Changes confined to the allowed files; `claim_task` default behavior unchanged

## Provenance

Implementer: codex-cli 0.143.0, `gpt-5.5` @ `xhigh`, cheap-coder workflow (spec-driven, TDD, isolated worktree + own venv). Architecture, spec, review: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)