### PR TITLE
fix(threads): union-find repair pass for fragmented thread identity

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -34,7 +34,7 @@ The CLI (`src/maildb/cli.py`, Typer) ships `serve` (run MCP), `ingest run|status
 
 ## 4. Load-Bearing Design Decisions
 
-**One row per message, not per thread.** `thread_id` is derived at parse time from RFC 2822 headers (`References[0]` → `In-Reply-To` → `message_id` fallback) and stored on the email row; queries group by the stored `thread_id`. This gives semantic search the precision to match the specific message, not every quoted reply.
+**One row per message, not per thread.** `thread_id` is derived at parse time from RFC 2822 headers (`References[0]` → `In-Reply-To` → `message_id` fallback) and stored on the email row; queries group by the stored `thread_id`. A post-parse union-find pass repairs fragmentation from In-Reply-To-only clients by rewriting `thread_id` to the connected-component root, with the oldest message winning. This gives semantic search the precision to match the specific message, not every quoted reply.
 
 **Denormalized `emails` row.** Recipients as JSONB, labels as text array, sender domain extracted at ingest. Avoids joins for the common query shapes.
 

--- a/src/maildb/cli.py
+++ b/src/maildb/cli.py
@@ -1,4 +1,4 @@
-"""Unified maildb CLI — `serve`, `ingest run/status/reset/migrate`."""
+"""Unified maildb CLI — `serve`, `ingest run/status/reset/migrate/repair-threads`."""
 
 from __future__ import annotations
 
@@ -32,6 +32,7 @@ from maildb.ingest.process_attachments import (
 from maildb.ingest.process_attachments import (
     sweep_empty_extractions as pa_sweep_empty_extractions,
 )
+from maildb.ingest.threads import repair_thread_ids
 from maildb.pii import scrub_pii
 from maildb.server import mcp
 
@@ -363,6 +364,19 @@ def ingest_migrate(
     finally:
         pool.close()
     typer.echo(f"Backfilled {result['rows_updated']} rows with source_account={account}")
+
+
+@ingest_app.command("repair-threads")
+def ingest_repair_threads() -> None:
+    """Backfill repaired thread_id values across existing emails."""
+    settings = Settings()
+    pool = create_pool(settings)
+    init_db(pool)
+    try:
+        updated = repair_thread_ids(pool)
+    finally:
+        pool.close()
+    typer.echo(f"Thread repair complete. updated={updated}")
 
 
 process_app = typer.Typer(

--- a/src/maildb/ingest/orchestrator.py
+++ b/src/maildb/ingest/orchestrator.py
@@ -26,6 +26,7 @@ from maildb.ingest.tasks import (
     reset_failed_tasks,
     reset_stale_in_progress,
 )
+from maildb.ingest.threads import repair_thread_ids
 
 logger = structlog.get_logger()
 
@@ -274,6 +275,10 @@ def run_pipeline(
                     "after workers exited. Retry the import."
                 )
                 raise RuntimeError(msg)  # noqa: TRY301
+
+            # Thread repair is cheap and idempotent; a crash simply reruns it on the next pipeline.
+            thread_updates = repair_thread_ids(pool)
+            logger.info("thread_repair_pipeline_complete", updated=thread_updates)
 
             # Phase 3: Index
             index_status = get_phase_status(pool, "index", import_id=import_id)

--- a/src/maildb/ingest/threads.py
+++ b/src/maildb/ingest/threads.py
@@ -1,0 +1,145 @@
+"""Repair thread ids after parsing.
+
+In-Reply-To-only clients can make each reply point at its direct parent instead
+of the thread root, fragmenting conversations across thread_id values. Missing
+archive messages still carry identity through reply headers, so absent
+intermediates must participate in the connectivity graph.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, cast
+
+import structlog
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = structlog.get_logger()
+
+type ThreadRow = tuple[str, str, str | None, list[str] | None, datetime | None]
+
+
+class _UnionFind:
+    def __init__(self) -> None:
+        self._index: dict[str, int] = {}
+        self._parent: list[int] = []
+        self._size: list[int] = []
+
+    def add(self, key: str) -> int:
+        idx = self._index.get(key)
+        if idx is not None:
+            return idx
+        idx = len(self._parent)
+        self._index[key] = idx
+        self._parent.append(idx)
+        self._size.append(1)
+        return idx
+
+    def find(self, idx: int) -> int:
+        root = idx
+        while self._parent[root] != root:
+            root = self._parent[root]
+        while self._parent[idx] != idx:
+            next_idx = self._parent[idx]
+            self._parent[idx] = root
+            idx = next_idx
+        return root
+
+    def union(self, left: int, right: int) -> None:
+        left_root = self.find(left)
+        right_root = self.find(right)
+        if left_root == right_root:
+            return
+        if self._size[left_root] < self._size[right_root]:
+            left_root, right_root = right_root, left_root
+        self._parent[right_root] = left_root
+        self._size[left_root] += self._size[right_root]
+
+
+def _load_rows(pool: ConnectionPool) -> list[ThreadRow]:
+    with pool.connection() as conn:
+        cur = conn.execute(
+            'SELECT message_id, thread_id, in_reply_to, "references", date FROM emails'
+        )
+        return cast("list[ThreadRow]", cur.fetchall())
+
+
+def _is_older(
+    date: datetime | None,
+    message_id: str,
+    best_date: datetime | None,
+    best_message_id: str,
+) -> bool:
+    if date is None and best_date is None:
+        return message_id < best_message_id
+    if date is None:
+        return False
+    if best_date is None:
+        return True
+    if date == best_date:
+        return message_id < best_message_id
+    return date < best_date
+
+
+def _compute_updates(rows: list[ThreadRow]) -> tuple[list[tuple[str, str]], int]:
+    uf = _UnionFind()
+
+    for message_id, _thread_id, in_reply_to, references, _date in rows:
+        message_node = uf.add(message_id)
+        if in_reply_to is not None:
+            uf.union(message_node, uf.add(in_reply_to))
+        for reference in references or []:
+            uf.union(message_node, uf.add(reference))
+
+    component_roots: dict[int, tuple[datetime | None, str]] = {}
+    for message_id, _thread_id, _in_reply_to, _references, date in rows:
+        component = uf.find(uf.add(message_id))
+        best = component_roots.get(component)
+        if best is None or _is_older(date, message_id, best[0], best[1]):
+            component_roots[component] = (date, message_id)
+
+    updates: list[tuple[str, str]] = []
+    for message_id, thread_id, _in_reply_to, _references, _date in rows:
+        component = uf.find(uf.add(message_id))
+        new_thread_id = component_roots[component][1]
+        if thread_id != new_thread_id:
+            updates.append((message_id, new_thread_id))
+
+    return updates, len(component_roots)
+
+
+def _apply_updates(pool: ConnectionPool, updates: list[tuple[str, str]]) -> int:
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """CREATE TEMP TABLE thread_id_repair_updates (
+                   message_id text PRIMARY KEY,
+                   new_thread_id text NOT NULL
+               ) ON COMMIT DROP"""
+        )
+        if updates:
+            cur.executemany(
+                """INSERT INTO thread_id_repair_updates (message_id, new_thread_id)
+                   VALUES (%s, %s)""",
+                updates,
+            )
+        cur.execute(
+            """UPDATE emails e
+               SET thread_id = t.new_thread_id
+               FROM thread_id_repair_updates t
+               WHERE e.message_id = t.message_id"""
+        )
+        updated = max(cur.rowcount, 0)
+        conn.commit()
+        return updated
+
+
+def repair_thread_ids(pool: ConnectionPool) -> int:
+    """Rewrite thread_id to the connected-component root. Returns rows updated."""
+    rows = _load_rows(pool)
+    logger.info("thread_repair_start", rows=len(rows))
+    updates, components = _compute_updates(rows)
+    updated = _apply_updates(pool, updates)
+    logger.info("thread_repair_complete", updated=updated, components=components)
+    return updated

--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -50,6 +50,13 @@ def test_run_pipeline_split_and_parse(test_pool, test_settings, tmp_path):
     with test_pool.connection() as conn:
         cur = conn.execute("SELECT count(*) FROM emails")
         assert cur.fetchone()[0] > 0
+        cur = conn.execute(
+            """SELECT count(DISTINCT thread_id)
+               FROM emails
+               WHERE message_id = ANY(%(ids)s)""",
+            {"ids": ["msg001@example.com", "msg002@example.com", "msg003@example.com"]},
+        )
+        assert cur.fetchone()[0] == 1
 
 
 def test_run_pipeline_reclaims_stale_parse_task(test_pool, test_settings, tmp_path):

--- a/tests/integration/test_threads.py
+++ b/tests/integration/test_threads.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from maildb.config import Settings
+from maildb.ingest.threads import repair_thread_ids
+from maildb.maildb import MailDB
+
+pytestmark = pytest.mark.integration
+
+
+INSERT_EMAIL_SQL = """
+INSERT INTO emails (
+    message_id, thread_id, subject, sender_name, sender_address, sender_domain,
+    recipients, date, body_text, body_html, has_attachment, attachments,
+    labels, in_reply_to, "references"
+) VALUES (
+    %(message_id)s, %(thread_id)s, %(subject)s, %(sender_name)s, %(sender_address)s,
+    %(sender_domain)s, %(recipients)s, %(date)s, %(body_text)s, %(body_html)s,
+    %(has_attachment)s, %(attachments)s, %(labels)s, %(in_reply_to)s, %(references)s
+)
+"""
+
+
+def _row(
+    message_id: str,
+    *,
+    thread_id: str | None = None,
+    sender: str = "sender@example.com",
+    recipients: list[str] | None = None,
+    date: datetime | None = None,
+    in_reply_to: str | None = None,
+    references: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "message_id": message_id,
+        "thread_id": thread_id or message_id,
+        "subject": "Thread repair",
+        "sender_name": sender.split("@", maxsplit=1)[0],
+        "sender_address": sender,
+        "sender_domain": sender.split("@", maxsplit=1)[1],
+        "recipients": json.dumps(
+            {"to": recipients or ["recipient@example.com"], "cc": [], "bcc": []}
+        ),
+        "date": date,
+        "body_text": "body",
+        "body_html": None,
+        "has_attachment": False,
+        "attachments": json.dumps([]),
+        "labels": [],
+        "in_reply_to": in_reply_to,
+        "references": references,
+    }
+
+
+def _seed(test_pool, rows: list[dict[str, object]]) -> None:  # type: ignore[no-untyped-def]
+    with test_pool.connection() as conn:
+        for row in rows:
+            conn.execute(INSERT_EMAIL_SQL, row)
+        conn.commit()
+
+
+def _thread_ids(test_pool) -> dict[str, str]:  # type: ignore[no-untyped-def]
+    with test_pool.connection() as conn:
+        cur = conn.execute("SELECT message_id, thread_id FROM emails ORDER BY message_id")
+        return dict(cur.fetchall())
+
+
+def test_in_reply_to_only_fragmentation_heals(test_pool) -> None:  # type: ignore[no-untyped-def]
+    _seed(
+        test_pool,
+        [
+            _row(
+                "thread-a@example.com",
+                date=datetime(2025, 1, 1, 9, 0, tzinfo=UTC),
+            ),
+            _row(
+                "thread-b@example.com",
+                thread_id="thread-a@example.com",
+                date=datetime(2025, 1, 1, 10, 0, tzinfo=UTC),
+                in_reply_to="thread-a@example.com",
+                references=["thread-a@example.com"],
+            ),
+            _row(
+                "thread-c@example.com",
+                thread_id="thread-b@example.com",
+                date=datetime(2025, 1, 1, 11, 0, tzinfo=UTC),
+                in_reply_to="thread-b@example.com",
+            ),
+        ],
+    )
+
+    updated = repair_thread_ids(test_pool)
+
+    assert updated == 1
+    assert set(_thread_ids(test_pool).values()) == {"thread-a@example.com"}
+
+
+def test_absent_intermediate_connects_present_messages(test_pool) -> None:  # type: ignore[no-untyped-def]
+    _seed(
+        test_pool,
+        [
+            _row(
+                "absent-x@example.com",
+                thread_id="missing-middle@example.com",
+                date=datetime(2025, 2, 1, 9, 0, tzinfo=UTC),
+                in_reply_to="missing-middle@example.com",
+            ),
+            _row(
+                "absent-y@example.com",
+                thread_id="missing-middle@example.com",
+                date=datetime(2025, 2, 1, 10, 0, tzinfo=UTC),
+                references=["missing-middle@example.com"],
+            ),
+        ],
+    )
+
+    updated = repair_thread_ids(test_pool)
+
+    assert updated == 2
+    assert _thread_ids(test_pool) == {
+        "absent-x@example.com": "absent-x@example.com",
+        "absent-y@example.com": "absent-x@example.com",
+    }
+
+
+def test_repair_thread_ids_is_idempotent(test_pool) -> None:  # type: ignore[no-untyped-def]
+    _seed(
+        test_pool,
+        [
+            _row("idem-a@example.com", date=datetime(2025, 3, 1, 9, 0, tzinfo=UTC)),
+            _row(
+                "idem-b@example.com",
+                thread_id="idem-a@example.com",
+                date=datetime(2025, 3, 1, 10, 0, tzinfo=UTC),
+                references=["idem-a@example.com"],
+            ),
+            _row(
+                "idem-c@example.com",
+                thread_id="idem-b@example.com",
+                date=datetime(2025, 3, 1, 11, 0, tzinfo=UTC),
+                in_reply_to="idem-b@example.com",
+            ),
+        ],
+    )
+
+    assert repair_thread_ids(test_pool) == 1
+    repaired = _thread_ids(test_pool)
+    assert repair_thread_ids(test_pool) == 0
+    assert _thread_ids(test_pool) == repaired
+
+
+def test_date_ties_choose_lexicographically_smallest_message_id(test_pool) -> None:  # type: ignore[no-untyped-def]
+    same_date = datetime(2025, 4, 1, 9, 0, tzinfo=UTC)
+    _seed(
+        test_pool,
+        [
+            _row("tie-b@example.com", date=same_date),
+            _row(
+                "tie-a@example.com",
+                thread_id="tie-b@example.com",
+                date=same_date,
+                in_reply_to="tie-b@example.com",
+            ),
+        ],
+    )
+
+    assert repair_thread_ids(test_pool) == 2
+    assert _thread_ids(test_pool) == {
+        "tie-a@example.com": "tie-a@example.com",
+        "tie-b@example.com": "tie-a@example.com",
+    }
+    assert repair_thread_ids(test_pool) == 0
+    assert _thread_ids(test_pool) == {
+        "tie-a@example.com": "tie-a@example.com",
+        "tie-b@example.com": "tie-a@example.com",
+    }
+
+
+def test_independent_threads_untouched_and_not_counted(test_pool) -> None:  # type: ignore[no-untyped-def]
+    _seed(
+        test_pool,
+        [
+            _row("solo@example.com", date=datetime(2025, 5, 1, 9, 0, tzinfo=UTC)),
+            _row("ind-a@example.com", date=datetime(2025, 5, 2, 9, 0, tzinfo=UTC)),
+            _row(
+                "ind-b@example.com",
+                thread_id="ind-a@example.com",
+                date=datetime(2025, 5, 2, 10, 0, tzinfo=UTC),
+                references=["ind-a@example.com"],
+            ),
+            _row(
+                "ind-c@example.com",
+                thread_id="ind-b@example.com",
+                date=datetime(2025, 5, 2, 11, 0, tzinfo=UTC),
+                in_reply_to="ind-b@example.com",
+            ),
+        ],
+    )
+
+    assert repair_thread_ids(test_pool) == 1
+    assert _thread_ids(test_pool)["solo@example.com"] == "solo@example.com"
+
+
+def test_unreplied_false_positive_disappears_after_thread_repair(test_pool) -> None:  # type: ignore[no-untyped-def]
+    me = "alice@example.com"
+    frank = "frank@example.com"
+    _seed(
+        test_pool,
+        [
+            _row(
+                "false-f@example.com",
+                sender=frank,
+                recipients=[me],
+                date=datetime(2025, 6, 1, 9, 0, tzinfo=UTC),
+            ),
+            _row(
+                "false-r@example.com",
+                thread_id="false-f@example.com",
+                sender=me,
+                recipients=[frank],
+                date=datetime(2025, 6, 1, 10, 0, tzinfo=UTC),
+                in_reply_to="false-f@example.com",
+                references=["false-f@example.com"],
+            ),
+            _row(
+                "false-g@example.com",
+                thread_id="false-r@example.com",
+                sender=frank,
+                recipients=[me],
+                date=datetime(2025, 6, 1, 11, 0, tzinfo=UTC),
+                in_reply_to="false-r@example.com",
+            ),
+            _row(
+                "false-h@example.com",
+                thread_id="false-g@example.com",
+                sender=me,
+                recipients=[frank],
+                date=datetime(2025, 6, 1, 12, 0, tzinfo=UTC),
+                in_reply_to="false-g@example.com",
+            ),
+        ],
+    )
+    db = MailDB._from_pool(test_pool, config=Settings(user_email=me, _env_file=None))  # type: ignore[call-arg]
+
+    before, _ = db.unreplied()
+    assert "false-g@example.com" in {email.message_id for email in before}
+
+    assert repair_thread_ids(test_pool) == 2
+    assert set(_thread_ids(test_pool).values()) == {"false-f@example.com"}
+    after, _ = db.unreplied()
+    assert "false-g@example.com" not in {email.message_id for email in after}


### PR DESCRIPTION
## Objective

Deep-review strategic Decision C: In-Reply-To-only clients fragment threads (reply stamped with its parent's id, not the root), corrupting get_thread results and producing unreplied() false positives — including connectivity that only exists through messages absent from the archive.

## Change

- New `ingest/threads.py`: `repair_thread_ids(pool)` — int-mapped union-find (path compression + union by size) over message_id ∪ references ∪ in_reply_to including absent intermediates; component root = oldest present message (date ASC NULLS LAST, message_id tiebreak); set-wise apply via ON COMMIT DROP temp table + single UPDATE...FROM; returns updated count.
- `orchestrator.py`: runs after the parse gates, before the index phase (no task machinery — cheap + idempotent, commented as such).
- `cli.py`: `maildb ingest repair-threads` for one-time backfill of existing archives.
- `docs/DESIGN.md`: thread-identity decision amended (one sentence).

## Acceptance criteria

- [x] Fragmentation heals (In-Reply-To-only chain unifies to root); absent-intermediate connectivity proven
- [x] Idempotent (second run: 0) and deterministic (date-tie test)
- [x] unreplied() false positive present before repair, gone after
- [x] `uv run just check` (coverage gate) — exit 0

## Provenance

Implementer: codex-cli 0.143.0, `gpt-5.5` @ `xhigh`, cheap-coder workflow. Architecture, spec, review: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)