### PR TITLE
perf(query): HNSW-friendly vector searches, GIN recipient filters, trigram indexes, stable pagination

### DIFF
--- a/src/maildb/ingest/index.py
+++ b/src/maildb/ingest/index.py
@@ -19,6 +19,8 @@ DROP_INDEXES = [
     "idx_email_has_attachment",
     "idx_email_labels",
     "idx_email_recipients",
+    "idx_email_body_trgm",
+    "idx_email_subject_trgm",
     "idx_email_embedding",
     "idx_email_thread_sender_date",
     "idx_email_attachments_email_id",

--- a/src/maildb/maildb.py
+++ b/src/maildb/maildb.py
@@ -46,6 +46,22 @@ SELECT_COLS = """
 """
 
 
+def _order_clause(order: str, *, qualifier: str = "") -> str:
+    """Return the deterministic SQL ORDER BY clause for a validated public order."""
+    if order not in VALID_ORDERS:
+        msg = f"Invalid order '{order}'. Must be one of: {', '.join(sorted(VALID_ORDERS))}"
+        raise ValueError(msg)
+
+    prefix = f"{qualifier}." if qualifier else ""
+    if order == "date DESC":
+        return f"{prefix}date DESC NULLS LAST, {prefix}id"
+    if order == "date ASC":
+        return f"{prefix}date ASC NULLS FIRST, {prefix}id"
+    if order == "sender_address DESC":
+        return f"{prefix}sender_address DESC, {prefix}id"
+    return f"{prefix}sender_address ASC, {prefix}id"
+
+
 def _query_dicts(
     pool: ConnectionPool,
     sql: str,
@@ -55,6 +71,27 @@ def _query_dicts(
     logger.debug("sql_execute", sql=sql, params=params)
     t0 = time.monotonic()
     with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, params)
+        rows = [dict(row) for row in cur.fetchall()]
+    elapsed_ms = round((time.monotonic() - t0) * 1000, 1)
+    logger.debug("sql_complete", rows=len(rows), elapsed_ms=elapsed_ms)
+    return rows
+
+
+def _query_dicts_with_hnsw_ef_search(
+    pool: ConnectionPool,
+    sql: str,
+    params: dict[str, Any],
+    *,
+    ef_search: str,
+) -> list[dict[str, Any]]:
+    """Execute a vector query after raising transaction-local HNSW search breadth."""
+    logger.debug("sql_execute", sql=sql, params=params, ef_search=ef_search)
+    t0 = time.monotonic()
+    with pool.connection() as conn, conn.transaction(), conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            "SELECT set_config('hnsw.ef_search', %(ef_search)s, true)", {"ef_search": ef_search}
+        )
         cur.execute(sql, params)
         rows = [dict(row) for row in cur.fetchall()]
     elapsed_ms = round((time.monotonic() - t0) * 1000, 1)
@@ -162,11 +199,11 @@ class MailDB:
             params["sender_domain"] = sender_domain
         if recipient is not None:
             conditions.append(
-                "(recipients->'to' @> %(recipient_json)s "
-                "OR recipients->'cc' @> %(recipient_json)s "
-                "OR recipients->'bcc' @> %(recipient_json)s)"
+                "(recipients @> jsonb_build_object('to', %(recipient_arr)s::jsonb) "
+                "OR recipients @> jsonb_build_object('cc', %(recipient_arr)s::jsonb) "
+                "OR recipients @> jsonb_build_object('bcc', %(recipient_arr)s::jsonb))"
             )
-            params["recipient_json"] = json.dumps([recipient])
+            params["recipient_arr"] = json.dumps([recipient])
         if after is not None:
             conditions.append("date >= %(after)s")
             params["after"] = after
@@ -247,9 +284,7 @@ class MailDB:
         account: str | None = None,
     ) -> tuple[list[Email], int]:
         """Structured query with dynamic WHERE clauses. Returns (emails, total_count)."""
