### PR TITLE
fix(server): validate fields, page attachment markdown, correct docstrings, add account scoping

### DIFF
--- a/src/maildb/maildb.py
+++ b/src/maildb/maildb.py
@@ -651,12 +651,20 @@ class MailDB:
         *,
         sender: str | None = None,
         sender_domain: str | None = None,
+        account: str | None = None,
         limit: int = 5,
         offset: int = 0,
     ) -> tuple[list[Email], int]:
         """Representative emails spanning different topics with a contact. Returns (emails, total_count).
 
         Uses greedy farthest-point selection on embeddings.
+
+        Args:
+            sender: Exact sender email address.
+            sender_domain: Sender domain to match.
+            account: Scope to a single source_account. Omit to query across all accounts.
+            limit: Max results to return.
+            offset: Skip first N results.
         """
         conditions: list[str] = ["embedding IS NOT NULL"]
         params: dict[str, Any] = {}
@@ -670,6 +678,10 @@ class MailDB:
         else:
             msg = "Either sender or sender_domain must be provided"
             raise ValueError(msg)
+
+        account_conditions, account_params = self._build_filters(account=account)
+        conditions.extend(account_conditions)
+        params.update(account_params)
 
         where = " AND ".join(conditions)
         sql = f"SELECT {SELECT_COLS} FROM emails WHERE {where} ORDER BY date DESC NULLS LAST, id LIMIT 500"
@@ -942,6 +954,7 @@ class MailDB:
         address: str,
         after: str | None = None,
         before: str | None = None,
+        account: str | None = None,
         limit: int = 500,
         offset: int = 0,
         order: str = "date ASC",
@@ -949,6 +962,15 @@ class MailDB:
         """All emails exchanged with a specific person. Returns (emails, total_count).
         Returns emails where address is sender OR is in recipients (to/cc/bcc).
         Default chronological order, higher limit than find().
+
+        Args:
+            address: Email address to match as sender or recipient.
+            after: Only include emails on or after this date.
+            before: Only include emails before this date.
+            account: Scope to a single source_account. Omit to query across all accounts.
+            limit: Max results to return.
+            offset: Skip first N results.
+            order: Result ordering.
         """
         order_sql = _order_clause(order)
 
@@ -971,6 +993,10 @@ class MailDB:
         if before:
             conditions.append("date < %(before)s")
             params["before"] = before
+
+        account_conditions, account_params = self._build_filters(account=account)
+        conditions.extend(account_conditions)
+        params.update(account_params)
 
         where = " AND ".join(conditions)
         sql = f"SELECT {SELECT_COLS}, COUNT(*) OVER() AS _total FROM emails WHERE {where} ORDER BY {order_sql} LIMIT %(limit)s OFFSET %(offset)s"

