### PR TITLE
fix(dsl): suppress default ORDER BY for aggregate-only selects; reject empty and/or

### DIFF
--- a/src/maildb/dsl.py
+++ b/src/maildb/dsl.py
@@ -197,13 +197,15 @@ def parse_query(spec: dict[str, Any]) -> tuple[str, dict[str, Any]]:
 
     select_aliases: set[str] = set()
     alias_exprs: dict[str, str] = {}
-    select_exprs = _resolve_select(
-        spec.get("select"), allowed, has_group_by, select_aliases, alias_exprs
-    )
+    raw_select = spec.get("select")
+    has_aggregates = any(any(agg in item for agg in _AGGREGATES) for item in raw_select or [])
+    select_exprs = _resolve_select(raw_select, allowed, has_group_by, select_aliases, alias_exprs)
     where_sql = _resolve_where(spec.get("where"), allowed, acc)
     group_sql = _resolve_group_by(spec.get("group_by"), allowed, select_aliases, alias_exprs)
     having_sql = _resolve_having(spec.get("having"), allowed, select_aliases, acc, alias_exprs)
-    order_sql = _resolve_order_by(spec.get("order_by"), allowed, select_aliases, has_group_by)
+    order_sql = _resolve_order_by(
+        spec.get("order_by"), allowed, select_aliases, has_group_by, has_aggregates
+    )
     limit_sql = _resolve_limit(spec.get("limit", 50), spec.get("offset", 0))
 
     table = "source" if source != "emails" else "emails"
@@ -342,9 +344,10 @@ def _resolve_order_by(
     allowed: set[str],
     select_aliases: set[str],
     has_group_by: bool,
+    has_aggregates: bool,
 ) -> str:
     if not order_by:
-        return "" if has_group_by else " ORDER BY date DESC"
+        return "" if (has_group_by or has_aggregates) else " ORDER BY date DESC"
     parts: list[str] = []
     for item in order_by:
         col = item["field"]
@@ -490,12 +493,10 @@ def _build_where(
     """
     # Boolean combinators
     if "and" in where:
-        parts = [_build_where(sub, allowed, acc) for sub in where["and"]]
-        return f"({' AND '.join(parts)})"
+        return _build_where_combinator("and", where["and"], "AND", allowed, acc)
 
     if "or" in where:
-        parts = [_build_where(sub, allowed, acc) for sub in where["or"]]
-        return f"({' OR '.join(parts)})"
+        return _build_where_combinator("or", where["or"], "OR", allowed, acc)
 
     if "not" in where:
         inner = _build_where(where["not"], allowed, acc)
@@ -544,3 +545,17 @@ def _build_where(
     sql_op = _OP_SQL[op]
     pname = acc.add(value)
     return f"{field} {sql_op} %({pname})s"
+
+
+def _build_where_combinator(
+    key: str,
+    conditions: list[dict[str, Any]],
+    joiner: str,
+    allowed: set[str],
+    acc: _ParamAccumulator,
+) -> str:
+    if not conditions:
+        msg = f"'{key}' requires at least one condition"
+        raise ValueError(msg)
+    parts = [_build_where(sub, allowed, acc) for sub in conditions]
+    return f"({f' {joiner} '.join(parts)})"

--- a/tests/integration/test_dsl.py
+++ b/tests/integration/test_dsl.py
@@ -196,6 +196,12 @@ def test_aggregation_count_by_domain(test_pool, seed_dsl) -> None:  # type: igno
     assert by_domain["corp.com"] == 1
 
 
+def test_aggregation_count_all_executes(test_pool, seed_dsl) -> None:  # type: ignore[no-untyped-def]
+    rows = _execute_dsl(test_pool, {"select": [{"count": "*", "as": "total"}]})
+    assert len(rows) == 1
+    assert rows[0]["total"] == 3
+
+
 def test_date_range_filter(test_pool, seed_dsl) -> None:  # type: ignore[no-untyped-def]
     rows = _execute_dsl(
         test_pool,

--- a/tests/unit/test_dsl.py
+++ b/tests/unit/test_dsl.py
@@ -201,6 +201,14 @@ class TestBooleanCombinators:
         assert "OR" in sql
         assert len(params) == 3
 
+    def test_empty_and_raises_clear_error(self) -> None:
+        with pytest.raises(ValueError, match="'and'"):
+            parse_query({"where": {"and": []}})
+
+    def test_empty_or_raises_clear_error(self) -> None:
+        with pytest.raises(ValueError, match="'or'"):
+            parse_query({"where": {"or": []}})
+
 
 # ---------------------------------------------------------------------------
 # Select expressions
@@ -224,6 +232,11 @@ class TestSelect:
             }
         )
         assert "count(*) AS total" in sql
+
+    def test_count_star_without_group_by_has_no_default_order(self) -> None:
+        sql, _ = parse_query({"select": [{"count": "*", "as": "total"}]})
+        assert "SELECT count(*) AS total FROM emails" in sql
+        assert "ORDER BY" not in sql
 
     def test_count_distinct(self) -> None:
         sql, _ = parse_query(
@@ -319,6 +332,10 @@ class TestGroupByHavingOrderBy:
 
     def test_default_order_is_date_desc(self) -> None:
         sql, _ = parse_query({})
+        assert "ORDER BY date DESC" in sql
+
+    def test_non_aggregate_select_without_order_by_defaults_to_date_desc(self) -> None:
+        sql, _ = parse_query({"select": [{"field": "subject"}]})
         assert "ORDER BY date DESC" in sql
 
 


### PR DESCRIPTION
## Objective

Two deep-review DSL findings (MEDIUM: aggregate-only queries always fail with GroupingError; LOW: empty and/or lists compile to invalid SQL `()`).

## Change

- `parse_query` computes `has_aggregates` from the select items (same key-check idiom `_build_select` already uses) and `_resolve_order_by` suppresses the default `ORDER BY date DESC` when true, exactly mirroring the `has_group_by` suppression. Explicit `order_by` unchanged.
- `and`/`or` combinators route through a shared `_build_where_combinator` that raises `ValueError("'and' requires at least one condition")` on empty lists.

## Acceptance criteria

- [x] Aggregate-only spec compiles without ORDER BY and **executes** against Postgres (integration test: count == seeded 3)
- [x] Non-aggregate default ordering pinned unchanged; explicit order_by with aggregates unchanged
- [x] Empty and/or raise ValueError
- [x] `uv run just check` — exit 0

## Provenance

Implementer: codex-cli 0.143.0, `gpt-5.5` @ `xhigh`, cheap-coder workflow. Architecture, spec, review: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)