-        if order not in VALID_ORDERS:
-            msg = f"Invalid order '{order}'. Must be one of: {', '.join(sorted(VALID_ORDERS))}"
-            raise ValueError(msg)
+        order_sql = _order_clause(order)
 
         conditions, params = self._build_filters(
             sender=sender,
@@ -268,7 +303,7 @@ class MailDB:
         )
 
         where = " AND ".join(conditions) if conditions else "TRUE"
-        query = f"SELECT {SELECT_COLS}, COUNT(*) OVER() AS _total FROM emails WHERE {where} ORDER BY {order} LIMIT %(limit)s OFFSET %(offset)s"
+        query = f"SELECT {SELECT_COLS}, COUNT(*) OVER() AS _total FROM emails WHERE {where} ORDER BY {order_sql} LIMIT %(limit)s OFFSET %(offset)s"
         params["limit"] = limit
         params["offset"] = offset
 
@@ -298,7 +333,11 @@ class MailDB:
         direct_only: bool = False,
         account: str | None = None,
     ) -> tuple[list[SearchResult], int]:
-        """Semantic search with optional structured filters. Returns (results, total_count)."""
+        """Semantic search with optional structured filters.
+
+        Returns total as an approximate count of results seen so far
+        (offset + rows returned), not an exact match count.
+        """
         query_embedding = self._embedding_client.embed(query)
 
         conditions, params = self._build_filters(
@@ -322,8 +361,7 @@ class MailDB:
         where = " AND ".join(conditions)
         sql = f"""
             SELECT {SELECT_COLS},
-                   1 - (embedding <=> %(query_embedding)s::vector) AS similarity,
-                   COUNT(*) OVER() AS _total
+                   1 - (embedding <=> %(query_embedding)s::vector) AS similarity
             FROM emails
             WHERE {where}
             ORDER BY embedding <=> %(query_embedding)s::vector
@@ -332,10 +370,13 @@ class MailDB:
         params["limit"] = limit
         params["offset"] = offset
 
-        rows = _query_dicts(self._pool, sql, params)
-        total = rows[0]["_total"] if rows else 0
-        for row in rows:
-            row.pop("_total", None)
+        rows = _query_dicts_with_hnsw_ef_search(
+            self._pool,
+            sql,
+            params,
+            ef_search=str(max(40, limit + offset)),
+        )
+        total = offset + len(rows)
         return [
             SearchResult(
                 email=Email.from_row(row),
@@ -631,7 +672,7 @@ class MailDB:
             raise ValueError(msg)
 
         where = " AND ".join(conditions)
-        sql = f"SELECT {SELECT_COLS} FROM emails WHERE {where} ORDER BY date DESC LIMIT 500"
+        sql = f"SELECT {SELECT_COLS} FROM emails WHERE {where} ORDER BY date DESC NULLS LAST, id LIMIT 500"
 
         rows = _query_dicts(self._pool, sql, params)
         if not rows:
@@ -697,7 +738,7 @@ class MailDB:
                 SELECT {SELECT_COLS} FROM emails
                 WHERE message_id IN ({placeholders})
                   AND embedding IS NOT NULL
-                ORDER BY date DESC
+                ORDER BY date DESC NULLS LAST, id
             """
             rows = _query_dicts(self._pool, sql, params)
         else:
@@ -705,7 +746,7 @@ class MailDB:
             sql = f"""
                 SELECT {SELECT_COLS} FROM emails
                 WHERE {where_sql} AND embedding IS NOT NULL
-                ORDER BY date DESC LIMIT 500
+                ORDER BY date DESC NULLS LAST, id LIMIT 500
             """
             rows = _query_dicts(self._pool, sql, params)
 
@@ -828,7 +869,7 @@ class MailDB:
                         AND reply.sender_address = ANY(%(user_emails)s)
                         AND reply.date > e.date
                   )
