### PR TITLE
perf(embed): hold claim locks across embedding; backlog partial index

### DIFF
--- a/src/maildb/ingest/embed.py
+++ b/src/maildb/ingest/embed.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 from psycopg.rows import dict_row
@@ -9,6 +9,9 @@ from psycopg_pool import ConnectionPool
 
 from maildb.embeddings import EmbeddingClient, build_embedding_text
 from maildb.ingest.progress import ProgressTracker
+
+if TYPE_CHECKING:
+    from psycopg import Connection
 
 logger = structlog.get_logger()
 
@@ -25,36 +28,32 @@ FOR UPDATE SKIP LOCKED
 SKIP_SENTINEL = "[0]"
 
 
-def _fetch_batch(pool: ConnectionPool, batch_size: int) -> list[dict[str, Any]]:
+def _fetch_batch(conn: Connection[Any], batch_size: int) -> list[dict[str, Any]]:
     """Fetch a batch of un-embedded rows. Returns empty list when no work remains."""
-    with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=dict_row) as cur:
         cur.execute(SELECT_BATCH_SQL, {"batch_size": batch_size})
         rows = cur.fetchall()
-        # Rollback to release FOR UPDATE locks — we'll update by id later
-        conn.rollback()
     return [dict(r) for r in rows]
 
 
 def _embed_and_update_batch(
-    pool: ConnectionPool,
+    conn: Connection[Any],
     client: EmbeddingClient,
     rows: list[dict[str, Any]],
     texts: list[str],
 ) -> int:
     """Embed a full batch and update all rows. Returns count updated."""
     embeddings = client.embed_batch(texts)
