### PR TITLE
feat(contacts): contacts subsystem Phase 1 — address book, human-probability classifier, MCP resolution tools

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -30,7 +30,7 @@ Initial source is local `.mbox` files. Gmail API sync is planned.
 | Query | `src/maildb/maildb.py`, `src/maildb/dsl.py`, `src/maildb/ingest/chunking.py`, `src/maildb/tokenizer.py` | Tier 1 fixed methods + Tier 2 JSON DSL + attachment semantic search |
 | MCP server | `src/maildb/server.py` | FastMCP wrapper exposing every query method as a tool |
 
-The CLI (`src/maildb/cli.py`, Typer) ships `serve` (run MCP), `ingest run|status|reset|migrate`, `jobs` (process/throughput/orphan monitoring), and `process_attachments run|status|retry|reembed`.
+The CLI (`src/maildb/cli.py`, Typer) ships `serve` (run MCP), `ingest run|status|reset|migrate`, `jobs` (process/throughput/orphan monitoring), `process_attachments run|status|retry|reembed`, and `contacts refresh|classify`.
 
 ## 4. Load-Bearing Design Decisions
 
@@ -55,6 +55,8 @@ The CLI (`src/maildb/cli.py`, Typer) ships `serve` (run MCP), `ingest run|status
 **Ingest is a 4-phase pipeline backed by `ingest_tasks`.** Split → parse → index → embed. Parse and embed workers claim tasks with `SKIP LOCKED` for parallelism. Indexes are dropped before parse and rebuilt after for bulk-insert performance.
 
 **Dual-sink logging with PII scrubbing.** INFO+ to stderr (MCP-stdio-safe), DEBUG+ to a rotating debug log. All events pass through an email/SSN/CC/phone redactor before either sink.
+
+**Contacts are an entity-level address book, not a query-time aggregation.** `contacts` ← `contact_addresses` is materialized from the archive and refreshed at ingest (and via `maildb contacts refresh`). An automated human-probability classifier writes explainable signals and a score, but never writes `kind` — final kind is always a manual decision, guarded by `kind_source='manual'` so refresh/classify cannot clobber curation. MCP exposes read tools plus a single-contact curation write (`update_contact`); batch/maintenance jobs stay on the CLI (`contacts refresh|classify`).
 
 ## 5. Multi-Account Semantics (Summary)
 

--- a/src/maildb/cli.py
+++ b/src/maildb/cli.py
@@ -15,6 +15,7 @@ import typer
 
 from maildb import jobs as jobs_mod
 from maildb.config import Settings
+from maildb.contacts import build_contacts, classify_contact, classify_contacts
 from maildb.db import create_hnsw_index_attachment_chunks, create_pool, init_db
 from maildb.ingest import run_logs as run_logs_mod
 from maildb.ingest.orchestrator import (
@@ -47,6 +48,11 @@ app = typer.Typer(
 
 ingest_app = typer.Typer(name="ingest", help="Ingest pipeline commands.", no_args_is_help=True)
 app.add_typer(ingest_app, name="ingest")
+
+contacts_app = typer.Typer(
+    name="contacts", help="Contact address book commands.", no_args_is_help=True
+)
+app.add_typer(contacts_app, name="contacts")
 
 
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
@@ -377,6 +383,78 @@ def ingest_repair_threads() -> None:
     finally:
         pool.close()
     typer.echo(f"Thread repair complete. updated={updated}")
+
+
+@contacts_app.command("refresh")
+def contacts_refresh(
+    classify: bool = typer.Option(
+        True,
+        "--classify/--no-classify",
+        help="Run the human-probability classifier after building contacts.",
+    ),
+) -> None:
+    """Materialize/refresh contacts from the full email corpus."""
+    settings = Settings()
+    pool = create_pool(settings)
+    init_db(pool)
+    try:
+        result = build_contacts(pool)
+        typer.echo(
+            f"Contacts refresh complete. "
+            f"addresses={result['addresses']} contacts_created={result['contacts_created']}"
+        )
+        if classify:
+            n = classify_contacts(pool)
+            typer.echo(f"Classified {n} contact(s).")
+    finally:
+        pool.close()
+
+
+@contacts_app.command("classify")
+def contacts_classify(
+    address: str | None = typer.Option(
+        None,
+        "--address",
+        help="Limit classification to the contact owning this address.",
+    ),
+) -> None:
+    """Run the human-probability classifier over contacts."""
+    settings = Settings()
+    pool = create_pool(settings)
+    init_db(pool)
+    try:
+        if address is not None:
+            with pool.connection() as conn:
+                row = conn.execute(
+                    "SELECT contact_id FROM contact_addresses WHERE address = %(addr)s",
+                    {"addr": address.lower().strip()},
+                ).fetchone()
+            if row is None:
+                typer.echo(f"No contact found for address {address!r}.")
+                raise typer.Exit(code=1)
+            n = 1
+            classify_contact(pool, row[0])
+        else:
+            n = classify_contacts(pool)
+
+        with pool.connection() as conn:
+            cur = conn.execute(
+                """
+                SELECT
+                    count(*) FILTER (WHERE human_probability < 0.3),
+                    count(*) FILTER (
+                        WHERE human_probability >= 0.3 AND human_probability <= 0.7
+                    ),
+                    count(*) FILTER (WHERE human_probability > 0.7)
+                  FROM contacts
+                 WHERE human_probability IS NOT NULL
+                """
+            )
+            low, mid, high = cur.fetchone()  # type: ignore[misc]
+        typer.echo(f"Classified {n} contact(s).")
+        typer.echo(f"Distribution: <0.3={low}  0.3-0.7={mid}  >0.7={high}")
+    finally:
+        pool.close()
 
 
 process_app = typer.Typer(

--- a/src/maildb/contacts.py
+++ b/src/maildb/contacts.py
@@ -125,9 +125,26 @@ def build_contacts(
         if not touched:
             return {"addresses": 0, "contacts_created": 0, "contact_ids": []}
 
-        # Full-corpus stats for touched addresses.
+        # Stage full-corpus stats for touched addresses, then apply set-based.
+        conn.execute(
+            """CREATE TEMP TABLE contacts_staging (
+                   address text PRIMARY KEY,
+                   new_contact_id uuid NOT NULL DEFAULT gen_random_uuid(),
+                   top_name text,
+                   name_variants text[],
+                   is_user boolean,
+                   first_seen timestamptz,
+                   last_seen timestamptz,
+                   messages_from int,
+                   messages_to int
+               ) ON COMMIT DROP"""
+        )
         cur = conn.execute(
             """
+            INSERT INTO contacts_staging (
+                address, top_name, name_variants, is_user,
+                first_seen, last_seen, messages_from, messages_to
+            )
             WITH touched AS (
                 SELECT unnest(%(addrs)s::text[]) AS address
             ),
@@ -207,13 +224,13 @@ def build_contacts(
                   ) rs ON rs.address = t.address
             )
             SELECT t.address,
-                   coalesce(nv.name_variants, '{}'::text[]) AS name_variants,
                    tn.top_name,
-                   coalesce(fs.messages_from, 0) AS messages_from,
-                   coalesce(ts.messages_to, 0) AS messages_to,
+                   coalesce(nv.name_variants, '{}'::text[]) AS name_variants,
+                   (t.address = ANY(%(user_emails)s)) AS is_user,
                    db.first_seen,
                    db.last_seen,
-                   (t.address = ANY(%(user_emails)s)) AS is_user
+                   coalesce(fs.messages_from, 0) AS messages_from,
+                   coalesce(ts.messages_to, 0) AS messages_to
               FROM touched t
               LEFT JOIN name_variants nv ON nv.address = t.address
               LEFT JOIN top_names tn ON tn.address = t.address
@@ -223,99 +240,64 @@ def build_contacts(
             """,
             {"addrs": touched, "user_emails": user_ids},
         )
-        rows = cur.fetchall()
+        addresses_count = max(cur.rowcount, 0)
 
-        contacts_created = 0
-        contact_ids: list[UUID] = []
-        for (
-            address,
-            name_variants,
-            top_name,
-            messages_from,
-            messages_to,
-            first_seen,
-            last_seen,
-            is_user,
-        ) in rows:
-            existing = conn.execute(
-                "SELECT contact_id FROM contact_addresses WHERE address = %(addr)s",
-                {"addr": address},
-            ).fetchone()
-            if existing is None:
-                inserted = conn.execute(
-                    """INSERT INTO contacts (display_name)
-                       VALUES (%(display_name)s)
-                       RETURNING id""",
-                    {"display_name": top_name},
-                ).fetchone()
-                if inserted is None:
-                    msg = "INSERT INTO contacts RETURNING id produced no row"
-                    raise RuntimeError(msg)
-                contact_id = inserted[0]
-                conn.execute(
-                    """INSERT INTO contact_addresses (
-                           address, contact_id, name_variants, is_user,
-                           first_seen, last_seen, messages_from, messages_to
-                       ) VALUES (
-                           %(address)s, %(contact_id)s, %(name_variants)s, %(is_user)s,
-                           %(first_seen)s, %(last_seen)s, %(messages_from)s, %(messages_to)s
-                       )""",
-                    {
-                        "address": address,
-                        "contact_id": contact_id,
-                        "name_variants": name_variants or [],
-                        "is_user": is_user,
-                        "first_seen": first_seen,
-                        "last_seen": last_seen,
-                        "messages_from": messages_from,
-                        "messages_to": messages_to,
-                    },
-                )
-                contacts_created += 1
-                contact_ids.append(contact_id)
-            else:
-                contact_id = existing[0]
-                conn.execute(
-                    """UPDATE contact_addresses
-                          SET name_variants = %(name_variants)s,
-                              is_user = %(is_user)s,
-                              first_seen = %(first_seen)s,
-                              last_seen = %(last_seen)s,
-                              messages_from = %(messages_from)s,
-                              messages_to = %(messages_to)s
-                        WHERE address = %(address)s""",
-                    {
-                        "address": address,
-                        "name_variants": name_variants or [],
-                        "is_user": is_user,
-                        "first_seen": first_seen,
-                        "last_seen": last_seen,
-                        "messages_from": messages_from,
-                        "messages_to": messages_to,
-                    },
-                )
-                contact_ids.append(contact_id)
+        # (c) refresh stats on existing address rows first
+        conn.execute(
+            """UPDATE contact_addresses ca
+                  SET name_variants = s.name_variants,
+                      is_user = s.is_user,
+                      first_seen = s.first_seen,
+                      last_seen = s.last_seen,
+                      messages_from = s.messages_from,
+                      messages_to = s.messages_to
+                 FROM contacts_staging s
+                WHERE ca.address = s.address"""
+        )
+        # (a) new singleton contacts for addresses not yet in contact_addresses
+        cur = conn.execute(
+            """INSERT INTO contacts (id, display_name)
+               SELECT s.new_contact_id, s.top_name
+                 FROM contacts_staging s
+                WHERE NOT EXISTS (
+                          SELECT 1 FROM contact_addresses ca
+                           WHERE ca.address = s.address
+                      )"""
+        )
+        contacts_created = max(cur.rowcount, 0)
+        # (b) matching address rows for those new contacts
+        conn.execute(
+            """INSERT INTO contact_addresses (
+                   address, contact_id, name_variants, is_user,
+                   first_seen, last_seen, messages_from, messages_to
+               )
+               SELECT s.address, s.new_contact_id, s.name_variants, s.is_user,
+                      s.first_seen, s.last_seen, s.messages_from, s.messages_to
+                 FROM contacts_staging s
+                WHERE NOT EXISTS (
+                          SELECT 1 FROM contact_addresses ca
+                           WHERE ca.address = s.address
+                      )"""
+        )
 
+        cur = conn.execute(
+            """SELECT DISTINCT ca.contact_id
+                 FROM contacts_staging s
+                 JOIN contact_addresses ca ON ca.address = s.address"""
+        )
+        contact_ids = [row[0] for row in cur.fetchall()]
         conn.commit()
-
-    # Dedupe contact_ids while preserving order
-    seen_ids: set[UUID] = set()
-    unique_ids: list[UUID] = []
-    for cid in contact_ids:
-        if cid not in seen_ids:
-            seen_ids.add(cid)
-            unique_ids.append(cid)
 
     logger.info(
         "contacts_built",
-        addresses=len(rows),
+        addresses=addresses_count,
         contacts_created=contacts_created,
         import_id=str(import_id) if import_id else None,
     )
     return {
-        "addresses": len(rows),
+        "addresses": addresses_count,
         "contacts_created": contacts_created,
-        "contact_ids": unique_ids,
+        "contact_ids": contact_ids,
     }
 
 
@@ -420,7 +402,7 @@ def classify_contacts(
             )
         rows = cur.fetchall()
 
-        classified = 0
+        updates: list[dict[str, Any]] = []
         for (
             contact_id,
             only_user,
@@ -437,20 +419,25 @@ def classify_contacts(
                 name_variants=list(name_variants or []),
                 addresses=list(addresses or []),
             )
-            conn.execute(
-                """UPDATE contacts
-                      SET human_probability = %(prob)s,
-                          classification_signals = %(signals)s::jsonb,
-                          classified_at = now(),
-                          updated_at = now()
-                    WHERE id = %(id)s""",
+            updates.append(
                 {
                     "prob": probability,
                     "signals": json.dumps(signals),
                     "id": contact_id,
-                },
+                }
             )
-            classified += 1
+        if updates:
+            with conn.cursor() as cur:
+                cur.executemany(
+                    """UPDATE contacts
+                          SET human_probability = %(prob)s,
+                              classification_signals = %(signals)s::jsonb,
+                              classified_at = now(),
+                              updated_at = now()
+                        WHERE id = %(id)s""",
+                    updates,
+                )
+        classified = len(updates)
         conn.commit()
 
     logger.info("contacts_classified", count=classified)

--- a/src/maildb/contacts.py
+++ b/src/maildb/contacts.py
@@ -1,0 +1,470 @@
+"""Contacts subsystem: materialize address book + human-probability classifier.
+
+The classifier never writes ``kind`` / ``kind_source`` — those are manual.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from maildb.config import Settings
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from psycopg_pool import ConnectionPool
+
+logger = structlog.get_logger()
+
+# Signal weights — deterministic, documented for explainability.
+BASE_PROBABILITY = 0.50  # Prior before any address-level evidence.
+WEIGHT_BIDIRECTIONAL = 0.35  # Both sent and received with the user.
+WEIGHT_USER_INITIATED = 0.15  # User has written to this address at least once.
+WEIGHT_PERSONAL_NAME = 0.10  # Display name looks like a personal first+last.
+WEIGHT_AUTOMATED_PATTERN = -0.40  # Local-part matches noreply/billing/etc.
+WEIGHT_LIST_PATTERN = -0.30  # Address looks like a mailing list.
+WEIGHT_ONE_WAY_BULK = -0.20  # Many inbound messages, zero outbound.
+
+_PERSONAL_NAME_RE = re.compile(r"^[A-Z][a-z]+(?:\s+[A-Z][a-z]+)+$")
+_NON_PERSONAL_NAME_RE = re.compile(
+    r"\b(list|team|support|noreply|newsletter|admin|mailer|billing|notifications?)\b",
+    re.IGNORECASE,
+)
+_AUTOMATED_LOCAL_RE = re.compile(
+    r"(?:no-?reply|donotreply|do-not-reply|notifications?|alerts?|mailer-daemon|"
+    r"postmaster|bounce|newsletters?|marketing|updates|receipts?|billing|invoices?)",
+    re.IGNORECASE,
+)
+_LIST_ADDRESS_RE = re.compile(
+    r"lists\.|googlegroups\.com|listserv|-announce@|-dev@|-users@",
+    re.IGNORECASE,
+)
+
+
+def _normalize_address(address: str) -> str:
+    return address.lower().strip()
+
+
+def _user_identities(pool: ConnectionPool) -> list[str]:
+    """Configured user_emails (+ legacy user_email) union imports.source_account."""
+    settings = Settings()
+    with pool.connection() as conn:
+        cur = conn.execute("SELECT DISTINCT source_account FROM imports")
+        ingested = [r[0] for r in cur.fetchall() if r[0]]
+    seen: set[str] = set()
+    merged: list[str] = []
+    for addr in (*settings.user_emails, *ingested):
+        if not addr:
+            continue
+        norm = _normalize_address(addr)
+        if norm not in seen:
+            seen.add(norm)
+            merged.append(norm)
+    return merged
+
+
+def build_contacts(
+    pool: ConnectionPool,
+    *,
+    import_id: UUID | str | None = None,
+) -> dict[str, Any]:
+    """Materialize/refresh contact_addresses + singleton contacts from emails.
+
+    With ``import_id``, only addresses appearing in that import are touched;
+    stats for those addresses are recomputed from the full corpus. Without,
+    the whole corpus is processed.
+
+    Returns ``{"addresses": n, "contacts_created": n, "contact_ids": [...]}``.
+    """
+    user_ids = _user_identities(pool)
+    with pool.connection() as conn:
+        # Addresses touched by the (scoped) source rows.
+        cur = conn.execute(
+            """
+            WITH scoped AS (
+                SELECT sender_address, recipients
+                  FROM emails
+                 WHERE (%(import_id)s::uuid IS NULL OR import_id = %(import_id)s::uuid)
+            ),
+            from_addrs AS (
+                SELECT lower(btrim(sender_address)) AS address
+                  FROM scoped
+                 WHERE sender_address IS NOT NULL AND btrim(sender_address) <> ''
+            ),
+            to_addrs AS (
+                SELECT lower(btrim(r.addr)) AS address
+                  FROM scoped e
+                  CROSS JOIN LATERAL (
+                      SELECT jsonb_array_elements_text(
+                                 COALESCE(e.recipients->'to', '[]'::jsonb)
+                             ) AS addr
+                      UNION ALL
+                      SELECT jsonb_array_elements_text(
+                                 COALESCE(e.recipients->'cc', '[]'::jsonb)
+                             )
+                      UNION ALL
+                      SELECT jsonb_array_elements_text(
+                                 COALESCE(e.recipients->'bcc', '[]'::jsonb)
+                             )
+                  ) r
+                 WHERE e.recipients IS NOT NULL
+                   AND r.addr IS NOT NULL
+                   AND btrim(r.addr) <> ''
+            )
+            SELECT DISTINCT address FROM from_addrs
+            UNION
+            SELECT DISTINCT address FROM to_addrs
+            """,
+            {"import_id": import_id},
+        )
+        touched = [row[0] for row in cur.fetchall()]
+        if not touched:
+            return {"addresses": 0, "contacts_created": 0, "contact_ids": []}
+
+        # Full-corpus stats for touched addresses.
+        cur = conn.execute(
+            """
+            WITH touched AS (
+                SELECT unnest(%(addrs)s::text[]) AS address
+            ),
+            sender_names AS (
+                SELECT lower(btrim(e.sender_address)) AS address,
+                       e.sender_name,
+                       count(*) AS cnt
+                  FROM emails e
+                  JOIN touched t ON lower(btrim(e.sender_address)) = t.address
+                 WHERE e.sender_name IS NOT NULL AND btrim(e.sender_name) <> ''
+                 GROUP BY 1, 2
+            ),
+            name_variants AS (
+                SELECT address,
+                       array_agg(sender_name ORDER BY sender_name) AS name_variants
+                  FROM sender_names
+                 GROUP BY address
+            ),
+            top_names AS (
+                SELECT DISTINCT ON (address) address, sender_name AS top_name
+                  FROM sender_names
+                 ORDER BY address, cnt DESC, sender_name
+            ),
+            from_stats AS (
+                SELECT lower(btrim(e.sender_address)) AS address,
+                       count(*)::int AS messages_from,
+                       min(e.date) AS first_seen,
+                       max(e.date) AS last_seen
+                  FROM emails e
+                  JOIN touched t ON lower(btrim(e.sender_address)) = t.address
+                 GROUP BY 1
+            ),
+            to_stats AS (
+                SELECT t.address,
+                       count(*)::int AS messages_to
+                  FROM touched t
+                  JOIN emails e ON (
+                      lower(btrim(e.sender_address)) = ANY(%(user_emails)s)
+                      AND (
+                          e.recipients @> jsonb_build_object(
+                              'to', to_jsonb(ARRAY[t.address])
+                          )
+                          OR e.recipients @> jsonb_build_object(
+                              'cc', to_jsonb(ARRAY[t.address])
+                          )
+                          OR e.recipients @> jsonb_build_object(
+                              'bcc', to_jsonb(ARRAY[t.address])
+                          )
+                      )
+                  )
+                 GROUP BY t.address
+            ),
+            date_bounds AS (
+                -- first/last seen across both sent and received for recipient-only addrs
+                SELECT t.address,
+                       least(fs.first_seen, rs.first_seen) AS first_seen,
+                       greatest(fs.last_seen, rs.last_seen) AS last_seen
+                  FROM touched t
+                  LEFT JOIN from_stats fs ON fs.address = t.address
+                  LEFT JOIN (
+                      SELECT t2.address,
+                             min(e.date) AS first_seen,
+                             max(e.date) AS last_seen
+                        FROM touched t2
+                        JOIN emails e ON (
+                            e.recipients @> jsonb_build_object(
+                                'to', to_jsonb(ARRAY[t2.address])
+                            )
+                            OR e.recipients @> jsonb_build_object(
+                                'cc', to_jsonb(ARRAY[t2.address])
+                            )
+                            OR e.recipients @> jsonb_build_object(
+                                'bcc', to_jsonb(ARRAY[t2.address])
+                            )
+                        )
+                       GROUP BY t2.address
+                  ) rs ON rs.address = t.address
+            )
+            SELECT t.address,
+                   coalesce(nv.name_variants, '{}'::text[]) AS name_variants,
+                   tn.top_name,
+                   coalesce(fs.messages_from, 0) AS messages_from,
+                   coalesce(ts.messages_to, 0) AS messages_to,
+                   db.first_seen,
+                   db.last_seen,
+                   (t.address = ANY(%(user_emails)s)) AS is_user
+              FROM touched t
+              LEFT JOIN name_variants nv ON nv.address = t.address
+              LEFT JOIN top_names tn ON tn.address = t.address
+              LEFT JOIN from_stats fs ON fs.address = t.address
+              LEFT JOIN to_stats ts ON ts.address = t.address
+              LEFT JOIN date_bounds db ON db.address = t.address
+            """,
+            {"addrs": touched, "user_emails": user_ids},
+        )
+        rows = cur.fetchall()
+
+        contacts_created = 0
+        contact_ids: list[UUID] = []
+        for (
+            address,
+            name_variants,
+            top_name,
+            messages_from,
+            messages_to,
+            first_seen,
+            last_seen,
+            is_user,
+        ) in rows:
+            existing = conn.execute(
+                "SELECT contact_id FROM contact_addresses WHERE address = %(addr)s",
+                {"addr": address},
+            ).fetchone()
+            if existing is None:
+                inserted = conn.execute(
+                    """INSERT INTO contacts (display_name)
+                       VALUES (%(display_name)s)
+                       RETURNING id""",
+                    {"display_name": top_name},
+                ).fetchone()
+                if inserted is None:
+                    msg = "INSERT INTO contacts RETURNING id produced no row"
+                    raise RuntimeError(msg)
+                contact_id = inserted[0]
+                conn.execute(
+                    """INSERT INTO contact_addresses (
+                           address, contact_id, name_variants, is_user,
+                           first_seen, last_seen, messages_from, messages_to
+                       ) VALUES (
+                           %(address)s, %(contact_id)s, %(name_variants)s, %(is_user)s,
+                           %(first_seen)s, %(last_seen)s, %(messages_from)s, %(messages_to)s
+                       )""",
+                    {
+                        "address": address,
+                        "contact_id": contact_id,
+                        "name_variants": name_variants or [],
+                        "is_user": is_user,
+                        "first_seen": first_seen,
+                        "last_seen": last_seen,
+                        "messages_from": messages_from,
+                        "messages_to": messages_to,
+                    },
+                )
+                contacts_created += 1
+                contact_ids.append(contact_id)
+            else:
+                contact_id = existing[0]
+                conn.execute(
+                    """UPDATE contact_addresses
+                          SET name_variants = %(name_variants)s,
+                              is_user = %(is_user)s,
+                              first_seen = %(first_seen)s,
+                              last_seen = %(last_seen)s,
+                              messages_from = %(messages_from)s,
+                              messages_to = %(messages_to)s
+                        WHERE address = %(address)s""",
+                    {
+                        "address": address,
+                        "name_variants": name_variants or [],
+                        "is_user": is_user,
+                        "first_seen": first_seen,
+                        "last_seen": last_seen,
+                        "messages_from": messages_from,
+                        "messages_to": messages_to,
+                    },
+                )
+                contact_ids.append(contact_id)
+
+        conn.commit()
+
+    # Dedupe contact_ids while preserving order
+    seen_ids: set[UUID] = set()
+    unique_ids: list[UUID] = []
+    for cid in contact_ids:
+        if cid not in seen_ids:
+            seen_ids.add(cid)
+            unique_ids.append(cid)
+
+    logger.info(
+        "contacts_built",
+        addresses=len(rows),
+        contacts_created=contacts_created,
+        import_id=str(import_id) if import_id else None,
+    )
+    return {
+        "addresses": len(rows),
+        "contacts_created": contacts_created,
+        "contact_ids": unique_ids,
+    }
+
+
+def _is_personal_name(name: str) -> bool:
+    if not _PERSONAL_NAME_RE.match(name.strip()):
+        return False
+    if _NON_PERSONAL_NAME_RE.search(name):
+        return False
+    return not any(ch.isdigit() for ch in name)
+
+
+def _compute_probability(
+    *,
+    messages_from: int,
+    messages_to: int,
+    name_variants: list[str],
+    addresses: list[str],
+) -> tuple[float, dict[str, float]]:
+    score = BASE_PROBABILITY
+    signals: dict[str, float] = {}
+
+    if messages_from > 0 and messages_to > 0:
+        score += WEIGHT_BIDIRECTIONAL
+        signals["bidirectional"] = WEIGHT_BIDIRECTIONAL
+    if messages_to > 0:
+        score += WEIGHT_USER_INITIATED
+        signals["user_initiated"] = WEIGHT_USER_INITIATED
+    if any(_is_personal_name(n) for n in name_variants):
+        score += WEIGHT_PERSONAL_NAME
+        signals["personal_name"] = WEIGHT_PERSONAL_NAME
+
+    for addr in addresses:
+        local = addr.split("@", 1)[0]
+        if _AUTOMATED_LOCAL_RE.search(local):
+            score += WEIGHT_AUTOMATED_PATTERN
+            signals["automated_pattern"] = WEIGHT_AUTOMATED_PATTERN
+            break
+    for addr in addresses:
+        if _LIST_ADDRESS_RE.search(addr):
+            score += WEIGHT_LIST_PATTERN
+            signals["list_pattern"] = WEIGHT_LIST_PATTERN
+            break
+
+    if messages_from >= 20 and messages_to == 0:
+        score += WEIGHT_ONE_WAY_BULK
+        signals["one_way_bulk"] = WEIGHT_ONE_WAY_BULK
+
+    probability = max(0.01, min(0.99, score))
+    return probability, signals
+
+
+def classify_contacts(
+    pool: ConnectionPool,
+    *,
+    contact_ids: list[UUID] | None = None,
+) -> int:
+    """Compute human_probability for contacts. Never writes kind/kind_source.
+
+    With ``contact_ids=None``, classifies the whole corpus. Skips contacts
+    whose only address is the user. Returns the number classified.
+    """
+    with pool.connection() as conn:
+        if contact_ids is not None:
+            if not contact_ids:
+                return 0
+            cur = conn.execute(
+                """
+                SELECT c.id,
+                       bool_and(ca.is_user) AS only_user,
+                       coalesce(sum(ca.messages_from), 0)::int AS messages_from,
+                       coalesce(sum(ca.messages_to), 0)::int AS messages_to,
+                       coalesce(
+                           array_agg(DISTINCT v) FILTER (WHERE v IS NOT NULL),
+                           '{}'::text[]
+                       ) AS name_variants,
+                       array_agg(DISTINCT ca.address) AS addresses
+                  FROM contacts c
+                  JOIN contact_addresses ca ON ca.contact_id = c.id
+                  LEFT JOIN LATERAL unnest(ca.name_variants) AS v ON TRUE
+                 WHERE c.id = ANY(%(ids)s)
+                 GROUP BY c.id
+                """,
+                {"ids": contact_ids},
+            )
+        else:
+            cur = conn.execute(
+                """
+                SELECT c.id,
+                       bool_and(ca.is_user) AS only_user,
+                       coalesce(sum(ca.messages_from), 0)::int AS messages_from,
+                       coalesce(sum(ca.messages_to), 0)::int AS messages_to,
+                       coalesce(
+                           array_agg(DISTINCT v) FILTER (WHERE v IS NOT NULL),
+                           '{}'::text[]
+                       ) AS name_variants,
+                       array_agg(DISTINCT ca.address) AS addresses
+                  FROM contacts c
+                  JOIN contact_addresses ca ON ca.contact_id = c.id
+                  LEFT JOIN LATERAL unnest(ca.name_variants) AS v ON TRUE
+                 GROUP BY c.id
+                """
+            )
+        rows = cur.fetchall()
+
+        classified = 0
+        for (
+            contact_id,
+            only_user,
+            messages_from,
+            messages_to,
+            name_variants,
+            addresses,
+        ) in rows:
+            if only_user:
+                continue
+            probability, signals = _compute_probability(
+                messages_from=messages_from,
+                messages_to=messages_to,
+                name_variants=list(name_variants or []),
+                addresses=list(addresses or []),
+            )
+            conn.execute(
+                """UPDATE contacts
+                      SET human_probability = %(prob)s,
+                          classification_signals = %(signals)s::jsonb,
+                          classified_at = now(),
+                          updated_at = now()
+                    WHERE id = %(id)s""",
+                {
+                    "prob": probability,
+                    "signals": json.dumps(signals),
+                    "id": contact_id,
+                },
+            )
+            classified += 1
+        conn.commit()
+
+    logger.info("contacts_classified", count=classified)
+    return classified
+
+
+def classify_contact(pool: ConnectionPool, contact_id: UUID) -> float:
+    """Classify a single contact; return its human_probability."""
+    classify_contacts(pool, contact_ids=[contact_id])
+    with pool.connection() as conn:
+        row = conn.execute(
+            "SELECT human_probability FROM contacts WHERE id = %(id)s",
+            {"id": contact_id},
+        ).fetchone()
+    if row is None or row[0] is None:
+        return 0.0
+    return float(row[0])

--- a/src/maildb/ingest/orchestrator.py
+++ b/src/maildb/ingest/orchestrator.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 import structlog
 from psycopg_pool import ConnectionPool
 
+from maildb.contacts import build_contacts, classify_contacts
 from maildb.ingest.embed import embed_worker
 from maildb.ingest.index import (
     create_embed_backlog_index,
@@ -279,6 +280,16 @@ def run_pipeline(
             # Thread repair is cheap and idempotent; a crash simply reruns it on the next pipeline.
             thread_updates = repair_thread_ids(pool)
             logger.info("thread_repair_pipeline_complete", updated=thread_updates)
+
+            # Contacts refresh is cheap and idempotent; a crash simply reruns it on the next pipeline.
+            contacts_result = build_contacts(pool, import_id=import_id)
+            logger.info(
+                "contacts_build_pipeline_complete",
+                addresses=contacts_result["addresses"],
+                contacts_created=contacts_result["contacts_created"],
+            )
+            classified = classify_contacts(pool, contact_ids=contacts_result["contact_ids"])
+            logger.info("contacts_classify_pipeline_complete", classified=classified)
 
             # Phase 3: Index
             index_status = get_phase_status(pool, "index", import_id=import_id)

--- a/src/maildb/maildb.py
+++ b/src/maildb/maildb.py
@@ -38,6 +38,8 @@ VALID_ORDERS = {
     "sender_address DESC",
 }
 
+VALID_CONTACT_KINDS = frozenset({"human", "organization", "automated", "mailing_list", "unknown"})
+
 # Standard reciprocal-rank-fusion constant; higher values flatten the rank penalty.
 RRF_K = 60
 
@@ -1196,6 +1198,257 @@ class MailDB:
                 )
             )
         return results, total
+
+    # --- Contacts address book ---
+
+    def contacts_search(
+        self,
+        *,
+        query: str | None = None,
+        kind: str | None = None,
+        tag: str | None = None,
+        min_human_probability: float | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Search the contacts address book. Returns (contacts, total_count).
+
+        Joins contacts ← contact_addresses (aggregated per contact). Excludes
+        contacts whose every address is the user. Order is by total message
+        volume DESC, then last_seen DESC NULLS LAST, then id.
+        """
+        conditions: list[str] = ["NOT only_user"]
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+
+        if kind is not None:
+            conditions.append("kind = %(kind)s")
+            params["kind"] = kind
+        if tag is not None:
+            conditions.append("%(tag)s = ANY(tags)")
+            params["tag"] = tag
+        if min_human_probability is not None:
+            conditions.append("human_probability >= %(min_human_probability)s")
+            params["min_human_probability"] = min_human_probability
+        if query is not None:
+            escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            params["query_pattern"] = f"%{escaped}%"
+            conditions.append(
+                "("
+                "display_name ILIKE %(query_pattern)s ESCAPE '\\' "
+                "OR EXISTS ("
+                "  SELECT 1 FROM unnest(name_variants) AS nv "
+                "  WHERE nv ILIKE %(query_pattern)s ESCAPE '\\'"
+                ") "
+                "OR EXISTS ("
+                "  SELECT 1 FROM unnest(addresses) AS addr "
+                "  WHERE addr ILIKE %(query_pattern)s ESCAPE '\\'"
+                ")"
+                ")"
+            )
+
+        where = " AND ".join(conditions)
+        sql = f"""
+            WITH contact_stats AS (
+                SELECT
+                    c.id,
+                    c.display_name,
+                    c.kind,
+                    c.kind_source,
+                    c.tags,
+                    c.human_probability,
+                    array_agg(DISTINCT ca.address ORDER BY ca.address) AS addresses,
+                    coalesce(
+                        (
+                            SELECT array_agg(DISTINCT v ORDER BY v)
+                              FROM contact_addresses ca2
+                              LEFT JOIN LATERAL unnest(ca2.name_variants) AS v ON TRUE
+                             WHERE ca2.contact_id = c.id AND v IS NOT NULL
+                        ),
+                        '{{}}'::text[]
+                    ) AS name_variants,
+                    coalesce(sum(ca.messages_from), 0)::int AS messages_from,
+                    coalesce(sum(ca.messages_to), 0)::int AS messages_to,
+                    min(ca.first_seen) AS first_seen,
+                    max(ca.last_seen) AS last_seen,
+                    bool_and(ca.is_user) AS only_user
+                  FROM contacts c
+                  JOIN contact_addresses ca ON ca.contact_id = c.id
+                 GROUP BY c.id
+            )
+            SELECT
+                id, display_name, kind, kind_source, tags, human_probability,
+                addresses, name_variants, messages_from, messages_to,
+                first_seen, last_seen,
+                COUNT(*) OVER() AS _total
+              FROM contact_stats
+             WHERE {where}
+             ORDER BY (messages_from + messages_to) DESC,
+                      last_seen DESC NULLS LAST,
+                      id
+             LIMIT %(limit)s OFFSET %(offset)s
+        """
+        rows = _query_dicts(self._pool, sql, params)
+        total = rows[0]["_total"] if rows else 0
+        results: list[dict[str, Any]] = []
+        for row in rows:
+            row.pop("_total", None)
+            results.append(self._format_contact_row(row, full=False))
+        return results, total
+
+    def get_contact(
+        self,
+        *,
+        address: str | None = None,
+        contact_id: UUID | str | None = None,
+    ) -> dict[str, Any] | None:
+        """Return a full contact card by address or contact_id.
+
+        Exactly one of address/contact_id is required. Address lookup is
+        normalized to lowercase. Returns None if not found.
+        """
+        if (address is None) == (contact_id is None):
+            msg = "Exactly one of address or contact_id is required"
+            raise ValueError(msg)
+
+        if address is not None:
+            params: dict[str, Any] = {"address": address.lower().strip()}
+            id_filter = """
+                c.id = (
+                    SELECT ca0.contact_id FROM contact_addresses ca0
+                     WHERE ca0.address = %(address)s
+                )
+            """
+        else:
+            params = {"contact_id": contact_id}
+            id_filter = "c.id = %(contact_id)s"
+
+        sql = f"""
+            SELECT
+                c.id,
+                c.display_name,
+                c.kind,
+                c.kind_source,
+                c.tags,
+                c.notes,
+                c.metadata,
+                c.human_probability,
+                c.classification_signals,
+                c.classified_at,
+                array_agg(DISTINCT ca.address ORDER BY ca.address) AS addresses,
+                coalesce(
+                    (
+                        SELECT array_agg(DISTINCT v ORDER BY v)
+                          FROM contact_addresses ca2
+                          LEFT JOIN LATERAL unnest(ca2.name_variants) AS v ON TRUE
+                         WHERE ca2.contact_id = c.id AND v IS NOT NULL
+                    ),
+                    '{{}}'::text[]
+                ) AS name_variants,
+                coalesce(sum(ca.messages_from), 0)::int AS messages_from,
+                coalesce(sum(ca.messages_to), 0)::int AS messages_to,
+                min(ca.first_seen) AS first_seen,
+                max(ca.last_seen) AS last_seen
+              FROM contacts c
+              JOIN contact_addresses ca ON ca.contact_id = c.id
+             WHERE {id_filter}
+             GROUP BY c.id
+        """
+        row = _query_one_dict(self._pool, sql, params)
+        if row is None:
+            return None
+        return self._format_contact_row(row, full=True)
+
+    def update_contact(
+        self,
+        *,
+        contact_id: UUID | str,
+        kind: str | None = None,
+        tags: list[str] | None = None,
+        notes: str | None = None,
+        display_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Curation-only write for a single contact.
+
+        Updates only the provided fields. Setting kind also sets
+        kind_source='manual'. Raises ValueError if the kind is invalid or the
+        contact does not exist.
+        """
+        if kind is not None and kind not in VALID_CONTACT_KINDS:
+            msg = (
+                f"Invalid kind {kind!r}. Must be one of: {', '.join(sorted(VALID_CONTACT_KINDS))}"
+            )
+            raise ValueError(msg)
+
+        sets: list[str] = []
+        params: dict[str, Any] = {"contact_id": contact_id}
+        if kind is not None:
+            sets.append("kind = %(kind)s")
+            sets.append("kind_source = 'manual'")
+            params["kind"] = kind
+        if tags is not None:
+            sets.append("tags = %(tags)s")
+            params["tags"] = tags
+        if notes is not None:
+            sets.append("notes = %(notes)s")
+            params["notes"] = notes
+        if display_name is not None:
+            sets.append("display_name = %(display_name)s")
+            params["display_name"] = display_name
+
+        if sets:
+            sets.append("updated_at = now()")
+            sql = f"""
+                UPDATE contacts
+                   SET {", ".join(sets)}
+                 WHERE id = %(contact_id)s
+             RETURNING id
+            """
+            row = _query_one_dict(self._pool, sql, params)
+            if row is None:
+                msg = f"Contact {contact_id} does not exist"
+                raise ValueError(msg)
+        else:
+            # No fields to update — still verify existence.
+            exists = _query_one_dict(
+                self._pool,
+                "SELECT id FROM contacts WHERE id = %(contact_id)s",
+                params,
+            )
+            if exists is None:
+                msg = f"Contact {contact_id} does not exist"
+                raise ValueError(msg)
+
+        card = self.get_contact(contact_id=contact_id)
+        if card is None:
+            msg = f"Contact {contact_id} does not exist"
+            raise ValueError(msg)
+        return card
+
+    @staticmethod
+    def _format_contact_row(row: dict[str, Any], *, full: bool) -> dict[str, Any]:
+        """Normalize a contact row to the public dict shape."""
+        out: dict[str, Any] = {
+            "id": str(row["id"]) if row.get("id") is not None else None,
+            "display_name": row.get("display_name"),
+            "kind": row.get("kind"),
+            "kind_source": row.get("kind_source"),
+            "tags": list(row["tags"]) if row.get("tags") is not None else [],
+            "human_probability": row.get("human_probability"),
+            "addresses": list(row["addresses"]) if row.get("addresses") is not None else [],
+            "name_variants": (
+                list(row["name_variants"]) if row.get("name_variants") is not None else []
+            ),
+            "messages_from": row.get("messages_from") or 0,
+            "messages_to": row.get("messages_to") or 0,
+            "first_seen": row.get("first_seen"),
+            "last_seen": row.get("last_seen"),
+        }
+        if full:
+            out["notes"] = row.get("notes")
+            out["metadata"] = row.get("metadata") if row.get("metadata") is not None else {}
+            out["classification_signals"] = row.get("classification_signals")
+            out["classified_at"] = row.get("classified_at")
+        return out
 
     def get_attachment_markdown(
         self, attachment_id: int, *, account: str | None = None

--- a/src/maildb/schema_indexes.sql
+++ b/src/maildb/schema_indexes.sql
@@ -30,3 +30,9 @@ CREATE INDEX IF NOT EXISTS idx_attachment_chunks_attachment_id
 
 -- HNSW index created separately after embed phase:
 -- CREATE INDEX IF NOT EXISTS idx_email_embedding ON emails USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+
+-- Contacts indexes (not part of the parse drop/rebuild cycle — not bulk-loaded during parse).
+CREATE INDEX IF NOT EXISTS idx_contact_addresses_contact_id ON contact_addresses (contact_id);
+CREATE INDEX IF NOT EXISTS idx_contacts_tags ON contacts USING GIN (tags);
+CREATE INDEX IF NOT EXISTS idx_contacts_kind ON contacts (kind);
+CREATE INDEX IF NOT EXISTS idx_contacts_human_probability ON contacts (human_probability);

--- a/src/maildb/schema_tables.sql
+++ b/src/maildb/schema_tables.sql
@@ -90,6 +90,34 @@ CREATE TABLE IF NOT EXISTS email_accounts (
     PRIMARY KEY (email_id, source_account)
 );
 
+CREATE TABLE IF NOT EXISTS contacts (
+    id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    display_name           TEXT,
+    kind                   TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (kind IN ('human','organization','automated','mailing_list','unknown')),
+    kind_source            TEXT NOT NULL DEFAULT 'heuristic'
+        CHECK (kind_source IN ('heuristic','manual')),
+    tags                   TEXT[] NOT NULL DEFAULT '{}',
+    notes                  TEXT,
+    metadata               JSONB NOT NULL DEFAULT '{}',
+    human_probability      REAL,
+    classification_signals JSONB,
+    classified_at          TIMESTAMPTZ,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS contact_addresses (
+    address       TEXT PRIMARY KEY,
+    contact_id    UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+    name_variants TEXT[] NOT NULL DEFAULT '{}',
+    is_user       BOOLEAN NOT NULL DEFAULT FALSE,
+    first_seen    TIMESTAMPTZ,
+    last_seen     TIMESTAMPTZ,
+    messages_from INT NOT NULL DEFAULT 0,
+    messages_to   INT NOT NULL DEFAULT 0
+);
+
 CREATE TABLE IF NOT EXISTS attachment_contents (
     attachment_id     INT PRIMARY KEY REFERENCES attachments(id) ON DELETE CASCADE,
     status            TEXT NOT NULL

--- a/src/maildb/server.py
+++ b/src/maildb/server.py
@@ -934,6 +934,119 @@ def get_attachment_markdown(
 
 @mcp.tool()
 @log_tool
+def contacts(
+    ctx: Context,
+    query: str | None = None,
+    kind: str | None = None,
+    tag: str | None = None,
+    min_human_probability: float | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Resolve people and senders: search the address book by name fragment,
+    address fragment, kind, or tag.
+
+    This is the entry point for "who is Bob?" — resolve a person to their
+    email address(es), then pass those addresses into every other tool
+    (find, correspondence, topics_with, etc.).
+
+    Parameters:
+      query: case-insensitive substring match against display_name, any name
+        variant, or any address (e.g. "Bob", "bob@", "corp.com")
+      kind: filter by curated kind — one of "human", "organization",
+        "automated", "mailing_list", "unknown"
+      tag: filter contacts that have this tag (e.g. "vip")
+      min_human_probability: minimum automated human-probability estimate
+        (0.0-1.0). This is an automated estimate only; the final `kind` is
+        always manually curated and may disagree with the score.
+      limit: max results (default 20)
+      offset: skip first N results for pagination (default 0)
+
+    Returns {total, offset, limit, results: [{id, display_name, kind,
+    kind_source, tags, human_probability, addresses, name_variants,
+    messages_from, messages_to, first_seen, last_seen}, ...]}.
+    total is 0 when offset is past the last matching row — stop paginating
+    on an empty page rather than comparing offset to total.
+    """
+    db = _get_db(ctx)
+    results, total = db.contacts_search(
+        query=query,
+        kind=kind,
+        tag=tag,
+        min_human_probability=min_human_probability,
+        limit=limit,
+        offset=offset,
+    )
+    return _wrap_response(results, total=total, offset=offset, limit=limit)
+
+
+@mcp.tool()
+@log_tool
+def get_contact(
+    ctx: Context,
+    address: str | None = None,
+    contact_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Return the full contact card for one person/sender.
+
+    Exactly one of address or contact_id is required. Address lookup is
+    case-insensitive (normalized to lowercase).
+
+    Parameters:
+      address: email address to look up (e.g. "bob@corp.com")
+      contact_id: contact UUID from a prior contacts() result
+
+    Returns the contact card including notes, metadata, classification_signals,
+    and classified_at; or null if not found. Raises ValueError if neither or
+    both of address/contact_id are provided.
+    """
+    db = _get_db(ctx)
+    return db.get_contact(address=address, contact_id=contact_id)
+
+
+@mcp.tool()
+@log_tool
+def update_contact(
+    ctx: Context,
+    contact_id: str,
+    kind: str | None = None,
+    tags: list[str] | None = None,
+    notes: str | None = None,
+    display_name: str | None = None,
+) -> dict[str, Any]:
+    """Curation write for a single contact — the only MCP write for contacts.
+
+    Updates only the fields you provide. Setting `kind` marks the contact as
+    manually curated (`kind_source='manual'`) so automated refresh/classify
+    never overrides it. Allowed kinds: "human", "organization", "automated",
+    "mailing_list", "unknown".
+
+    Bulk/maintenance operations (rebuild the address book, reclassify the
+    corpus) live in the `maildb contacts` CLI (`contacts refresh`,
+    `contacts classify`), not here.
+
+    Parameters:
+      contact_id: contact UUID (required)
+      kind: curated kind (optional; setting it also sets kind_source='manual')
+      tags: replace the tags array (optional)
+      notes: free-text notes (optional)
+      display_name: preferred display name (optional)
+
+    Returns the updated full contact card. Raises ValueError on invalid kind
+    or missing contact.
+    """
+    db = _get_db(ctx)
+    return db.update_contact(
+        contact_id=contact_id,
+        kind=kind,
+        tags=tags,
+        notes=notes,
+        display_name=display_name,
+    )
+
+
+@mcp.tool()
+@log_tool
 def accounts(ctx: Context) -> list[dict[str, Any]]:
     """List the email accounts present in the database with email counts.
 

--- a/tests/integration/test_contacts.py
+++ b/tests/integration/test_contacts.py
@@ -1,0 +1,476 @@
+# tests/integration/test_contacts.py
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from maildb.contacts import build_contacts, classify_contact, classify_contacts
+from maildb.ingest.orchestrator import run_pipeline
+
+pytestmark = pytest.mark.integration
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+INSERT_EMAIL = """
+INSERT INTO emails (
+    message_id, thread_id, subject, sender_name, sender_address, sender_domain,
+    recipients, date, body_text, body_html, has_attachment, attachments,
+    labels, in_reply_to, "references", import_id, source_account
+) VALUES (
+    %(message_id)s, %(thread_id)s, %(subject)s, %(sender_name)s, %(sender_address)s,
+    %(sender_domain)s, %(recipients)s, %(date)s, %(body_text)s, NULL,
+    FALSE, '[]'::jsonb, %(labels)s, NULL, %(references)s, %(import_id)s, %(source_account)s
+)
+"""
+
+
+def _clean_contacts(pool) -> None:  # type: ignore[no-untyped-def]
+    with pool.connection() as conn:
+        conn.execute("DELETE FROM contact_addresses")
+        conn.execute("DELETE FROM contacts")
+        conn.commit()
+
+
+def _insert_import(pool, source_account: str = "me@example.com"):  # type: ignore[no-untyped-def]
+    import_id = uuid4()
+    with pool.connection() as conn:
+        conn.execute(
+            """INSERT INTO imports (id, source_account, source_file, status, completed_at)
+               VALUES (%(id)s, %(acct)s, 'seed', 'completed', now())""",
+            {"id": import_id, "acct": source_account},
+        )
+        conn.commit()
+    return import_id
+
+
+def _email(  # type: ignore[no-untyped-def]
+    *,
+    message_id: str,
+    sender_address: str,
+    sender_name: str | None = None,
+    to: list[str] | None = None,
+    date: datetime | None = None,
+    import_id=None,
+    source_account: str = "me@example.com",
+    subject: str = "Test",
+) -> dict:
+    domain = sender_address.split("@")[1] if "@" in sender_address else "example.com"
+    return {
+        "message_id": message_id,
+        "thread_id": message_id,
+        "subject": subject,
+        "sender_name": sender_name,
+        "sender_address": sender_address,
+        "sender_domain": domain,
+        "recipients": json.dumps({"to": to or [], "cc": [], "bcc": []}),
+        "date": date or datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
+        "body_text": "hello",
+        "labels": ["INBOX"],
+        "references": [],
+        "import_id": import_id,
+        "source_account": source_account,
+    }
+
+
+def _seed(pool, emails: list[dict]) -> None:  # type: ignore[no-untyped-def]
+    with pool.connection() as conn:
+        for e in emails:
+            conn.execute(INSERT_EMAIL, e)
+        conn.commit()
+
+
+def test_build_contacts_aggregates_addresses_and_counts(test_pool) -> None:  # type: ignore[no-untyped-def]
+    _clean_contacts(test_pool)
+    import_id = _insert_import(test_pool, "me@example.com")
+    _seed(
+        test_pool,
+        [
+            _email(
+                message_id="c-alice-1@x.com",
+                sender_address="alice@x.com",
+                sender_name="Alice A",
+                to=["me@example.com"],
+                date=datetime(2025, 1, 10, 9, 0, tzinfo=UTC),
+                import_id=import_id,
+            ),
+            _email(
+                message_id="c-alice-2@x.com",
+                sender_address="alice@x.com",
+                sender_name="Alice",
+                to=["me@example.com"],
+                date=datetime(2025, 1, 20, 11, 0, tzinfo=UTC),
+                import_id=import_id,
+            ),
+            _email(
+                message_id="c-me-to-bob@x.com",
+                sender_address="me@example.com",
+                sender_name="Me",
+                to=["bob@y.com"],
+                date=datetime(2025, 1, 15, 12, 0, tzinfo=UTC),
+                import_id=import_id,
+            ),
+        ],
+    )
+
+    result = build_contacts(test_pool)
+    assert result["addresses"] >= 3
+    assert result["contacts_created"] >= 3
+
+    with test_pool.connection() as conn:
+        alice = conn.execute(
+            "SELECT name_variants, messages_from, messages_to, first_seen, last_seen, is_user "
+            "FROM contact_addresses WHERE address = 'alice@x.com'"
+        ).fetchone()
+        assert alice is not None
+        name_variants, messages_from, messages_to, first_seen, last_seen, is_user = alice
+        assert set(name_variants) == {"Alice A", "Alice"}
+        assert messages_from == 2
+        assert messages_to == 0
+        assert first_seen == datetime(2025, 1, 10, 9, 0, tzinfo=UTC)
+        assert last_seen == datetime(2025, 1, 20, 11, 0, tzinfo=UTC)
+        assert is_user is False
+
+        bob = conn.execute(
+            "SELECT messages_from, messages_to, is_user FROM contact_addresses "
+            "WHERE address = 'bob@y.com'"
+        ).fetchone()
+        assert bob is not None
+        assert bob[0] == 0  # messages_from
+        assert bob[1] == 1  # messages_to (from user)
+        assert bob[2] is False
+
+        me = conn.execute(
+            "SELECT is_user, messages_from FROM contact_addresses WHERE address = 'me@example.com'"
+        ).fetchone()
+        assert me is not None
+        assert me[0] is True
+        assert me[1] == 1
+
+        # Singleton contacts: one contact per address
+        cur = conn.execute(
+            """SELECT ca.address, c.id, c.kind, c.display_name
+               FROM contact_addresses ca JOIN contacts c ON c.id = ca.contact_id
+               WHERE ca.address IN ('alice@x.com', 'bob@y.com', 'me@example.com')"""
+        )
+        rows = cur.fetchall()
+        assert len(rows) == 3
+        contact_ids = {r[1] for r in rows}
+        assert len(contact_ids) == 3
+        alice_display = next(r[3] for r in rows if r[0] == "alice@x.com")
+        assert alice_display in ("Alice A", "Alice")
+
+
+def test_build_contacts_preserves_manual_curation(test_pool) -> None:  # type: ignore[no-untyped-def]
+    _clean_contacts(test_pool)
+    import_id = _insert_import(test_pool)
+    _seed(
+        test_pool,
+        [
+            _email(
+                message_id="curate-1@x.com",
+                sender_address="alice@x.com",
+                sender_name="Alice",
+                to=["me@example.com"],
+                date=datetime(2025, 1, 10, tzinfo=UTC),
+                import_id=import_id,
+            ),
+        ],
+    )
+    build_contacts(test_pool)
+
+    with test_pool.connection() as conn:
+        contact_id = conn.execute(
+            "SELECT contact_id FROM contact_addresses WHERE address = 'alice@x.com'"
+        ).fetchone()[0]
+        conn.execute(
+            """UPDATE contacts
+               SET kind = 'human', kind_source = 'manual',
+                   tags = ARRAY['vip'], notes = 'friend',
+                   metadata = '{"curated": true}'::jsonb,
+                   display_name = 'Alice Manual'
+               WHERE id = %(id)s""",
+            {"id": contact_id},
+        )
+        conn.commit()
+
+    # Add another message and refresh
+    _seed(
+        test_pool,
+        [
+            _email(
+                message_id="curate-2@x.com",
+                sender_address="alice@x.com",
+                sender_name="Alice New",
+                to=["me@example.com"],
+                date=datetime(2025, 2, 1, tzinfo=UTC),
+                import_id=import_id,
+            ),
+        ],
+    )
+    build_contacts(test_pool)
+
+    with test_pool.connection() as conn:
+        row = conn.execute(
+            """SELECT c.kind, c.kind_source, c.tags, c.notes, c.metadata, c.display_name,
+                      ca.messages_from, ca.name_variants
+               FROM contacts c
+               JOIN contact_addresses ca ON ca.contact_id = c.id
+               WHERE ca.address = 'alice@x.com'"""
+        ).fetchone()
+        kind, kind_source, tags, notes, metadata, display_name, messages_from, name_variants = row
+        assert kind == "human"
+        assert kind_source == "manual"
+        assert tags == ["vip"]
+        assert notes == "friend"
+        assert metadata == {"curated": True}
+        assert display_name == "Alice Manual"
+        assert messages_from == 2
+        assert set(name_variants) == {"Alice", "Alice New"}
+
+
+def test_classifier_signal_ordering_and_never_sets_kind(test_pool) -> None:  # type: ignore[no-untyped-def]
+    _clean_contacts(test_pool)
+    import_id = _insert_import(test_pool, "me@example.com")
+
+    # noreply bulk: 25 inbound, 0 outbound
+    emails = [
+        _email(
+            message_id=f"noreply-{i}@shop.com",
+            sender_address="noreply@shop.com",
+            sender_name="Shop",
+            to=["me@example.com"],
+            date=datetime(2025, 1, 1 + (i % 28), tzinfo=UTC),
+            import_id=import_id,
+        )
+        for i in range(25)
+    ]
+    # Bidirectional personal-named contact
+    emails.extend(
+        [
+            _email(
+                message_id="person-from@p.com",
+                sender_address="jane@p.com",
+                sender_name="Jane Smith",
+                to=["me@example.com"],
+                date=datetime(2025, 3, 1, tzinfo=UTC),
+                import_id=import_id,
+            ),
+            _email(
+                message_id="person-to@p.com",
+                sender_address="me@example.com",
+                sender_name="Me",
+                to=["jane@p.com"],
+                date=datetime(2025, 3, 2, tzinfo=UTC),
+                import_id=import_id,
+            ),
+            # Unknown one-message sender
+            _email(
+                message_id="unknown-1@z.com",
+                sender_address="stranger@z.com",
+                sender_name="x",
+                to=["me@example.com"],
+                date=datetime(2025, 4, 1, tzinfo=UTC),
+                import_id=import_id,
+            ),
+        ]
+    )
+    _seed(test_pool, emails)
+    build_contacts(test_pool)
+    n = classify_contacts(test_pool)
+    assert n >= 3
+
+    with test_pool.connection() as conn:
+        noreply = conn.execute(
+            """SELECT c.human_probability, c.classification_signals, c.classified_at, c.kind
+               FROM contacts c JOIN contact_addresses ca ON ca.contact_id = c.id
+               WHERE ca.address = 'noreply@shop.com'"""
+        ).fetchone()
+        assert noreply[0] < 0.2
+        assert "automated_pattern" in noreply[1]
+        assert "one_way_bulk" in noreply[1]
+        assert noreply[2] is not None
+        assert noreply[3] == "unknown"
+
+        person = conn.execute(
+            """SELECT c.human_probability, c.classification_signals, c.kind
+               FROM contacts c JOIN contact_addresses ca ON ca.contact_id = c.id
+               WHERE ca.address = 'jane@p.com'"""
+        ).fetchone()
+        assert person[0] > 0.85
+        assert "bidirectional" in person[1]
+        assert "personal_name" in person[1]
+        assert person[2] == "unknown"
+
+        unknown = conn.execute(
+            """SELECT c.human_probability, c.classification_signals, c.kind
+               FROM contacts c JOIN contact_addresses ca ON ca.contact_id = c.id
+               WHERE ca.address = 'stranger@z.com'"""
+        ).fetchone()
+        assert 0.4 <= unknown[0] <= 0.7
+        assert unknown[2] == "unknown"
+
+        user = conn.execute(
+            """SELECT c.human_probability
+               FROM contacts c JOIN contact_addresses ca ON ca.contact_id = c.id
+               WHERE ca.address = 'me@example.com'"""
+        ).fetchone()
+        assert user[0] is None
+
+
+def test_classify_contact_matches_batch(test_pool) -> None:  # type: ignore[no-untyped-def]
+    _clean_contacts(test_pool)
+    import_id = _insert_import(test_pool)
+    _seed(
+        test_pool,
+        [
+            _email(
+                message_id="single-1@x.com",
+                sender_address="alice@x.com",
+                sender_name="Alice Smith",
+                to=["me@example.com"],
+                import_id=import_id,
+            ),
+            _email(
+                message_id="single-2@x.com",
+                sender_address="me@example.com",
+                sender_name="Me",
+                to=["alice@x.com"],
+                import_id=import_id,
+            ),
+        ],
+    )
+    build_contacts(test_pool)
+    with test_pool.connection() as conn:
+        contact_id = conn.execute(
+            "SELECT contact_id FROM contact_addresses WHERE address = 'alice@x.com'"
+        ).fetchone()[0]
+
+    classify_contacts(test_pool, contact_ids=[contact_id])
+    with test_pool.connection() as conn:
+        batch_prob = conn.execute(
+            "SELECT human_probability FROM contacts WHERE id = %(id)s",
+            {"id": contact_id},
+        ).fetchone()[0]
+        # Clear so single path rewrites
+        conn.execute(
+            """UPDATE contacts
+               SET human_probability = NULL, classification_signals = NULL, classified_at = NULL
+               WHERE id = %(id)s""",
+            {"id": contact_id},
+        )
+        conn.commit()
+
+    single_prob = classify_contact(test_pool, contact_id)
+    assert single_prob == pytest.approx(batch_prob)
+    with test_pool.connection() as conn:
+        row = conn.execute(
+            "SELECT human_probability FROM contacts WHERE id = %(id)s",
+            {"id": contact_id},
+        ).fetchone()
+        assert row[0] == pytest.approx(batch_prob)
+
+
+def test_build_and_classify_idempotent(test_pool) -> None:  # type: ignore[no-untyped-def]
+    _clean_contacts(test_pool)
+    import_id = _insert_import(test_pool)
+    _seed(
+        test_pool,
+        [
+            _email(
+                message_id="idemp-1@x.com",
+                sender_address="alice@x.com",
+                sender_name="Alice Smith",
+                to=["me@example.com"],
+                import_id=import_id,
+            ),
+            _email(
+                message_id="idemp-2@x.com",
+                sender_address="me@example.com",
+                sender_name="Me",
+                to=["alice@x.com"],
+                import_id=import_id,
+            ),
+        ],
+    )
+    r1 = build_contacts(test_pool)
+    c1 = classify_contacts(test_pool)
+    with test_pool.connection() as conn:
+        addr_count_1 = conn.execute("SELECT count(*) FROM contact_addresses").fetchone()[0]
+        contact_count_1 = conn.execute("SELECT count(*) FROM contacts").fetchone()[0]
+        probs_1 = {
+            row[0]: row[1]
+            for row in conn.execute(
+                "SELECT ca.address, c.human_probability "
+                "FROM contact_addresses ca JOIN contacts c ON c.id = ca.contact_id"
+            ).fetchall()
+        }
+
+    r2 = build_contacts(test_pool)
+    c2 = classify_contacts(test_pool)
+    with test_pool.connection() as conn:
+        addr_count_2 = conn.execute("SELECT count(*) FROM contact_addresses").fetchone()[0]
+        contact_count_2 = conn.execute("SELECT count(*) FROM contacts").fetchone()[0]
+        probs_2 = {
+            row[0]: row[1]
+            for row in conn.execute(
+                "SELECT ca.address, c.human_probability "
+                "FROM contact_addresses ca JOIN contacts c ON c.id = ca.contact_id"
+            ).fetchall()
+        }
+
+    assert addr_count_1 == addr_count_2
+    assert contact_count_1 == contact_count_2
+    assert r2["contacts_created"] == 0
+    assert c1 == c2
+    assert probs_1 == probs_2
+    assert r1["addresses"] == r2["addresses"]
+
+
+def test_orchestrator_builds_and_classifies_contacts(test_pool, test_settings, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    _clean_contacts(test_pool)
+    run_pipeline(
+        mbox_path=FIXTURES / "sample.mbox",
+        database_url=test_settings.database_url,
+        attachment_dir=tmp_path / "attachments",
+        tmp_dir=tmp_path / "chunks",
+        chunk_size_bytes=50 * 1024 * 1024,
+        parse_workers=2,
+        skip_embed=True,
+        source_account="test@example.com",
+    )
+    with test_pool.connection() as conn:
+        cur = conn.execute("SELECT count(*) FROM contact_addresses")
+        assert cur.fetchone()[0] > 0
+        # Fixture senders should be present
+        for addr in (
+            "alice@example.com",
+            "bob@example.com",
+            "carol@example.com",
+            "dave@example.com",
+            "noreply@notifications.example.com",
+        ):
+            row = conn.execute(
+                """SELECT c.human_probability, c.kind
+                   FROM contact_addresses ca
+                   JOIN contacts c ON c.id = ca.contact_id
+                   WHERE ca.address = %(addr)s""",
+                {"addr": addr},
+            ).fetchone()
+            assert row is not None, f"missing contact for {addr}"
+            assert row[0] is not None, f"missing probability for {addr}"
+            assert row[1] == "unknown"
+
+        user = conn.execute(
+            """SELECT c.human_probability
+               FROM contact_addresses ca
+               JOIN contacts c ON c.id = ca.contact_id
+               WHERE ca.address = 'test@example.com'"""
+        ).fetchone()
+        # User identity contact may or may not exist depending on whether the
+        # address appears in the mbox; if it does, probability stays NULL.
+        if user is not None:
+            assert user[0] is None

--- a/tests/integration/test_maildb.py
+++ b/tests/integration/test_maildb.py
@@ -10,6 +10,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from maildb.config import Settings
+from maildb.contacts import build_contacts, classify_contacts
 from maildb.maildb import MailDB
 from maildb.models import Email, SearchResult
 
@@ -1834,3 +1835,297 @@ def test_effective_user_emails_dedupes_overlap(test_pool, test_settings) -> None
     db = MailDB._from_pool(test_pool, config=config)
     identities = db._identity_addresses(None)
     assert identities == ["a@example.com"]
+
+
+# ---------------------------------------------------------------------------
+# Contacts address-book methods (contacts_search / get_contact / update_contact)
+# ---------------------------------------------------------------------------
+
+
+def _clean_contacts(pool) -> None:  # type: ignore[no-untyped-def]
+    with pool.connection() as conn:
+        conn.execute("DELETE FROM contact_addresses")
+        conn.execute("DELETE FROM contacts")
+        conn.commit()
+
+
+def _contacts_insert_import(pool, source_account: str = "me@example.com"):  # type: ignore[no-untyped-def]
+    import_id = uuid4()
+    with pool.connection() as conn:
+        conn.execute(
+            """INSERT INTO imports (id, source_account, source_file, status, completed_at)
+               VALUES (%(id)s, %(acct)s, 'seed', 'completed', now())""",
+            {"id": import_id, "acct": source_account},
+        )
+        conn.commit()
+    return import_id
+
+
+def _contacts_email(  # type: ignore[no-untyped-def]
+    *,
+    message_id: str,
+    sender_address: str,
+    sender_name: str | None = None,
+    to: list[str] | None = None,
+    date: datetime | None = None,
+    import_id=None,
+    source_account: str = "me@example.com",
+    subject: str = "Test",
+) -> dict:
+    domain = sender_address.split("@")[1] if "@" in sender_address else "example.com"
+    return {
+        "message_id": message_id,
+        "thread_id": message_id,
+        "subject": subject,
+        "sender_name": sender_name,
+        "sender_address": sender_address,
+        "sender_domain": domain,
+        "recipients": json.dumps({"to": to or [], "cc": [], "bcc": []}),
+        "date": date or datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
+        "body_text": "hello",
+        "body_html": None,
+        "has_attachment": False,
+        "attachments": json.dumps([]),
+        "labels": ["INBOX"],
+        "in_reply_to": None,
+        "references": [],
+        "import_id": import_id,
+        "source_account": source_account,
+    }
+
+
+def _contacts_seed(pool, emails: list[dict]) -> None:  # type: ignore[no-untyped-def]
+    insert = """
+    INSERT INTO emails (
+        message_id, thread_id, subject, sender_name, sender_address, sender_domain,
+        recipients, date, body_text, body_html, has_attachment, attachments,
+        labels, in_reply_to, "references", import_id, source_account
+    ) VALUES (
+        %(message_id)s, %(thread_id)s, %(subject)s, %(sender_name)s, %(sender_address)s,
+        %(sender_domain)s, %(recipients)s, %(date)s, %(body_text)s, %(body_html)s,
+        %(has_attachment)s, %(attachments)s::jsonb, %(labels)s, %(in_reply_to)s,
+        %(references)s, %(import_id)s, %(source_account)s
+    )
+    """
+    with pool.connection() as conn:
+        for e in emails:
+            conn.execute(insert, e)
+        conn.commit()
+
+
+def _seed_contacts_corpus(test_pool):  # type: ignore[no-untyped-def]
+    """Seed a multi-contact corpus and run build_contacts. Returns MailDB."""
+    _clean_contacts(test_pool)
+    import_id = _contacts_insert_import(test_pool, "me@example.com")
+    # Alice: 3 inbound messages (highest volume)
+    emails = [
+        _contacts_email(
+            message_id=f"alice-{i}@x.com",
+            sender_address="alice@x.com",
+            sender_name="Alice Wonder",
+            to=["me@example.com"],
+            date=datetime(2025, 1, 10 + i, tzinfo=UTC),
+            import_id=import_id,
+        )
+        for i in range(3)
+    ]
+    # Bob: 1 inbound
+    emails.append(
+        _contacts_email(
+            message_id="bob-1@y.com",
+            sender_address="bob@y.com",
+            sender_name="Bob Builder",
+            to=["me@example.com"],
+            date=datetime(2025, 2, 1, tzinfo=UTC),
+            import_id=import_id,
+        )
+    )
+    # Carol: user wrote to her once (messages_to only)
+    emails.append(
+        _contacts_email(
+            message_id="me-to-carol@z.com",
+            sender_address="me@example.com",
+            sender_name="Me",
+            to=["carol@z.com"],
+            date=datetime(2025, 1, 20, tzinfo=UTC),
+            import_id=import_id,
+        )
+    )
+    # noreply bulk: 2 inbound
+    emails.extend(
+        [
+            _contacts_email(
+                message_id=f"noreply-{i}@shop.com",
+                sender_address="noreply@shop.com",
+                sender_name="Shop",
+                to=["me@example.com"],
+                date=datetime(2025, 1, 5 + i, tzinfo=UTC),
+                import_id=import_id,
+            )
+            for i in range(2)
+        ]
+    )
+    _contacts_seed(test_pool, emails)
+    build_contacts(test_pool)
+    classify_contacts(test_pool)
+    return MailDB._from_pool(test_pool)
+
+
+def test_contacts_search_by_name_fragment(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = _seed_contacts_corpus(test_pool)
+    results, total = db.contacts_search(query="Alice")
+    assert total >= 1
+    assert any("alice@x.com" in (r["addresses"] or []) for r in results)
+    alice = next(r for r in results if "alice@x.com" in r["addresses"])
+    assert alice["display_name"] is not None
+    assert "Alice" in (alice["display_name"] or "") or any(
+        "Alice" in v for v in (alice["name_variants"] or [])
+    )
+
+
+def test_contacts_search_by_address_fragment(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = _seed_contacts_corpus(test_pool)
+    results, total = db.contacts_search(query="bob@y")
+    assert total == 1
+    assert results[0]["addresses"] == ["bob@y.com"]
+
+
+def test_contacts_search_by_tag(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = _seed_contacts_corpus(test_pool)
+    # Tag alice as vip
+    with test_pool.connection() as conn:
+        contact_id = conn.execute(
+            "SELECT contact_id FROM contact_addresses WHERE address = 'alice@x.com'"
+        ).fetchone()[0]
+        conn.execute(
+            "UPDATE contacts SET tags = ARRAY['vip'] WHERE id = %(id)s",
+            {"id": contact_id},
+        )
+        conn.commit()
+
+    results, total = db.contacts_search(tag="vip")
+    assert total == 1
+    assert results[0]["addresses"] == ["alice@x.com"]
+    assert "vip" in results[0]["tags"]
+
+
+def test_contacts_search_by_min_human_probability(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = _seed_contacts_corpus(test_pool)
+    # All classified contacts have some probability; high threshold should
+    # prefer Alice (personal name + inbound) over noreply.
+    results, total = db.contacts_search(min_human_probability=0.5)
+    addresses = {a for r in results for a in r["addresses"]}
+    assert "noreply@shop.com" not in addresses or all(
+        r["human_probability"] is not None and r["human_probability"] >= 0.5 for r in results
+    )
+    assert all(
+        r["human_probability"] is not None and r["human_probability"] >= 0.5 for r in results
+    )
+    assert total == len(results) or total >= len(results)
+
+
+def test_contacts_search_excludes_user_only(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = _seed_contacts_corpus(test_pool)
+    results, _ = db.contacts_search(limit=100)
+    all_addresses = {a for r in results for a in r["addresses"]}
+    assert "me@example.com" not in all_addresses
+
+
+def test_contacts_search_deterministic_ordering(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = _seed_contacts_corpus(test_pool)
+    results, total = db.contacts_search(limit=100)
+    assert total == len(results)
+    # Ordered by (messages_from + messages_to) DESC
+    volumes = [r["messages_from"] + r["messages_to"] for r in results]
+    assert volumes == sorted(volumes, reverse=True)
+    # Alice (3) should rank above Bob (1)
+    alice_idx = next(i for i, r in enumerate(results) if "alice@x.com" in r["addresses"])
+    bob_idx = next(i for i, r in enumerate(results) if "bob@y.com" in r["addresses"])
+    assert alice_idx < bob_idx
+
+
+def test_get_contact_by_address_and_id(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = _seed_contacts_corpus(test_pool)
+    by_addr = db.get_contact(address="Alice@X.com")  # normalized lowercase
+    assert by_addr is not None
+    assert "alice@x.com" in by_addr["addresses"]
+    assert "notes" in by_addr
+    assert "metadata" in by_addr
+    assert "classification_signals" in by_addr
+    assert "classified_at" in by_addr
+
+    by_id = db.get_contact(contact_id=by_addr["id"])
+    assert by_id is not None
+    assert by_id["id"] == by_addr["id"]
+    assert by_id["addresses"] == by_addr["addresses"]
+
+
+def test_get_contact_exactly_one_arg(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = MailDB._from_pool(test_pool)
+    with pytest.raises(ValueError, match=r"[Ee]xactly one"):
+        db.get_contact()
+    with pytest.raises(ValueError, match=r"[Ee]xactly one"):
+        db.get_contact(address="a@b.com", contact_id=uuid4())
+
+
+def test_get_contact_not_found(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = MailDB._from_pool(test_pool)
+    assert db.get_contact(address="nobody@nowhere.com") is None
+    assert db.get_contact(contact_id=uuid4()) is None
+
+
+def test_update_contact_sets_fields_and_kind_source(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = _seed_contacts_corpus(test_pool)
+    card = db.get_contact(address="alice@x.com")
+    assert card is not None
+    updated = db.update_contact(
+        contact_id=card["id"],
+        kind="human",
+        tags=["vip", "friend"],
+        notes="college roommate",
+        display_name="Alice Manual",
+    )
+    assert updated["kind"] == "human"
+    assert updated["kind_source"] == "manual"
+    assert updated["tags"] == ["vip", "friend"]
+    assert updated["notes"] == "college roommate"
+    assert updated["display_name"] == "Alice Manual"
+
+
+def test_update_contact_rejects_bad_kind(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = _seed_contacts_corpus(test_pool)
+    card = db.get_contact(address="alice@x.com")
+    assert card is not None
+    with pytest.raises(ValueError, match="kind"):
+        db.update_contact(contact_id=card["id"], kind="robot")
+
+
+def test_update_contact_missing_raises(test_pool) -> None:  # type: ignore[no-untyped-def]
+    db = MailDB._from_pool(test_pool)
+    with pytest.raises(ValueError, match=r"does not exist"):
+        db.update_contact(contact_id=uuid4(), kind="human")
+
+
+def test_update_contact_preserved_across_build_and_classify(test_pool) -> None:  # type: ignore[no-untyped-def]
+    """Critical invariant: manual curation survives build_contacts + classify_contacts."""
+    db = _seed_contacts_corpus(test_pool)
+    card = db.get_contact(address="alice@x.com")
+    assert card is not None
+    db.update_contact(
+        contact_id=card["id"],
+        kind="human",
+        tags=["vip"],
+        notes="friend",
+        display_name="Alice Curated",
+    )
+
+    build_contacts(test_pool)
+    classify_contacts(test_pool)
+
+    after = db.get_contact(address="alice@x.com")
+    assert after is not None
+    assert after["kind"] == "human"
+    assert after["kind_source"] == "manual"
+    assert after["tags"] == ["vip"]
+    assert after["notes"] == "friend"
+    assert after["display_name"] == "Alice Curated"

--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -57,6 +57,27 @@ def test_run_pipeline_split_and_parse(test_pool, test_settings, tmp_path):
             {"ids": ["msg001@example.com", "msg002@example.com", "msg003@example.com"]},
         )
         assert cur.fetchone()[0] == 1
+        # Contacts subsystem hook: addresses from the fixture mbox are materialised
+        # and classified (human_probability set; kind left as default).
+        cur = conn.execute("SELECT count(*) FROM contact_addresses")
+        assert cur.fetchone()[0] > 0
+        for addr in (
+            "alice@example.com",
+            "bob@example.com",
+            "carol@example.com",
+            "dave@example.com",
+            "noreply@notifications.example.com",
+        ):
+            row = conn.execute(
+                """SELECT c.human_probability, c.kind
+                   FROM contact_addresses ca
+                   JOIN contacts c ON c.id = ca.contact_id
+                   WHERE ca.address = %(addr)s""",
+                {"addr": addr},
+            ).fetchone()
+            assert row is not None, f"missing contact for {addr}"
+            assert row[0] is not None, f"missing probability for {addr}"
+            assert row[1] == "unknown"
 
 
 def test_run_pipeline_reclaims_stale_parse_task(test_pool, test_settings, tmp_path):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -5,6 +5,8 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pytest
+
 from maildb import server
 from maildb.models import (
     AccountSummary,
@@ -380,3 +382,115 @@ def test_search_all_passes_recipient_count_filters_through() -> None:
     assert kwargs["max_cc"] == 0
     assert kwargs["max_recipients"] == 3
     assert kwargs["direct_only"] is True
+
+
+def test_contacts_tool_passes_params_and_uses_envelope() -> None:
+    mock_db = MagicMock()
+    mock_db.contacts_search.return_value = (
+        [
+            {
+                "id": "c1",
+                "display_name": "Alice",
+                "kind": "unknown",
+                "kind_source": "heuristic",
+                "tags": [],
+                "human_probability": 0.7,
+                "addresses": ["alice@x.com"],
+                "name_variants": ["Alice"],
+                "messages_from": 3,
+                "messages_to": 0,
+                "first_seen": None,
+                "last_seen": None,
+            }
+        ],
+        1,
+    )
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context.db = mock_db
+
+    result = server.contacts(
+        ctx,
+        query="Alice",
+        kind="human",
+        tag="vip",
+        min_human_probability=0.5,
+        limit=10,
+        offset=5,
+    )
+    kwargs = mock_db.contacts_search.call_args.kwargs
+    assert kwargs["query"] == "Alice"
+    assert kwargs["kind"] == "human"
+    assert kwargs["tag"] == "vip"
+    assert kwargs["min_human_probability"] == 0.5
+    assert kwargs["limit"] == 10
+    assert kwargs["offset"] == 5
+    assert result["total"] == 1
+    assert result["offset"] == 5
+    assert result["limit"] == 10
+    assert len(result["results"]) == 1
+    assert result["results"][0]["display_name"] == "Alice"
+
+
+def test_get_contact_tool_passes_params() -> None:
+    mock_db = MagicMock()
+    mock_db.get_contact.return_value = {
+        "id": "c1",
+        "display_name": "Alice",
+        "notes": None,
+        "metadata": {},
+        "classification_signals": None,
+        "classified_at": None,
+        "addresses": ["alice@x.com"],
+    }
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context.db = mock_db
+
+    result = server.get_contact(ctx, address="alice@x.com")
+    mock_db.get_contact.assert_called_once_with(address="alice@x.com", contact_id=None)
+    assert result is not None
+    assert result["id"] == "c1"
+
+    mock_db.reset_mock()
+    mock_db.get_contact.return_value = {"id": "c1"}
+    server.get_contact(ctx, contact_id="c1")
+    mock_db.get_contact.assert_called_once_with(address=None, contact_id="c1")
+
+
+def test_update_contact_tool_passes_params() -> None:
+    mock_db = MagicMock()
+    mock_db.update_contact.return_value = {
+        "id": "c1",
+        "kind": "human",
+        "kind_source": "manual",
+        "tags": ["vip"],
+        "notes": "n",
+        "display_name": "Alice",
+    }
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context.db = mock_db
+
+    result = server.update_contact(
+        ctx,
+        contact_id="c1",
+        kind="human",
+        tags=["vip"],
+        notes="n",
+        display_name="Alice",
+    )
+    kwargs = mock_db.update_contact.call_args.kwargs
+    assert kwargs["contact_id"] == "c1"
+    assert kwargs["kind"] == "human"
+    assert kwargs["tags"] == ["vip"]
+    assert kwargs["notes"] == "n"
+    assert kwargs["display_name"] == "Alice"
+    assert result["kind_source"] == "manual"
+
+
+def test_update_contact_tool_surfaces_value_error() -> None:
+    mock_db = MagicMock()
+    mock_db.update_contact.side_effect = ValueError("Invalid kind 'robot'")
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context.db = mock_db
+
+    with pytest.raises(ValueError, match="Invalid kind"):
+        server.update_contact(ctx, contact_id="c1", kind="robot")


### PR DESCRIPTION
## Objective

Phase 1 of the contacts subsystem (design agreed in-session): an entity-level address book materialized from the archive; an automated probability-of-human classification (batch + per-contact incremental) with explainable signals; final categorization deliberately manual. CLI owns batch/maintenance writes; MCP gets read tools + a single curation write (task 2, pending).

## Tasks on this PR

- [x] Task 1: schema (contacts, contact_addresses), build_contacts (full/import-scoped), classify_contacts/classify_contact (probability + signals, never kind), orchestrator hook, `maildb contacts refresh|classify`
- [ ] Task 1 revision: set-based apply paths (see review)
- [ ] Task 2: MCP `contacts()`/`get_contact`/`update_contact` (curation-only write) + DESIGN.md

## Provenance

Implementer: Grok Build CLI, `grok-4.5` @ `max`, cheap-coder workflow. Architecture, spec, review: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)