-                ORDER BY e.date DESC
+                ORDER BY e.date DESC NULLS LAST, e.id
                 LIMIT %(limit)s OFFSET %(offset)s
             """
         else:
@@ -851,13 +892,12 @@ class MailDB:
                 params["account"] = account
 
             if recipient:
-                recipient_json = json.dumps([recipient])
                 conditions.append(
-                    "(e.recipients->'to' @> %(recipient_json)s"
-                    " OR e.recipients->'cc' @> %(recipient_json)s"
-                    " OR e.recipients->'bcc' @> %(recipient_json)s)"
+                    "(e.recipients @> jsonb_build_object('to', %(recipient_arr)s::jsonb)"
+                    " OR e.recipients @> jsonb_build_object('cc', %(recipient_arr)s::jsonb)"
+                    " OR e.recipients @> jsonb_build_object('bcc', %(recipient_arr)s::jsonb))"
                 )
-                params["recipient_json"] = recipient_json
+                params["recipient_arr"] = json.dumps([recipient])
                 not_exists = """
                     AND NOT EXISTS (
                         SELECT 1 FROM emails reply
@@ -886,7 +926,7 @@ class MailDB:
                 FROM emails e
                 WHERE {where}
                   {not_exists}
-                ORDER BY e.date DESC
+                ORDER BY e.date DESC NULLS LAST, e.id
                 LIMIT %(limit)s OFFSET %(offset)s
             """
 
@@ -910,19 +950,17 @@ class MailDB:
         Returns emails where address is sender OR is in recipients (to/cc/bcc).
         Default chronological order, higher limit than find().
         """
-        if order not in VALID_ORDERS:
-            msg = f"Invalid order '{order}'. Must be one of: {', '.join(sorted(VALID_ORDERS))}"
-            raise ValueError(msg)
+        order_sql = _order_clause(order)
 
         conditions: list[str] = [
             "(sender_address = %(address)s "
-            "OR recipients->'to' @> %(address_json)s "
-            "OR recipients->'cc' @> %(address_json)s "
-            "OR recipients->'bcc' @> %(address_json)s)"
+            "OR recipients @> jsonb_build_object('to', %(address_arr)s::jsonb) "
+            "OR recipients @> jsonb_build_object('cc', %(address_arr)s::jsonb) "
+            "OR recipients @> jsonb_build_object('bcc', %(address_arr)s::jsonb))"
         ]
         params: dict[str, Any] = {
             "address": address,
-            "address_json": json.dumps([address]),
+            "address_arr": json.dumps([address]),
             "limit": limit,
             "offset": offset,
         }
@@ -935,7 +973,7 @@ class MailDB:
             params["before"] = before
 
         where = " AND ".join(conditions)
-        sql = f"SELECT {SELECT_COLS}, COUNT(*) OVER() AS _total FROM emails WHERE {where} ORDER BY {order} LIMIT %(limit)s OFFSET %(offset)s"
+        sql = f"SELECT {SELECT_COLS}, COUNT(*) OVER() AS _total FROM emails WHERE {where} ORDER BY {order_sql} LIMIT %(limit)s OFFSET %(offset)s"
 
         rows = _query_dicts(self._pool, sql, params)
         total = rows[0]["_total"] if rows else 0
@@ -996,7 +1034,7 @@ class MailDB:
         conditions.extend(rcpt_conditions)
         params.update(rcpt_params)
         where = " AND ".join(conditions)
-        sql = f"SELECT {SELECT_COLS}, COUNT(*) OVER() AS _total FROM emails WHERE {where} ORDER BY date DESC LIMIT %(limit)s OFFSET %(offset)s"
+        sql = f"SELECT {SELECT_COLS}, COUNT(*) OVER() AS _total FROM emails WHERE {where} ORDER BY date DESC NULLS LAST, id LIMIT %(limit)s OFFSET %(offset)s"
         rows = _query_dicts(self._pool, sql, params)
         total = rows[0]["_total"] if rows else 0
         for row in rows:
@@ -1022,7 +1060,11 @@ class MailDB:
         limit: int = 20,
         offset: int = 0,
     ) -> tuple[list[AttachmentSearchResult], int]:
-        """Semantic search over attachment chunk embeddings."""
+        """Semantic search over attachment chunk embeddings.
+
+        Returns total as an approximate count of results seen so far
+        (offset + rows returned), not an exact match count.
+        """
         query_embedding = self._embedding_client.embed(query)
 
         # Build email-level conditions directly with `e.` prefixes — safer than