-    with pool.connection() as conn:
-        for row, emb in zip(rows, embeddings, strict=True):
-            conn.execute(
-                "UPDATE emails SET embedding = %s WHERE id = %s",
-                (emb, row["id"]),
-            )
-        conn.commit()
+    for row, emb in zip(rows, embeddings, strict=True):
+        conn.execute(
+            "UPDATE emails SET embedding = %s WHERE id = %s",
+            (emb, row["id"]),
+        )
     return len(rows)
 
 
 def _embed_and_update_single(
-    pool: ConnectionPool,
+    conn: Connection[Any],
     client: EmbeddingClient,
     rows: list[dict[str, Any]],
     texts: list[str],
@@ -69,19 +68,15 @@ def _embed_and_update_single(
         except Exception:
             logger.warning("embed_single_skipped", email_id=str(row["id"]))
             # Mark with zero vector so this row is not picked up again
-            with pool.connection() as conn:
-                conn.execute(
-                    "UPDATE emails SET embedding = %s WHERE id = %s",
-                    (zero_vector, row["id"]),
-                )
-                conn.commit()
-            continue
-        with pool.connection() as conn:
             conn.execute(
                 "UPDATE emails SET embedding = %s WHERE id = %s",
-                (emb, row["id"]),
+                (zero_vector, row["id"]),
             )
-            conn.commit()
+            continue
+        conn.execute(
+            "UPDATE emails SET embedding = %s WHERE id = %s",
+            (emb, row["id"]),
+        )
         updated += 1
     return updated
 
@@ -111,25 +106,29 @@ def embed_worker(
 
     try:
         while True:
-            rows = _fetch_batch(pool, batch_size)
-            if not rows:
-                break
+            with pool.connection() as conn:
+                rows = _fetch_batch(conn, batch_size)
+                if not rows:
+                    break
 
-            texts = [
-                build_embedding_text(r["subject"], r["sender_name"], r["body_text"]) for r in rows
-            ]
+                texts = [
+                    build_embedding_text(r["subject"], r["sender_name"], r["body_text"])
+                    for r in rows
+                ]
 
-            try:
-                batch_updated = _embed_and_update_batch(pool, client, rows, texts)
-                total_updated += batch_updated
-                logger.info("embed_batch_done", batch_size=batch_updated, total=total_updated)
-            except Exception:
-                # Batch failed — fall back to one-at-a-time
-                logger.warning("embed_batch_failed_falling_back", batch_size=len(rows))
-                batch_updated = _embed_and_update_single(
-                    pool, client, rows, texts, embedding_dimensions
-                )
-                total_updated += batch_updated
+                try:
+                    batch_updated = _embed_and_update_batch(conn, client, rows, texts)
+                    total_updated += batch_updated
+                    logger.info("embed_batch_done", batch_size=batch_updated, total=total_updated)
+                except Exception:
+                    # Batch failed — fall back to one-at-a-time
+                    logger.warning("embed_batch_failed_falling_back", batch_size=len(rows))
+                    batch_updated = _embed_and_update_single(
+                        conn, client, rows, texts, embedding_dimensions
+                    )
+                    total_updated += batch_updated
+
+                conn.commit()
 
             now = time.monotonic()
             if tracker is not None and now - last_report >= 60:

--- a/src/maildb/ingest/index.py
+++ b/src/maildb/ingest/index.py
@@ -53,6 +53,25 @@ def run_index_phase(pool: ConnectionPool, *, include_hnsw: bool = False) -> None
     logger.info("indexes_created", include_hnsw=include_hnsw)
 
 
+def create_embed_backlog_index(pool: ConnectionPool) -> None:
+    """Create a temporary partial index for the embed backlog scan."""
+    with pool.connection() as conn:
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_email_embedding_null "
+            "ON emails (id) WHERE embedding IS NULL"
+        )
+        conn.commit()
+    logger.info("embed_backlog_index_created")
+
+
+def drop_embed_backlog_index(pool: ConnectionPool) -> None:
+    """Drop the temporary partial index used during the embed phase."""
+    with pool.connection() as conn:
+        conn.execute("DROP INDEX IF EXISTS idx_email_embedding_null")
+        conn.commit()
+    logger.info("embed_backlog_index_dropped")
+
+
 def create_hnsw_index(pool: ConnectionPool) -> None:
     """Create the HNSW index on embeddings. Called after embed phase."""
     with pool.connection() as conn:

--- a/src/maildb/ingest/orchestrator.py
+++ b/src/maildb/ingest/orchestrator.py
@@ -10,7 +10,13 @@ import structlog
 from psycopg_pool import ConnectionPool
 
 from maildb.ingest.embed import embed_worker
-from maildb.ingest.index import create_hnsw_index, drop_non_unique_indexes, run_index_phase
+from maildb.ingest.index import (
+    create_embed_backlog_index,
+    create_hnsw_index,
+    drop_embed_backlog_index,
+    drop_non_unique_indexes,
+    run_index_phase,
+)
 from maildb.ingest.parse import process_chunk
 from maildb.ingest.split import split_mbox
 from maildb.ingest.tasks import (
@@ -280,20 +286,24 @@ def run_pipeline(
                     else:
                         task_id = None
 
-                    with ProcessPoolExecutor(max_workers=embed_workers) as executor:
-                        futures = [
-                            executor.submit(
-                                embed_worker,
-                                database_url=database_url,
-                                ollama_url=ollama_url,
-                                embedding_model=embedding_model,
-                                embedding_dimensions=embedding_dimensions,
-                                batch_size=embed_batch_size,
-                                _progress_total=unembedded,
-                            )
-                            for _ in range(embed_workers)
-                        ]
-                        total_embedded = sum(f.result() for f in futures)
+                    create_embed_backlog_index(pool)
+                    try:
+                        with ProcessPoolExecutor(max_workers=embed_workers) as executor:
+                            futures = [
+                                executor.submit(
+                                    embed_worker,
+                                    database_url=database_url,
+                                    ollama_url=ollama_url,
+                                    embedding_model=embedding_model,
+                                    embedding_dimensions=embedding_dimensions,
+                                    batch_size=embed_batch_size,
+                                    _progress_total=unembedded,
+                                )
+                                for _ in range(embed_workers)
+                            ]
+                            total_embedded = sum(f.result() for f in futures)
+                    finally:
+                        drop_embed_backlog_index(pool)
 
                     if task_id is not None:
                         complete_task(pool, task_id, messages_total=total_embedded)

--- a/tests/integration/test_embed_worker.py
+++ b/tests/integration/test_embed_worker.py
@@ -4,20 +4,22 @@ from uuid import uuid4
 import pytest
 from psycopg.rows import dict_row
 
-from maildb.ingest.embed import embed_worker
+from maildb.ingest.embed import _fetch_batch, embed_worker
 from maildb.ingest.orchestrator import get_status
 
 pytestmark = pytest.mark.integration
 
 
 def _insert_test_email(pool, message_id="test@example.com"):
+    email_id = uuid4()
     with pool.connection() as conn:
         conn.execute(
             """INSERT INTO emails (id, message_id, thread_id, subject, sender_name, body_text, created_at)
                VALUES (%(id)s, %(message_id)s, 'thread-1', 'Test', 'Sender', 'Body text', now())""",
-            {"id": uuid4(), "message_id": message_id},
+            {"id": email_id, "message_id": message_id},
         )
         conn.commit()
+    return email_id
 
 
 def test_embed_worker_processes_null_embeddings(test_pool, test_settings):
@@ -40,6 +42,27 @@ def test_embed_worker_processes_null_embeddings(test_pool, test_settings):
     with test_pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
         cur.execute("SELECT count(*) AS c FROM emails WHERE embedding IS NOT NULL")
         assert cur.fetchone()["c"] == 2
+
+
+def test_fetch_batch_holds_locks(test_pool):
+    for i in range(4):
+        _insert_test_email(test_pool, f"lock-test-{i}@example.com")
+
+    conn1 = test_pool.getconn()
+    conn2 = test_pool.getconn()
+    try:
+        rows1 = _fetch_batch(conn1, 2)
+        rows2 = _fetch_batch(conn2, 10)
+
+        ids1 = {row["id"] for row in rows1}
+        ids2 = {row["id"] for row in rows2}
+        assert len(ids1) == 2
+        assert ids1.isdisjoint(ids2)
+    finally:
+        conn1.rollback()
+        conn2.rollback()
+        test_pool.putconn(conn2)
+        test_pool.putconn(conn1)
 
 
 def _insert_email_with_zero_vector(pool, message_id, dimensions=768):

--- a/tests/integration/test_index_phase.py
+++ b/tests/integration/test_index_phase.py
@@ -1,6 +1,10 @@
 import pytest
 
-from maildb.ingest.index import run_index_phase
+from maildb.ingest.index import (
+    create_embed_backlog_index,
+    drop_embed_backlog_index,
+    run_index_phase,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -15,3 +19,19 @@ def test_run_index_phase_creates_indexes(test_pool):
     assert "idx_email_sender_address" in indexes
     assert "idx_email_date" in indexes
     assert "idx_email_thread_sender_date" in indexes
+
+
+def test_embed_backlog_index_create_drop_idempotent(test_pool):
+    create_embed_backlog_index(test_pool)
+    create_embed_backlog_index(test_pool)
+
+    with test_pool.connection() as conn:
+        cur = conn.execute("SELECT 1 FROM pg_indexes WHERE indexname = 'idx_email_embedding_null'")
+        assert cur.fetchone() is not None
+
+    drop_embed_backlog_index(test_pool)
+    drop_embed_backlog_index(test_pool)
+
+    with test_pool.connection() as conn:
+        cur = conn.execute("SELECT 1 FROM pg_indexes WHERE indexname = 'idx_email_embedding_null'")
+        assert cur.fetchone() is None


### PR DESCRIPTION
## Objective

Two deep-review findings (HIGH perf/correctness): embed workers released SKIP LOCKED locks before the Ollama call (all workers duplicated each other's batches), and the per-batch `WHERE embedding IS NULL` fetch had no supporting index (O(n²) page scans over a run).

## Change

- `embed.py`: `_fetch_batch`/`_embed_and_update_batch`/`_embed_and_update_single` now operate on one connection per batch; the claiming transaction stays open from fetch through a single commit. Crash mid-batch rolls back to NULL (safe retry). Zero-vector skip marking unchanged, now transactional with its batch.
- `index.py`: `create_embed_backlog_index` / `drop_embed_backlog_index` (partial index on `embedding IS NULL`).
- `orchestrator.py`: backlog index created before embed workers spawn, dropped in `finally` before HNSW creation.

## Acceptance criteria

- [x] New lock test: batch fetched on conn1 (uncommitted) is invisible to conn2's fetch — SKIP LOCKED verified to actually partition
- [x] Backlog index create/drop idempotency + existence checks
- [x] `uv run just check` — exit 0
- [x] Changes confined to allowed files; one commit per batch, no rollback in `_fetch_batch`

## Provenance

Implementer: codex-cli 0.143.0, `gpt-5.5` @ `xhigh`, cheap-coder workflow. Architecture, spec, review: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)