### PR TITLE
fix(parsing): decode RFC 2047 headers and MIME charsets; stream chunk parsing

### DIFF
--- a/src/maildb/ingest/parse.py
+++ b/src/maildb/ingest/parse.py
@@ -157,12 +157,11 @@ def _process_single_chunk(
     source_account: str,
 ) -> None:
     """Process a single chunk file: parse, extract attachments, insert into DB."""
-    messages = list(parse_mbox(chunk_path))
     email_rows: list[dict] = []
     attachment_meta: list[dict] = []  # {email_id, sha256, filename}
     unique_hashes: dict[str, dict] = {}  # sha256 -> attachment row data
 
-    for msg in messages:
+    for msg in parse_mbox(chunk_path):
         email_id = uuid4()
 
         email_rows.append(
@@ -210,6 +209,7 @@ def _process_single_chunk(
                     "filename": att["filename"],
                 }
             )
+        msg.pop("_attachments_with_data", None)
 
     # Insert rows individually so one bad row doesn't kill the chunk.
     # Use savepoints to isolate failures — rollback to the savepoint keeps
@@ -265,7 +265,7 @@ def _process_single_chunk(
     complete_task(
         pool,
         task_id,
-        messages_total=len(messages),
+        messages_total=len(email_rows),
         messages_inserted=inserted,
         messages_skipped=skipped + errored,
         attachments_extracted=len(unique_hashes),

--- a/src/maildb/parsing.py
+++ b/src/maildb/parsing.py
@@ -1,6 +1,7 @@
 # src/maildb/parsing.py
 from __future__ import annotations
 
+import email.header
 import email.utils
 import mailbox
 import re
@@ -67,6 +68,10 @@ def _safe_header(msg: mailbox.mboxMessage, name: str) -> str | None:
     except Exception:
         logger.warning("header_decode_failed", header=name)
         return None
+    try:  # noqa: SIM105
+        result = str(email.header.make_header(email.header.decode_header(result)))
+    except Exception:  # noqa: S110
+        pass  # keep the raw string — malformed encoded-words must never lose the header
     return result.replace("\x00", "")
 
 
@@ -88,6 +93,14 @@ def _derive_thread_id(message_id: str, references: list[str], in_reply_to: str |
     return message_id
 
 
+def _decode_payload(payload: bytes, part: mailbox.mboxMessage | Any) -> str:
+    charset = part.get_content_charset() or "utf-8"
+    try:
+        return payload.decode(charset, errors="replace")
+    except LookupError:
+        return payload.decode("utf-8", errors="replace")
+
+
 def _extract_body(msg: mailbox.mboxMessage) -> tuple[str | None, str | None]:
     text_body: str | None = None
     html_body: str | None = None
@@ -101,16 +114,16 @@ def _extract_body(msg: mailbox.mboxMessage) -> tuple[str | None, str | None]:
             if content_type == "text/plain" and text_body is None:
                 payload = part.get_payload(decode=True)
                 if isinstance(payload, bytes):
-                    text_body = payload.decode("utf-8", errors="replace")
+                    text_body = _decode_payload(payload, part)
             elif content_type == "text/html" and html_body is None:
                 payload = part.get_payload(decode=True)
                 if isinstance(payload, bytes):
-                    html_body = payload.decode("utf-8", errors="replace")
+                    html_body = _decode_payload(payload, part)
     else:
         content_type = msg.get_content_type()
         payload = msg.get_payload(decode=True)
         if isinstance(payload, bytes):
-            decoded = payload.decode("utf-8", errors="replace")
+            decoded = _decode_payload(payload, msg)
             if content_type == "text/html":
                 html_body = decoded
             else:

--- a/tests/integration/test_parse_worker.py
+++ b/tests/integration/test_parse_worker.py
@@ -31,6 +31,7 @@ def _insert_import(pool, account: str = "test@example.com"):
 
 def test_process_chunk_inserts_emails(test_pool, test_settings, tmp_path):
     import_id = _insert_import(test_pool)
+    attachment_dir = tmp_path / "attachments"
     create_task(
         test_pool,
         phase="parse",
@@ -39,13 +40,20 @@ def test_process_chunk_inserts_emails(test_pool, test_settings, tmp_path):
     )
     process_chunk(
         database_url=test_settings.database_url,
-        attachment_dir=tmp_path / "attachments",
+        attachment_dir=attachment_dir,
         import_id=import_id,
     )
     with test_pool.connection() as conn:
         cur = conn.execute("SELECT count(*) FROM emails")
         count = cur.fetchone()[0]
-    assert count > 0
+        cur = conn.execute("SELECT storage_path FROM attachments")
+        attachment_paths = [row[0] for row in cur.fetchall()]
+        cur = conn.execute("SELECT count(*) FROM email_attachments")
+        email_attachment_count = cur.fetchone()[0]
+    assert count == 10
+    assert attachment_paths
+    assert all((attachment_dir / path).exists() for path in attachment_paths)
+    assert email_attachment_count == len(attachment_paths)
     status = get_phase_status(test_pool, "parse")
     assert status["completed"] == 1
 

--- a/tests/unit/test_parsing.py
+++ b/tests/unit/test_parsing.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import email.header
 import mailbox as mb
+from email.message import Message
+from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
 
@@ -182,6 +184,78 @@ def test_no_gmail_labels_returns_empty() -> None:
     messages = list(parse_mbox(FIXTURES / "sample.mbox"))
     msg = messages[0]  # msg001 — no Gmail labels
     assert msg["labels"] == []
+
+
+def test_parse_message_decodes_rfc2047_subject_and_from() -> None:
+    msg = MIMEText("body")
+    msg["Message-ID"] = "<encoded-word-test@example.com>"
+    msg["From"] = "=?UTF-8?Q?Gr=C3=BC=C3=9Fe?= <x@y.com>"
+    msg["To"] = "to@example.com"
+    msg["Subject"] = "=?UTF-8?B?R3LDvMOfZQ==?="
+    msg["Date"] = "Mon, 10 Mar 2025 10:00:00 +0000"
+
+    result = parse_message(mb.mboxMessage(msg))
+
+    assert result is not None
+    assert result["subject"] == "Grüße"
+    assert result["sender_name"] == "Grüße"
+
+
+def test_parse_message_keeps_malformed_encoded_word_as_string() -> None:
+    msg = MIMEText("body")
+    msg["Message-ID"] = "<malformed-encoded-word-test@example.com>"
+    msg["From"] = "test@example.com"
+    msg["To"] = "to@example.com"
+    msg["Subject"] = "=?bogus-charset?B?????="
+    msg["Date"] = "Mon, 10 Mar 2025 10:00:00 +0000"
+
+    result = parse_message(mb.mboxMessage(msg))
+
+    assert result is not None
+    assert isinstance(result["subject"], str)
+
+
+def test_parse_message_decodes_non_multipart_body_charset() -> None:
+    msg = MIMEText("café", "plain", "iso-8859-1")
+    msg["Message-ID"] = "<latin1-body-test@example.com>"
+    msg["From"] = "test@example.com"
+    msg["To"] = "to@example.com"
+    msg["Date"] = "Mon, 10 Mar 2025 10:00:00 +0000"
+
+    result = parse_message(mb.mboxMessage(msg))
+
+    assert result is not None
+    assert result["body_text"] == "café"
+
+
+def test_parse_message_decodes_multipart_body_charset() -> None:
+    msg = MIMEMultipart()
+    msg["Message-ID"] = "<multipart-latin1-body-test@example.com>"
+    msg["From"] = "test@example.com"
+    msg["To"] = "to@example.com"
+    msg["Date"] = "Mon, 10 Mar 2025 10:00:00 +0000"
+    msg.attach(MIMEText("café", "plain", "iso-8859-1"))
+
+    result = parse_message(mb.mboxMessage(msg))
+
+    assert result is not None
+    assert result["body_text"] == "café"
+
+
+def test_parse_message_bogus_charset_falls_back_to_utf8() -> None:
+    msg = Message()
+    msg["Message-ID"] = "<bogus-charset-body-test@example.com>"
+    msg["From"] = "test@example.com"
+    msg["To"] = "to@example.com"
+    msg["Date"] = "Mon, 10 Mar 2025 10:00:00 +0000"
+    msg["Content-Type"] = "text/plain; charset=not-a-real-charset"
+    msg["Content-Transfer-Encoding"] = "8bit"
+    msg.set_payload("café".encode())
+
+    result = parse_message(mb.mboxMessage(msg))
+
+    assert result is not None
+    assert result["body_text"] == "café"
 
 
 def _make_msg_with_header(name: str, value: object) -> mb.mboxMessage:


### PR DESCRIPTION
## Objective

Three deep-review findings: RFC 2047 headers stored undecoded (HIGH — poisons search/embeddings for non-ASCII mail); body decodes ignore the MIME charset (MEDIUM — permanent mojibake at ingest); parse workers hold a whole chunk's decoded attachment bytes in memory (LOW).

## Change

- `parsing.py`: `_safe_header` decodes encoded words (`email.header.make_header(decode_header(...))`) before the NUL strip, falling back to the raw string on malformed input; new `_decode_payload` helper honors `get_content_charset()` (LookupError → utf-8) at all three decode sites.
- `parse.py`: `_process_single_chunk` iterates `parse_mbox` lazily and pops `_attachments_with_data` after each message's attachments hit disk; `messages_total` now derives from `email_rows` (same value).

## Acceptance criteria

- [x] New unit tests: encoded-word Subject/From round-trip; malformed encoded-word keeps raw header; iso-8859-1 non-multipart + multipart bodies decode to "café"; bogus charset falls back without raising
- [x] `uv run just check` — exit 0
- [x] Changes confined to allowed files

## Provenance

Implementer: codex-cli 0.143.0, `gpt-5.5` @ `xhigh`, cheap-coder workflow. Architecture, spec, review: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)