@@ -1039,11 +1081,11 @@ class MailDB:
             params["sender_domain"] = sender_domain
         if recipient is not None:
             conditions.append(
-                "(e.recipients->'to' @> %(recipient_json)s "
-                "OR e.recipients->'cc' @> %(recipient_json)s "
-                "OR e.recipients->'bcc' @> %(recipient_json)s)"
+                "(e.recipients @> jsonb_build_object('to', %(recipient_arr)s::jsonb) "
+                "OR e.recipients @> jsonb_build_object('cc', %(recipient_arr)s::jsonb) "
+                "OR e.recipients @> jsonb_build_object('bcc', %(recipient_arr)s::jsonb))"
             )
-            params["recipient_json"] = json.dumps([recipient])
+            params["recipient_arr"] = json.dumps([recipient])
         if after is not None:
             conditions.append("e.date >= %(after)s")
             params["after"] = after
@@ -1108,8 +1150,7 @@ class MailDB:
                    (SELECT COALESCE(array_agg(e2.message_id), ARRAY[]::text[])
                       FROM email_attachments ea2
                       JOIN emails e2 ON e2.id = ea2.email_id
-                     WHERE ea2.attachment_id = ac.attachment_id) AS email_message_ids,
-                   COUNT(*) OVER() AS _total
+                     WHERE ea2.attachment_id = ac.attachment_id) AS email_message_ids
             FROM attachment_chunks ac
             JOIN attachments a ON a.id = ac.attachment_id
             JOIN attachment_contents co
@@ -1122,8 +1163,13 @@ class MailDB:
             LIMIT %(limit)s OFFSET %(offset)s
         """
 
-        rows = _query_dicts(self._pool, sql, params)
-        total = rows[0]["_total"] if rows else 0
+        rows = _query_dicts_with_hnsw_ef_search(
+            self._pool,
+            sql,
+            params,
+            ef_search=str(max(40, limit + offset)),
+        )
+        total = offset + len(rows)
         results = []
         for row in rows:
             chunk = AttachmentChunk(
@@ -1191,8 +1237,12 @@ class MailDB:
         limit: int = 20,
         offset: int = 0,
     ) -> tuple[list[UnifiedSearchResult], int]:
-        """Run both email and attachment searches, merge by similarity."""
-        over_fetch = max(2 * (limit + offset), limit + offset)
+        """Run both email and attachment searches, merge by similarity.
+
+        The returned total is a lower-bound approximation over the merged
+        over-fetched results, not an exact count across both corpora.
+        """
+        over_fetch = 2 * (limit + offset)
         email_hits, _ = self.search(
             query,
             sender=sender,

--- a/src/maildb/schema_indexes.sql
+++ b/src/maildb/schema_indexes.sql
@@ -6,6 +6,8 @@ CREATE INDEX IF NOT EXISTS idx_email_in_reply_to ON emails (in_reply_to);
 CREATE INDEX IF NOT EXISTS idx_email_has_attachment ON emails (has_attachment) WHERE has_attachment = TRUE;
 CREATE INDEX IF NOT EXISTS idx_email_labels ON emails USING GIN (labels);
 CREATE INDEX IF NOT EXISTS idx_email_recipients ON emails USING GIN (recipients);
+CREATE INDEX IF NOT EXISTS idx_email_body_trgm ON emails USING gin (body_text gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_email_subject_trgm ON emails USING gin (subject gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS idx_email_thread_sender_date ON emails (thread_id, sender_address, date);
 CREATE INDEX IF NOT EXISTS idx_email_attachments_email_id ON email_attachments (email_id);
 CREATE INDEX IF NOT EXISTS idx_email_attachments_attachment_id ON email_attachments (attachment_id);

--- a/src/maildb/schema_tables.sql
+++ b/src/maildb/schema_tables.sql
@@ -1,4 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 CREATE TABLE IF NOT EXISTS imports (
     id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/src/maildb/server.py
+++ b/src/maildb/server.py
@@ -298,6 +298,7 @@ def search(
       fields: list of field names to return. Default returns headers + body_length (no body_text).
 
     Returns {total, offset, limit, results: [{email: {headers + body_length}, similarity}, ...]}.
+    total is approximate for semantic search: offset + returned results, not an exact match count.
 
     Example: search("complaints about deployment", sender_domain="eng.acme.com", limit=5)
     """
