### PR TITLE
fix(attachments): retry livelock, stuck-kill cascade, per-run counts, selector-aware limit/sample

### DIFF
--- a/src/maildb/cli.py
+++ b/src/maildb/cli.py
@@ -497,19 +497,25 @@ def process_run(
             "AND attachment_id IN (SELECT id FROM attachments WHERE size <= %(max_size)s)"
         )
         selector_params["max_size"] = max_size
+    eligible_states = "('pending','failed')" if retry_failed else "('pending')"
+    eligible_selector_sql = " ".join(selector_sql_parts)
     if sample is not None:
-        selector_sql_parts.append(
-            "AND attachment_id IN ("
+        sample_selector_sql = (
+            "AND attachment_id IN ("  # noqa: S608
             "SELECT attachment_id FROM attachment_contents "
+            f"WHERE status IN {eligible_states} {eligible_selector_sql} "
             "ORDER BY random() LIMIT %(sample)s)"
         )
+        selector_sql_parts.append(sample_selector_sql)
         selector_params["sample"] = sample
     elif limit is not None:
-        selector_sql_parts.append(
-            "AND attachment_id IN ("
+        limit_selector_sql = (
+            "AND attachment_id IN ("  # noqa: S608
             "SELECT attachment_id FROM attachment_contents "
+            f"WHERE status IN {eligible_states} {eligible_selector_sql} "
             "ORDER BY attachment_id LIMIT %(limit)s)"
         )
+        selector_sql_parts.append(limit_selector_sql)
         selector_params["limit"] = limit
 
     selector_sql = " ".join(selector_sql_parts)

--- a/src/maildb/ingest/process_attachments.py
+++ b/src/maildb/ingest/process_attachments.py
@@ -258,6 +258,7 @@ def _claim_row(
     selector_sql: str = "",
     selector_params: dict[str, Any] | None = None,
     claimed_by: str | None = None,
+    exclude_ids: list[int] | None = None,
 ) -> int | None:
     """Atomically move one row to 'extracting' and return its attachment_id.
 
@@ -267,11 +268,15 @@ def _claim_row(
     in-flight rows as hard-timeout (see issue #59).
     """
     states = "('pending','failed')" if retry_failed else "('pending')"
+    exclude_sql = ""
+    if exclude_ids:
+        exclude_sql = "AND attachment_id != ALL(%(_exclude_ids)s)"
     sql = f"""
         WITH claimed AS (
             SELECT attachment_id FROM attachment_contents
              WHERE status IN {states}
                {selector_sql}
+               {exclude_sql}
              ORDER BY attachment_id
              LIMIT 1
              FOR UPDATE SKIP LOCKED
@@ -284,7 +289,9 @@ def _claim_row(
          WHERE attachment_id IN (SELECT attachment_id FROM claimed)
         RETURNING attachment_id
     """
-    params = {"claimed_by": claimed_by, **(selector_params or {})}
+    params: dict[str, Any] = {"claimed_by": claimed_by, **(selector_params or {})}
+    if exclude_ids:
+        params["_exclude_ids"] = list(exclude_ids)
     with pool.connection() as conn:
         cur = conn.execute(sql, params)
         row = cur.fetchone()
@@ -408,6 +415,9 @@ def _claim_and_process_loop(
     claimed_by: str | None = None,
 ) -> None:
     """Claim rows one at a time via SKIP LOCKED and process until none remain."""
+    # Per worker session only: with multiple workers, a failed row can be tried
+    # once by each subprocess, which bounds retries without global coordination.
+    attempted_failed: list[int] = []
     while True:
         attachment_id = _claim_row(
             pool,
@@ -415,6 +425,7 @@ def _claim_and_process_loop(
             selector_sql=selector_sql,
             selector_params=selector_params,
             claimed_by=claimed_by,
+            exclude_ids=attempted_failed,
         )
         if attachment_id is None:
             return
@@ -427,6 +438,14 @@ def _claim_and_process_loop(
             )
         except Exception as exc:
             _set_status(pool, attachment_id, status="failed", reason=str(exc))
+        with pool.connection() as conn:
+            cur = conn.execute(
+                "SELECT status FROM attachment_contents WHERE attachment_id = %s",
+                (attachment_id,),
+            )
+            row = cur.fetchone()
+        if row is not None and row[0] == "failed":
+            attempted_failed.append(attachment_id)
 
 
 def _subprocess_worker(
@@ -491,8 +510,17 @@ def run(
     ``extract_timeout_s`` caps wall-clock time per attachment inside
     extract_markdown; 0 disables the cap. Timed-out rows are marked ``failed``
     with a reason prefixed ``"timed out after "`` so they can be queried and
-    retried as a distinct group.
+    retried as a distinct group. Returned counts are scoped to rows touched
+    during this run.
     """
+    with pool.connection() as conn:
+        cur = conn.execute("SELECT now()")
+        row = cur.fetchone()
+        if row is None:
+            msg = "database did not return run start time"
+            raise RuntimeError(msg)
+        run_start = row[0]
+
     ensure_pending_rows(pool)
     _reclaim_stale(pool)
 
@@ -546,7 +574,14 @@ def run(
                 f.result()
 
     with pool.connection() as conn:
-        cur = conn.execute("SELECT status, count(*) FROM attachment_contents GROUP BY status")
+        cur = conn.execute(
+            """
+            SELECT status, count(*) FROM attachment_contents
+             WHERE extracted_at >= %(run_start)s
+             GROUP BY status
+            """,
+            {"run_start": run_start},
+        )
         for status, n in cur.fetchall():
             if status in counts:
                 counts[status] = n
@@ -836,10 +871,23 @@ def _run_supervised_single_worker(
                     status="failed",
                     reason=f"hard-timeout: killed after {extract_timeout_s}s",
                 )
+            reverted = _revert_in_flight_to_pending(pool, claimed_by=supervisor_id)
+            logger.info(
+                "stuck_worker_in_flight_reverted",
+                supervisor_id=supervisor_id,
+                reverted_to_pending=reverted,
+            )
             killed = True
             break
 
         if not killed:
             worker.join()
+            reverted = _revert_in_flight_to_pending(pool, claimed_by=supervisor_id)
+            if reverted:
+                logger.info(
+                    "worker_exit_in_flight_reverted",
+                    supervisor_id=supervisor_id,
+                    reverted_to_pending=reverted,
+                )
             # Worker exited on its own — either work is done or it hit an unrecoverable
             # error. Outer loop re-checks remaining; exits when 0.

--- a/tests/integration/test_process_attachments.py
+++ b/tests/integration/test_process_attachments.py
@@ -4,8 +4,10 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typer.testing import CliRunner
 
 import maildb.ingest.process_attachments as process_attachments_module
+from maildb.cli import app
 from maildb.ingest.process_attachments import (
     _reclaim_stale,
     ensure_pending_rows,
@@ -17,6 +19,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 pytestmark = pytest.mark.integration
+runner = CliRunner()
 
 
 def _insert_attachment(pool, sha256: str, ct: str, filename: str, size: int = 10) -> int:
@@ -190,3 +193,174 @@ def test_watchdog_reclaims_stale_extracting_row(test_pool, tmp_path):
             (att_id,),
         )
         assert cur.fetchone()[0] == "pending"
+
+
+def test_claim_row_excludes_ids(test_pool):
+    first_id = _insert_attachment(test_pool, "ex1", "text/plain", "first.txt")
+    second_id = _insert_attachment(test_pool, "ex2", "text/plain", "second.txt")
+    ensure_pending_rows(test_pool)
+
+    claimed = process_attachments_module._claim_row(
+        test_pool,
+        retry_failed=False,
+        exclude_ids=[first_id],
+    )
+    assert claimed == second_id
+
+    claimed = process_attachments_module._claim_row(
+        test_pool,
+        retry_failed=False,
+        exclude_ids=[first_id, second_id],
+    )
+    assert claimed is None
+
+
+def test_claim_loop_does_not_reclaim_failed_row(test_pool, tmp_path: Path):
+    att_id = _insert_attachment(test_pool, "rf1", "text/plain", "missing.txt")
+    ensure_pending_rows(test_pool)
+
+    class ReclaimedTwiceError(BaseException):
+        pass
+
+    attempts: list[int] = []
+    original_process_one = process_attachments_module.process_one
+
+    def counting_process_one(*args, **kwargs):  # type: ignore[no-untyped-def]
+        attempts.append(args[1])
+        if len(attempts) > 1:
+            raise ReclaimedTwiceError
+        return original_process_one(*args, **kwargs)
+
+    with patch.object(process_attachments_module, "process_one", side_effect=counting_process_one):
+        process_attachments_module._claim_and_process_loop(
+            test_pool,
+            attachment_dir=tmp_path,
+            retry_failed=True,
+            selector_sql="",
+            selector_params={},
+        )
+
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT status FROM attachment_contents WHERE attachment_id = %s",
+            (att_id,),
+        )
+        status = cur.fetchone()[0]
+
+    assert attempts == [att_id]
+    assert status == "failed"
+
+
+def test_supervisor_stuck_kill_reverts_in_flight(test_pool, tmp_path: Path):
+    fake_ctx = MagicMock()
+    worker = MagicMock()
+    worker.is_alive.return_value = True
+    worker.pid = 12345
+    fake_ctx.Process.return_value = worker
+
+    with (
+        patch.object(process_attachments_module, "_count_selected", side_effect=[3, 0]),
+        patch.object(process_attachments_module, "_find_stuck_extracting", return_value=[42]),
+        patch.object(process_attachments_module, "_mp_context", return_value=fake_ctx),
+        patch.object(process_attachments_module, "_set_status") as set_status,
+        patch.object(process_attachments_module, "_killpg_quietly"),
+        patch.object(process_attachments_module, "_revert_in_flight_to_pending") as revert,
+        patch.object(process_attachments_module, "time") as time_mod,
+    ):
+        time_mod.sleep = MagicMock()
+        revert.return_value = 2
+        process_attachments_module._run_supervised_single_worker(
+            test_pool,
+            attachment_dir=tmp_path,
+            retry_failed=True,
+            selector_sql="",
+            selector_params={},
+            database_url="postgresql://x/y",
+            extract_timeout_s=300,
+        )
+
+    set_status.assert_called_once()
+    assert set_status.call_args.args[1] == 42
+    revert.assert_called_once()
+    assert revert.call_args.kwargs["claimed_by"].startswith("sup-")
+
+
+def test_supervisor_worker_exit_reverts_in_flight(test_pool, tmp_path: Path):
+    fake_ctx = MagicMock()
+    worker = MagicMock()
+    worker.is_alive.return_value = False
+    fake_ctx.Process.return_value = worker
+
+    with (
+        patch.object(process_attachments_module, "_count_selected", side_effect=[3, 0]),
+        patch.object(process_attachments_module, "_mp_context", return_value=fake_ctx),
+        patch.object(process_attachments_module, "_revert_in_flight_to_pending") as revert,
+    ):
+        revert.return_value = 1
+        process_attachments_module._run_supervised_single_worker(
+            test_pool,
+            attachment_dir=tmp_path,
+            retry_failed=True,
+            selector_sql="",
+            selector_params={},
+            database_url="postgresql://x/y",
+            extract_timeout_s=300,
+        )
+
+    worker.join.assert_called()
+    revert.assert_called_once()
+    assert revert.call_args.kwargs["claimed_by"].startswith("sup-")
+
+
+def test_run_reports_per_run_counts(test_pool, tmp_path: Path):
+    previous_ids = [
+        _insert_attachment(test_pool, f"old{i}", "text/plain", f"old{i}.txt") for i in range(5)
+    ]
+    new_id = _insert_attachment(test_pool, "new1", "audio/mpeg", "voicemail.mp3")
+    ensure_pending_rows(test_pool)
+
+    with test_pool.connection() as conn:
+        conn.execute(
+            "UPDATE attachment_contents "
+            "SET status = 'extracted', extracted_at = now() - interval '1 day' "
+            "WHERE attachment_id = ANY(%s)",
+            (previous_ids,),
+        )
+        conn.commit()
+
+    counts = run(test_pool, attachment_dir=tmp_path, workers=1, retry_failed=False)
+
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT status FROM attachment_contents WHERE attachment_id = %s",
+            (new_id,),
+        )
+        assert cur.fetchone()[0] == "skipped"
+
+    assert counts == {"extracted": 0, "failed": 0, "skipped": 1}
+
+
+def test_limit_selector_respects_eligibility(test_pool):
+    ids = [
+        _insert_attachment(test_pool, "lim1", "text/plain", "one.txt"),
+        _insert_attachment(test_pool, "lim2", "text/plain", "two.txt"),
+        _insert_attachment(test_pool, "lim3", "text/plain", "three.txt"),
+    ]
+    ensure_pending_rows(test_pool)
+    with test_pool.connection() as conn:
+        conn.execute(
+            "UPDATE attachment_contents "
+            "SET status = 'extracted', extracted_at = now() - interval '1 day' "
+            "WHERE attachment_id = ANY(%s)",
+            (ids[:2],),
+        )
+        conn.commit()
+
+    with (
+        patch("maildb.cli._build_process_pool", return_value=test_pool),
+        patch("maildb.cli._close_pool", return_value=None),
+    ):
+        result = runner.invoke(app, ["process_attachments", "run", "--dry-run", "--limit", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert "Would process 1 attachment(s)." in result.output


### PR DESCRIPTION
## Objective

Four deep-review findings in the attachment pipeline (HIGH: retry livelock on deterministic failures; MEDIUM: cascading false hard-timeouts after stuck-kill or abnormal worker death; MEDIUM: --limit/--sample ignore eligibility; LOW: run() reports lifetime counts).

## Change

- `process_attachments.py`: `_claim_row` gains parameterized `exclude_ids`; `_claim_and_process_loop` tracks per-session failed attempts (bounded per-worker, no global coordination — commented); both supervisor exit paths call `_revert_in_flight_to_pending` (stuck rows are already failed, so only innocent in-flight rows revert); `run()` scopes final counts to `extracted_at >= run_start` (DB clock).
- `cli.py`: `--limit`/`--sample` subqueries now include `status IN <eligible states>` (derived from `--retry-failed` exactly as `_claim_row` does) plus all previously built selector parts.

## Acceptance criteria

- [x] New tests: exclude-ids claim behavior; deterministic-failure loop terminates after exactly one attempt; both supervisor revert paths (mock call assertions); per-run counts ignore prior runs' rows; --limit selects the eligible row on a partially drained table
- [x] `uv run just check` — exit 0
- [x] Changes confined to allowed files

## Provenance

Implementer: codex-cli 0.143.0, `gpt-5.5` @ `xhigh`, cheap-coder workflow. Architecture, spec, review: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)