--- a/src/maildb/server.py
+++ b/src/maildb/server.py
@@ -102,6 +102,19 @@ SERIALIZABLE_EMAIL_FIELDS = frozenset(
 DEFAULT_LIST_FIELDS = SERIALIZABLE_EMAIL_FIELDS - {"body_text"}
 
 
+def _validate_fields(fields: list[str] | None) -> frozenset[str] | None:
+    """Validate a fields projection. Raises ValueError on unknown names."""
+    if not fields:
+        return None
+    unknown = set(fields) - SERIALIZABLE_EMAIL_FIELDS
+    if unknown:
+        msg = (
+            f"Unknown fields {sorted(unknown)}; valid fields: {sorted(SERIALIZABLE_EMAIL_FIELDS)}"
+        )
+        raise ValueError(msg)
+    return frozenset(fields)
+
+
 def _serialize_email(
     email: Any,
     fields: frozenset[str] | None = None,
@@ -257,7 +270,7 @@ def find(
         direct_only=direct_only,
         account=account,
     )
-    valid = frozenset(fields) & SERIALIZABLE_EMAIL_FIELDS if fields else None
+    valid = _validate_fields(fields)
     serialized = [_serialize_email(e, valid) for e in results]
     return _wrap_response(serialized, total=total, offset=offset, limit=limit)
 
@@ -321,7 +334,7 @@ def search(
         direct_only=direct_only,
         account=account,
     )
-    valid = frozenset(fields) & SERIALIZABLE_EMAIL_FIELDS if fields else None
+    valid = _validate_fields(fields)
     serialized = [_serialize_search_result(sr, valid) for sr in results]
     return _wrap_response(serialized, total=total, offset=offset, limit=limit)
 
@@ -337,7 +350,8 @@ def get_thread(
 
     Parameters:
       thread_id: the thread identifier (from an email's thread_id field)
-      fields: list of field names to return (default: all)
+      fields: list of field names to return. Default returns headers + body_length (no body_text).
+        Pass ["body_text", ...] to include body content.
 
     Returns list of email dicts ordered by date ASC.
 
@@ -345,7 +359,7 @@ def get_thread(
     """
     db = _get_db(ctx)
     results = db.get_thread(thread_id)
-    valid = frozenset(fields) & SERIALIZABLE_EMAIL_FIELDS if fields else None
+    valid = _validate_fields(fields)
     return [_serialize_email(e, valid) for e in results]
 
 
@@ -360,7 +374,8 @@ def get_thread_for(
 
     Parameters:
       message_id: the RFC 2822 Message-ID of any email in the thread
-      fields: list of field names to return (default: all)
+      fields: list of field names to return. Default returns headers + body_length (no body_text).
+        Pass ["body_text", ...] to include body content.
 
     Returns list of email dicts (the full thread) ordered by date ASC. Empty list if not found.
 
@@ -368,7 +383,7 @@ def get_thread_for(
     """
     db = _get_db(ctx)
     results = db.get_thread_for(message_id)
-    valid = frozenset(fields) & SERIALIZABLE_EMAIL_FIELDS if fields else None
+    valid = _validate_fields(fields)
     return [_serialize_email(e, valid) for e in results]
 
 
@@ -396,7 +411,8 @@ def top_contacts(
       limit: max results (default 10)
       offset: skip first N results for pagination (default 0)
 
-    Returns list of {address: str, count: int} (or {domain: str, count: int} when group_by="domain").
+    Returns {total, offset, limit, results: [{address: str, count: int}, ...]}
+    (or {domain: str, count: int} results when group_by="domain").
 
     Example: top_contacts(group_by="domain", exclude_domains=["mycompany.com"], direction="outbound")
     """
@@ -419,6 +435,7 @@ def topics_with(
     ctx: Context,
     sender: str | None = None,
     sender_domain: str | None = None,
+    account: str | None = None,
     limit: int = 5,
     offset: int = 0,
     fields: list[str] | None = None,
@@ -430,19 +447,26 @@ def topics_with(
     Parameters:
       sender: exact email address (e.g. "bob@acme.com")
       sender_domain: domain to match (e.g. "acme.com") — provide sender OR sender_domain
+      account: limit results to this source account (e.g. "you@gmail.com").
+        Omit to query across all accounts.
       limit: number of diverse representatives (default 5)
       offset: skip first N results for pagination (default 0)
-      fields: list of field names to return (default: all)
+      fields: list of field names to return. Default returns headers + body_length (no body_text).
+        Pass ["body_text", ...] to include body content.
 
-    Returns list of email dicts maximizing topic diversity.
+    Returns {total, offset, limit, results: [{email headers + body_length}, ...]}.
 
     Example: topics_with(sender="bob@corp.com", limit=5)
     """
     db = _get_db(ctx)
     results, total = db.topics_with(
-        sender=sender, sender_domain=sender_domain, limit=limit, offset=offset
+        sender=sender,
+        sender_domain=sender_domain,
+        account=account,
+        limit=limit,
+        offset=offset,
     )
-    valid = frozenset(fields) & SERIALIZABLE_EMAIL_FIELDS if fields else None
+    valid = _validate_fields(fields)
     serialized = [_serialize_email(e, valid) for e in results]
     return _wrap_response(serialized, total=total, offset=offset, limit=limit)
 
@@ -501,7 +525,7 @@ def unreplied(
         offset=offset,
         account=account,
     )
-    valid = frozenset(fields) & SERIALIZABLE_EMAIL_FIELDS if fields else None
+    valid = _validate_fields(fields)
     serialized = [_serialize_email(e, valid) for e in results]
     return _wrap_response(serialized, total=total, offset=offset, limit=limit)
 
@@ -513,6 +537,7 @@ def correspondence(
     address: str,
     after: str | None = None,
     before: str | None = None,
+    account: str | None = None,
     limit: int = 500,
     offset: int = 0,
     order: str = "date ASC",
@@ -523,6 +548,8 @@ def correspondence(
     Parameters:
       address: the person's email address (required)
       after, before: ISO date range filters
+      account: limit results to this source account (e.g. "you@gmail.com").
+        Omit to query across all accounts.
       limit: max results (default 500, higher for full relationship history)
       offset: skip first N results for pagination (default 0)
       order: "date ASC" (default, chronological) or "date DESC"
@@ -534,9 +561,15 @@ def correspondence(
     """
     db = _get_db(ctx)
     results, total = db.correspondence(
-        address=address, after=after, before=before, limit=limit, offset=offset, order=order
+        address=address,
+        after=after,
+        before=before,
+        account=account,
+        limit=limit,
+        offset=offset,
+        order=order,
     )
-    valid = frozenset(fields) & SERIALIZABLE_EMAIL_FIELDS if fields else None
+    valid = _validate_fields(fields)
     serialized = [_serialize_email(e, valid) for e in results]
     return _wrap_response(serialized, total=total, offset=offset, limit=limit)
 
@@ -593,7 +626,7 @@ def mention_search(
         direct_only=direct_only,
         account=account,
     )
-    valid = frozenset(fields) & SERIALIZABLE_EMAIL_FIELDS if fields else None
+    valid = _validate_fields(fields)
     serialized = [_serialize_email(e, valid) for e in results]
     return _wrap_response(serialized, total=total, offset=offset, limit=limit)
 
@@ -617,15 +650,16 @@ def cluster(
       message_ids: explicit list of message_id strings (for chaining with other tools)
       limit: number of diverse representatives (default 5)
       offset: skip first N results for pagination (default 0)
-      fields: list of field names to return (default: all)
+      fields: list of field names to return. Default returns headers + body_length (no body_text).
+        Pass ["body_text", ...] to include body content.
 
-    Returns list of email dicts maximizing topic diversity via farthest-point selection.
+    Returns {total, offset, limit, results: [{email headers + body_length}, ...]}.
 
     Example: cluster(where={"and": [{"field": "sender_domain", "eq": "stripe.com"}, {"field": "date", "gte": "2024-01-01"}]}, limit=5)
     """
     db = _get_db(ctx)
     results, total = db.cluster(where=where, message_ids=message_ids, limit=limit, offset=offset)
-    valid = frozenset(fields) & SERIALIZABLE_EMAIL_FIELDS if fields else None
+    valid = _validate_fields(fields)
     serialized = [_serialize_email(e, valid) for e in results]
     return _wrap_response(serialized, total=total, offset=offset, limit=limit)
 
@@ -652,7 +686,7 @@ def long_threads(
       limit: maximum number of threads to return (default 50)
       offset: skip first N results for pagination (default 0)
 
-    Returns list of {thread_id, message_count, first_date, last_date, participants[]}.
+    Returns {total, offset, limit, results: [{thread_id, message_count, first_date, last_date, participants[]}, ...]}.
 
     Example: long_threads(min_messages=10, participant="alice@example.com")
     """
@@ -719,11 +753,13 @@ def get_emails(
     """
     db = _get_db(ctx)
     results = db.get_emails(ids)
-    valid = frozenset(fields) & SERIALIZABLE_EMAIL_FIELDS if fields else None
+    valid = _validate_fields(fields)
     # For get_emails, include body_text by default (unlike list tools)
     serialized = [
         _serialize_email(
-            e, fields=valid or SERIALIZABLE_EMAIL_FIELDS, body_max_chars=body_max_chars
+            e,
+            fields=valid if valid is not None else SERIALIZABLE_EMAIL_FIELDS,
+            body_max_chars=body_max_chars,
         )
         for e in results
     ]
@@ -853,15 +889,42 @@ def search_all(
 @mcp.tool()
 @log_tool
 def get_attachment_markdown(
-    ctx: Context, attachment_id: int, account: str | None = None
-) -> str | None:
-    """Return the full extracted markdown for an attachment, or null if not extracted.
+    ctx: Context,
+    attachment_id: int,
+    account: str | None = None,
+    max_chars: int = 20000,
+    offset: int = 0,
+) -> dict[str, Any] | None:
+    """Return extracted markdown for an attachment, or null if not extracted.
+
+    Parameters:
+      attachment_id: attachment row id
+      account: limit results to this source account (e.g. "you@gmail.com").
+        Omit to query across all accounts.
+      max_chars: truncate markdown text to N characters (default 20000; 0 = full text).
+        When truncated, truncated=true is returned.
+      offset: skip first N characters for paging (default 0).
 
     When `account` is given, the attachment must be referenced by at least one email
     attributed to that account; otherwise returns null.
+
+    Returns {attachment_id, text, total_chars, offset, truncated}.
     """
     db = _get_db(ctx)
-    return db.get_attachment_markdown(attachment_id, account=account)
+    markdown = db.get_attachment_markdown(attachment_id, account=account)
+    if markdown is None:
+        return None
+
+    total_chars = len(markdown)
+    text = markdown[offset:] if max_chars == 0 else markdown[offset : offset + max_chars]
+    truncated = offset + len(text) < total_chars
+    return {
+        "attachment_id": attachment_id,
+        "text": text,
+        "total_chars": total_chars,
+        "offset": offset,
+        "truncated": truncated,
+    }
 
 
 @mcp.tool()

--- a/tests/integration/test_maildb.py
+++ b/tests/integration/test_maildb.py
@@ -702,6 +702,57 @@ def test_topics_with_sender_domain(test_pool, seed_advanced) -> None:  # type: i
     assert all(e.sender_address == "bob@corp.com" for e in topics)
 
 
+def test_topics_with_filters_by_account(test_pool, test_settings) -> None:  # type: ignore[no-untyped-def]
+    db = MailDB._from_pool(test_pool, config=test_settings)
+    iid_a = uuid4()
+    iid_b = uuid4()
+    with test_pool.connection() as conn:
+        for iid, acct in [(iid_a, "a@example.com"), (iid_b, "b@example.com")]:
+            conn.execute(
+                "INSERT INTO imports (id, source_account, source_file, status) "
+                "VALUES (%(id)s, %(acct)s, 'topics-account', 'completed')",
+                {"id": iid, "acct": acct},
+            )
+        for n, (iid, acct) in enumerate([(iid_a, "a@example.com"), (iid_b, "b@example.com")]):
+            eid = uuid4()
+            conn.execute(
+                """INSERT INTO emails (id, message_id, thread_id, subject, sender_address,
+                       sender_domain, recipients, date, body_text, embedding,
+                       source_account, import_id, created_at)
+                   VALUES (%(id)s, %(mid)s, 'topics-account-thread', 'Topic',
+                       'bob@corp.com', 'corp.com', %(recipients)s, now(),
+                       %(body)s, %(embedding)s, %(acct)s, %(iid)s, now())""",
+                {
+                    "id": eid,
+                    "mid": f"topics-account-{n}@corp.com",
+                    "recipients": json.dumps({"to": ["alice@example.com"], "cc": [], "bcc": []}),
+                    "body": f"topic body {n}",
+                    "embedding": [float(n + 1)] + [0.0] * 767,
+                    "acct": acct,
+                    "iid": iid,
+                },
+            )
+            conn.execute(
+                "INSERT INTO email_accounts (email_id, source_account, import_id) "
+                "VALUES (%(eid)s, %(acct)s, %(iid)s)",
+                {"eid": eid, "acct": acct, "iid": iid},
+            )
+        conn.commit()
+
+    a_only, a_total = db.topics_with(sender="bob@corp.com", account="a@example.com", limit=5)
+    assert {e.message_id for e in a_only} == {"topics-account-0@corp.com"}
+    assert a_total == 1
+
+    unscoped, unscoped_total = db.topics_with(sender="bob@corp.com", limit=5)
+    none_scoped, none_scoped_total = db.topics_with(sender="bob@corp.com", account=None, limit=5)
+    assert {e.message_id for e in unscoped} == {
+        "topics-account-0@corp.com",
+        "topics-account-1@corp.com",
+    }
+    assert [e.message_id for e in none_scoped] == [e.message_id for e in unscoped]
+    assert none_scoped_total == unscoped_total == 2
+
+
 def test_topics_with_no_args_raises(test_pool, seed_advanced) -> None:  # type: ignore[no-untyped-def]
     """topics_with() with neither sender nor sender_domain should raise ValueError."""
     db = MailDB._from_pool(test_pool)
@@ -1177,6 +1228,56 @@ def test_correspondence_limit(test_pool, seed_advanced) -> None:
     db = MailDB._from_pool(test_pool)
     results, _ = db.correspondence(address="bob@corp.com", limit=1)
     assert len(results) == 1
+
+
+def test_correspondence_filters_by_account(test_pool, test_settings) -> None:  # type: ignore[no-untyped-def]
+    db = MailDB._from_pool(test_pool, config=test_settings)
+    iid_a = uuid4()
+    iid_b = uuid4()
+    with test_pool.connection() as conn:
+        for iid, acct in [(iid_a, "a@example.com"), (iid_b, "b@example.com")]:
+            conn.execute(
+                "INSERT INTO imports (id, source_account, source_file, status) "
+                "VALUES (%(id)s, %(acct)s, 'correspondence-account', 'completed')",
+                {"id": iid, "acct": acct},
+            )
+        for n, (iid, acct) in enumerate([(iid_a, "a@example.com"), (iid_b, "b@example.com")]):
+            eid = uuid4()
+            conn.execute(
+                """INSERT INTO emails (id, message_id, thread_id, subject, sender_address,
+                       sender_domain, recipients, date, body_text, source_account,
+                       import_id, created_at)
+                   VALUES (%(id)s, %(mid)s, 'correspondence-account-thread',
+                       'Correspondence', 'bob@corp.com', 'corp.com', %(recipients)s,
+                       now(), %(body)s, %(acct)s, %(iid)s, now())""",
+                {
+                    "id": eid,
+                    "mid": f"correspondence-account-{n}@corp.com",
+                    "recipients": json.dumps({"to": ["alice@example.com"], "cc": [], "bcc": []}),
+                    "body": f"correspondence body {n}",
+                    "acct": acct,
+                    "iid": iid,
+                },
+            )
+            conn.execute(
+                "INSERT INTO email_accounts (email_id, source_account, import_id) "
+                "VALUES (%(eid)s, %(acct)s, %(iid)s)",
+                {"eid": eid, "acct": acct, "iid": iid},
+            )
+        conn.commit()
+
+    a_only, a_total = db.correspondence(address="bob@corp.com", account="a@example.com")
+    assert {e.message_id for e in a_only} == {"correspondence-account-0@corp.com"}
+    assert a_total == 1
+
+    unscoped, unscoped_total = db.correspondence(address="bob@corp.com")
+    none_scoped, none_scoped_total = db.correspondence(address="bob@corp.com", account=None)
+    assert {e.message_id for e in unscoped} == {
+        "correspondence-account-0@corp.com",
+        "correspondence-account-1@corp.com",
+    }
+    assert [e.message_id for e in none_scoped] == [e.message_id for e in unscoped]
+    assert none_scoped_total == unscoped_total == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from maildb import server
+from maildb.maildb import MailDB
+
+pytestmark = pytest.mark.integration
+
+
+def _ctx(test_pool, test_settings):  # type: ignore[no-untyped-def]
+    db = MailDB._from_pool(test_pool, config=test_settings)
+    return SimpleNamespace(
+        request_context=SimpleNamespace(lifespan_context=SimpleNamespace(db=db))
+    )
+
+
+def _seed_email(test_pool, *, message_id: str = "server-fields@example.com") -> None:  # type: ignore[no-untyped-def]
+    with test_pool.connection() as conn:
+        conn.execute(
+            """INSERT INTO emails (id, message_id, thread_id, subject, sender_address,
+                   sender_domain, recipients, date, body_text, has_attachment,
+                   attachments, labels, created_at)
+               VALUES (%(id)s, %(mid)s, 'server-thread', 'Server test',
+                   'alice@example.com', 'example.com', %(recipients)s, %(date)s,
+                   'Visible body text', false, %(attachments)s, %(labels)s, now())""",
+            {
+                "id": uuid4(),
+                "mid": message_id,
+                "recipients": json.dumps({"to": ["bob@example.com"], "cc": [], "bcc": []}),
+                "date": datetime(2025, 1, 1, 10, 0, tzinfo=UTC),
+                "attachments": json.dumps([]),
+                "labels": ["INBOX"],
+            },
+        )
+        conn.commit()
+
+
+def test_find_rejects_unknown_fields(test_pool, test_settings) -> None:  # type: ignore[no-untyped-def]
+    _seed_email(test_pool)
+
+    with pytest.raises(ValueError) as excinfo:
+        server.find(_ctx(test_pool, test_settings), fields=["body"])
+
+    message = str(excinfo.value)
+    assert "body" in message
+    assert "body_text" in message
+
+
+def test_get_emails_rejects_unknown_fields(test_pool, test_settings) -> None:  # type: ignore[no-untyped-def]
+    _seed_email(test_pool)
+
+    with pytest.raises(ValueError) as excinfo:
+        server.get_emails(
+            _ctx(test_pool, test_settings),
+            ids=["server-fields@example.com"],
+            fields=["body"],
+        )
+
+    message = str(excinfo.value)
+    assert "body" in message
+    assert "body_text" in message
+
+
+def test_empty_fields_uses_default_projection(test_pool, test_settings) -> None:  # type: ignore[no-untyped-def]
+    _seed_email(test_pool)
+
+    result = server.find(_ctx(test_pool, test_settings), fields=[])
+
+    email = result["results"][0]
+    assert "body_text" not in email
+    assert email["body_length"] == len("Visible body text")
+
+
+def test_get_attachment_markdown_pages_text(test_pool, test_settings) -> None:  # type: ignore[no-untyped-def]
+    markdown = "abcdefghi"
+    with test_pool.connection() as conn:
+        cur = conn.execute(
+            "INSERT INTO attachments (sha256, filename, content_type, size, storage_path) "
+            "VALUES ('server-md', 'doc.md', 'text/markdown', 9, 'server/md') RETURNING id"
+        )
+        attachment_id = cur.fetchone()[0]
+        conn.execute(
+            "INSERT INTO attachment_contents (attachment_id, status, markdown, markdown_bytes) "
+            "VALUES (%s, 'extracted', %s, %s)",
+            (attachment_id, markdown, len(markdown)),
+        )
+        conn.commit()
+
+    full = server.get_attachment_markdown(_ctx(test_pool, test_settings), attachment_id)
+    assert full == {
+        "attachment_id": attachment_id,
+        "text": markdown,
+        "total_chars": len(markdown),
+        "offset": 0,
+        "truncated": False,
+    }
+
+    first_page = server.get_attachment_markdown(
+        _ctx(test_pool, test_settings), attachment_id, max_chars=5
+    )
+    assert first_page == {
+        "attachment_id": attachment_id,
+        "text": "abcde",
+        "total_chars": len(markdown),
+        "offset": 0,
+        "truncated": True,
+    }
+
+    second_page = server.get_attachment_markdown(
+        _ctx(test_pool, test_settings), attachment_id, max_chars=5, offset=5
+    )
+    assert second_page == {
+        "attachment_id": attachment_id,
+        "text": "fghi",
+        "total_chars": len(markdown),
+        "offset": 5,
+        "truncated": False,
+    }

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -351,7 +351,14 @@ def test_get_attachment_markdown_tool_passes_account_through() -> None:
     mock_db.get_attachment_markdown.return_value = "# text"
     ctx = MagicMock()
     ctx.request_context.lifespan_context.db = mock_db
-    assert server.get_attachment_markdown(ctx, attachment_id=7, account="work@ex.com") == "# text"
+    result = server.get_attachment_markdown(ctx, attachment_id=7, account="work@ex.com")
+    assert result == {
+        "attachment_id": 7,
+        "text": "# text",
+        "total_chars": 6,
+        "offset": 0,
+        "truncated": False,
+    }
     mock_db.get_attachment_markdown.assert_called_with(7, account="work@ex.com")
 
 


### PR DESCRIPTION
## Objective

Four deep-review findings on the MCP tool surface: silent invalid-fields swallowing with divergent behaviors (MEDIUM), unbounded get_attachment_markdown (MEDIUM), docstrings misstating field defaults and return shapes (MEDIUM), missing account scoping on correspondence/topics_with (LOW).

## Change

- `server.py`: shared `_validate_fields` raises ValueError listing unknown + valid names (replaces ~10 silent-intersection sites); `get_emails` falsy-empty fallback fixed with exact None semantics; `get_attachment_markdown(max_chars=20000, offset=0)` returns `{attachment_id, text, total_chars, offset, truncated}`; docstring corrections for get_thread/get_thread_for/topics_with/cluster (default excludes body_text) and top_contacts/topics_with/cluster/long_threads (pagination envelope).
- `maildb.py`: `correspondence()` and `topics_with()` gain `account` via the existing `_build_filters` EXISTS clause.

## Acceptance criteria

- [x] Invalid fields raise (list tool + get_emails paths); empty list behaves as default
- [x] Markdown paging: full/truncated/offset slices asserted
- [x] Account scoping filters correctly, None unchanged
- [x] `uv run just check` — exit 0

## Provenance

Implementer: codex-cli 0.143.0, `gpt-5.5` @ `xhigh`, cheap-coder workflow. Architecture, spec, review: Claude (one small fix applied by reviewer — see review comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)