@@ -771,6 +772,7 @@ def search_attachments(
     """Semantic search over attachment chunk embeddings.
 
     Returns {total, offset, limit, results: [{attachment_id, filename, chunk, emails, similarity}]}.
+    total is approximate for semantic search: offset + returned results, not an exact match count.
     """
     db = _get_db(ctx)
     results, total = db.search_attachments(
@@ -817,7 +819,8 @@ def search_all(
 
     Returns {total, offset, limit, results: [{source, similarity, ...}]} where each
     result carries source="email" with an email payload, or source="attachment"
-    with an attachment_result payload.
+    with an attachment_result payload. total is a lower-bound approximation over
+    over-fetched semantic results, not an exact match count.
     """
     db = _get_db(ctx)
     results, total = db.search_all(

--- a/tests/integration/test_index_phase.py
+++ b/tests/integration/test_index_phase.py
@@ -3,6 +3,7 @@ import pytest
 from maildb.ingest.index import (
     create_embed_backlog_index,
     drop_embed_backlog_index,
+    drop_non_unique_indexes,
     run_index_phase,
 )
 
@@ -19,6 +20,21 @@ def test_run_index_phase_creates_indexes(test_pool):
     assert "idx_email_sender_address" in indexes
     assert "idx_email_date" in indexes
     assert "idx_email_thread_sender_date" in indexes
+    assert "idx_email_body_trgm" in indexes
+    assert "idx_email_subject_trgm" in indexes
+
+
+def test_drop_non_unique_indexes_removes_trigram_indexes(test_pool):
+    run_index_phase(test_pool)
+    drop_non_unique_indexes(test_pool)
+
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "SELECT indexname FROM pg_indexes WHERE indexname IN "
+            "('idx_email_body_trgm', 'idx_email_subject_trgm')"
+        )
+        indexes = {row[0] for row in cur.fetchall()}
+    assert indexes == set()
 
 
 def test_embed_backlog_index_create_drop_idempotent(test_pool):

--- a/tests/integration/test_maildb.py
+++ b/tests/integration/test_maildb.py
@@ -5,7 +5,7 @@ import json
 import json as json_mod
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -162,6 +162,35 @@ def test_find_order_date_asc(test_pool, seed_emails) -> None:  # type: ignore[no
     assert results[0].date <= results[-1].date
 
 
+def test_find_date_desc_nulls_last_and_tiebreaks_by_id(test_pool) -> None:  # type: ignore[no-untyped-def]
+    same_date = datetime(2025, 1, 1, 10, 0, tzinfo=UTC)
+    rows = [
+        (UUID("00000000-0000-0000-0000-000000000002"), "sort-second@example.com", same_date),
+        (UUID("00000000-0000-0000-0000-000000000001"), "sort-first@example.com", same_date),
+        (UUID("00000000-0000-0000-0000-000000000000"), "sort-null@example.com", None),
+    ]
+    with test_pool.connection() as conn:
+        for email_id, message_id, sent_at in rows:
+            conn.execute(
+                """INSERT INTO emails (id, message_id, thread_id, sender_address, date)
+                   VALUES (%(id)s, %(mid)s, 'sort-thread', 'sender@example.com', %(date)s)""",
+                {"id": email_id, "mid": message_id, "date": sent_at},
+            )
+        conn.commit()
+
+    db = MailDB._from_pool(test_pool)
+    first_page, _ = db.find(limit=10)
+    second_page, _ = db.find(limit=10)
+
+    expected = [
+        "sort-first@example.com",
+        "sort-second@example.com",
+        "sort-null@example.com",
+    ]
+    assert [email.message_id for email in first_page] == expected
+    assert [email.message_id for email in second_page] == expected
+
+
 def test_find_offset(test_pool, seed_emails) -> None:  # type: ignore[no-untyped-def]
     db = MailDB._from_pool(test_pool)
     all_results, _ = db.find(limit=10)
@@ -310,6 +339,12 @@ def test_find_max_recipients(test_pool, seed_recipient_counts) -> None:  # type:
     assert "rcpt-2@example.com" not in message_ids
 
 
+def test_find_recipient_matches_cc_only(test_pool, seed_recipient_counts) -> None:  # type: ignore[no-untyped-def]
+    db = MailDB._from_pool(test_pool)
+    results, _ = db.find(recipient="dave@example.com")
+    assert [email.message_id for email in results] == ["rcpt-2@example.com"]
+
+
 def test_find_direct_only_conflicts_with_max_to(test_pool, seed_recipient_counts) -> None:  # type: ignore[no-untyped-def]
     db = MailDB._from_pool(test_pool)
     with pytest.raises(ValueError, match="direct_only"):
@@ -368,12 +403,52 @@ def test_search(test_pool, seed_emails) -> None:  # type: ignore[no-untyped-def]
     assert results[0].similarity > 0
 
 
+def test_search_total_counts_seen_results(test_pool, seed_emails) -> None:  # type: ignore[no-untyped-def]
+    mock_ec = MagicMock()
+    mock_ec.embed.return_value = [0.1] * 768
+    db = MailDB._from_pool(test_pool, embedding_client=mock_ec)
+    results, total = db.search("budget discussion", limit=1, offset=1)
+    assert len(results) == 1
+    assert total == 1 + len(results)
+
+
 def test_search_with_filters(test_pool, seed_emails) -> None:  # type: ignore[no-untyped-def]
     mock_ec = MagicMock()
     mock_ec.embed.return_value = [0.1] * 768
     db = MailDB._from_pool(test_pool, embedding_client=mock_ec)
     results, _ = db.search("budget", sender_domain="example.com")
     assert all(r.email.sender_domain == "example.com" for r in results)
+
+
+def test_search_filtered_result_rows_unchanged(test_pool, seed_emails) -> None:  # type: ignore[no-untyped-def]
+    mock_ec = MagicMock()
+    mock_ec.embed.return_value = [0.1] * 768
+    db = MailDB._from_pool(test_pool, embedding_client=mock_ec)
+    results, total = db.search("invoice", sender="billing@stripe.com")
+    assert [result.email.message_id for result in results] == ["find-test-3@stripe.com"]
+    assert total == len(results)
+
+
+def test_search_deep_offset_exercises_hnsw_ef_search(test_pool) -> None:  # type: ignore[no-untyped-def]
+    with test_pool.connection() as conn:
+        for i in range(45):
+            conn.execute(
+                """INSERT INTO emails (message_id, thread_id, sender_address, date, embedding)
+                   VALUES (%(mid)s, 'deep-search', 'sender@example.com', %(date)s, %(embedding)s)""",
+                {
+                    "mid": f"deep-search-{i}@example.com",
+                    "date": datetime(2025, 1, 1, 10, i, tzinfo=UTC),
+                    "embedding": [float(i + 1)] + [0.1] * 767,
+                },
+            )
+        conn.commit()
+
+    mock_ec = MagicMock()
+    mock_ec.embed.return_value = [1.0] + [0.1] * 767
+    db = MailDB._from_pool(test_pool, embedding_client=mock_ec)
+    results, total = db.search("deep page", limit=1, offset=41)
+    assert len(results) == 1
+    assert total == 42
 
 
 # Additional seed data for advanced queries

--- a/tests/integration/test_search_attachments.py
+++ b/tests/integration/test_search_attachments.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -83,6 +84,25 @@ def test_search_attachments_returns_matching_chunk(test_pool, test_settings):
     assert hit.similarity > 0
 
 
+def test_search_attachments_total_counts_seen_results(test_pool, test_settings):
+    for i in range(3):
+        _seed_attachment_chunk(
+            test_pool,
+            sha256=f"total{i}",
+            filename=f"total-{i}.pdf",
+            chunk_text=f"Total semantics chunk {i}",
+            embedding=[0.1] * 768,
+        )
+    db = MailDB._from_pool(test_pool, config=test_settings)
+    db._embedding_client = MagicMock()
+    db._embedding_client.embed.return_value = [0.1] * 768
+
+    results, total = db.search_attachments(query="total semantics", limit=1, offset=1)
+
+    assert len(results) == 1
+    assert total == 1 + len(results)
+
+
 def test_search_attachments_filters_by_content_type(test_pool, test_settings):
     _seed_attachment_chunk(
         test_pool,
@@ -103,6 +123,31 @@ def test_search_attachments_filters_by_content_type(test_pool, test_settings):
     db._embedding_client.embed.return_value = [0.1] * 768
     results, _ = db.search_attachments(query="content", content_type="application/pdf")
     assert all(r.content_type == "application/pdf" for r in results)
+
+
+def test_search_attachments_filters_by_cc_recipient(test_pool, test_settings):
+    att_id, _ = _seed_attachment_chunk(
+        test_pool,
+        sha256="rcptcc",
+        filename="cc.pdf",
+        chunk_text="Visible through cc recipient.",
+        email_ids=["<att-cc@ex.com>"],
+    )
+    with test_pool.connection() as conn:
+        conn.execute(
+            "UPDATE emails SET recipients = %s WHERE message_id = '<att-cc@ex.com>'",
+            (json.dumps({"to": [], "cc": ["cc-recipient@example.com"], "bcc": []}),),
+        )
+        conn.commit()
+
+    db = MailDB._from_pool(test_pool, config=test_settings)
+    db._embedding_client = MagicMock()
+    db._embedding_client.embed.return_value = [0.1] * 768
+    results, _ = db.search_attachments(
+        query="cc recipient",
+        recipient="cc-recipient@example.com",
+    )
+    assert any(result.attachment_id == att_id for result in results)
 
 
 def test_search_attachments_honors_email_level_account_filter(test_pool, test_settings):

--- a/tests/unit/test_maildb_sql.py
+++ b/tests/unit/test_maildb_sql.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from maildb import maildb as maildb_module
+from maildb.config import Settings
+from maildb.maildb import MailDB
+
+
+class QueryCapture:
+    def __init__(self) -> None:
+        self.sql: list[str] = []
+        self.params: list[dict[str, Any] | None] = []
+
+    def __call__(
+        self,
+        pool: object,
+        sql: str,
+        params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.sql.append(" ".join(sql.split()))
+        self.params.append(params)
+        return []
+
+
+class FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, dict[str, Any] | None]] = []
+
+    def __enter__(self) -> FakeCursor:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: dict[str, Any] | None = None) -> None:
+        self.executed.append((" ".join(sql.split()), params))
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return []
+
+
+class FakeTransaction:
+    def __enter__(self) -> FakeTransaction:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+class FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = FakeCursor()
+
+    def __enter__(self) -> FakeConnection:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def transaction(self) -> FakeTransaction:
+        return FakeTransaction()
+
+    def cursor(self, **kwargs: object) -> FakeCursor:
+        return self.cursor_instance
+
+
+class FakePool:
+    def __init__(self) -> None:
+        self.connection_instance = FakeConnection()
+
+    def connection(self) -> FakeConnection:
+        return self.connection_instance
+
+
+def _db() -> MailDB:
+    return MailDB._from_pool(
+        object(),  # type: ignore[arg-type]
+        config=Settings(user_email="me@example.com", _env_file=None),  # type: ignore[call-arg]
+    )
+
+
+def test_find_uses_deterministic_order_clauses(monkeypatch) -> None:
+    capture = QueryCapture()
+    monkeypatch.setattr(maildb_module, "_query_dicts", capture)
+    db = _db()
+
+    db.find()
+    db.find(order="date ASC")
+    db.find(order="sender_address DESC")
+
+    assert "ORDER BY date DESC NULLS LAST, id LIMIT" in capture.sql[0]
+    assert "ORDER BY date ASC NULLS FIRST, id LIMIT" in capture.sql[1]
+    assert "ORDER BY sender_address DESC, id LIMIT" in capture.sql[2]
+
+
+def test_correspondence_uses_deterministic_order_clause(monkeypatch) -> None:
+    capture = QueryCapture()
+    monkeypatch.setattr(maildb_module, "_query_dicts", capture)
+    db = _db()
+
+    db.correspondence(address="alice@example.com")
+
+    assert "ORDER BY date ASC NULLS FIRST, id LIMIT" in capture.sql[0]
+
+
+def test_literal_date_desc_queries_use_tiebreakers(monkeypatch) -> None:
+    capture = QueryCapture()
+    monkeypatch.setattr(maildb_module, "_query_dicts", capture)
+    db = _db()
+
+    db.mention_search(text="budget")
+    db.unreplied(direction="inbound", account="me@example.com")
+    db.unreplied(direction="outbound", account="me@example.com")
+
+    assert "ORDER BY date DESC NULLS LAST, id LIMIT" in capture.sql[0]
+    assert "ORDER BY e.date DESC NULLS LAST, e.id LIMIT" in capture.sql[1]
+    assert "ORDER BY e.date DESC NULLS LAST, e.id LIMIT" in capture.sql[2]
+
+
+def test_search_sets_hnsw_ef_search_before_vector_query() -> None:
+    pool = FakePool()
+    embedding_client = MagicMock()
+    embedding_client.embed.return_value = [0.1] * 768
+    db = MailDB._from_pool(
+        pool,  # type: ignore[arg-type]
+        config=Settings(_env_file=None),  # type: ignore[call-arg]
+        embedding_client=embedding_client,
+    )
+
+    _, total = db.search("budget", limit=5, offset=41)
+
+    executed = pool.connection_instance.cursor_instance.executed
+    assert executed[0] == (
+        "SELECT set_config('hnsw.ef_search', %(ef_search)s, true)",
+        {"ef_search": "46"},
+    )
+    assert "COUNT(*) OVER()" not in executed[1][0]
+    assert "ORDER BY embedding <=> %(query_embedding)s::vector" in executed[1][0]
+    assert total == 41


### PR DESCRIPTION
## Objective

Five deep-review findings: COUNT(*) OVER() defeats HNSW on every semantic search (HIGH); recipient predicates bypass the GIN index (MEDIUM); no trigram index behind mention_search/subject_contains (HIGH); unstable OFFSET pagination over tied dates (LOW); no-op max() in search_all (LOW).

## Change

- `maildb.py`: vector queries drop the window aggregate (total = offset + rows, documented approximate) and run behind transaction-local `set_config('hnsw.ef_search', max(40, limit+offset))` via a dedicated query helper; all four recipient-containment sites rewritten to `recipients @> jsonb_build_object(...)` (identical semantics, GIN-servable); `_order_clause` helper maps validated orders to deterministic SQL (`NULLS LAST`/`NULLS FIRST` + `id` tiebreaker) across find/correspondence/mention_search/unreplied/long_threads and candidate pulls; `search_all` over-fetch simplified.
- `schema_tables.sql`: `CREATE EXTENSION IF NOT EXISTS pg_trgm`.
- `schema_indexes.sql` + `ingest/index.py`: trigram GIN indexes on body_text/subject, included in drop/rebuild cycle.
- `server.py`: docstring updates only (approximate totals).

## Acceptance criteria

- [x] Stable-pagination tests (tied dates stable across calls; NULL dates sort last); cc-arm recipient equivalence; ef_search paging beyond 40; trigram index existence + drop cycle; totals-semantics tests updated
- [x] Non-vector list queries keep exact COUNT(*) OVER() totals — untouched
- [x] `uv run just check` — exit 0

## Provenance

Implementer: codex-cli 0.143.0, `gpt-5.5` @ `xhigh`, cheap-coder workflow. Architecture, spec, review: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)