### PR TITLE
perf(contacts): one-pass full-build aggregation

### DIFF
--- a/src/maildb/contacts.py
+++ b/src/maildb/contacts.py
@@ -76,56 +76,13 @@ def build_contacts(
 
     With ``import_id``, only addresses appearing in that import are touched;
     stats for those addresses are recomputed from the full corpus. Without,
-    the whole corpus is processed.
+    the whole corpus is processed via single-pass aggregation (no per-address
+    containment probes).
 
     Returns ``{"addresses": n, "contacts_created": n, "contact_ids": [...]}``.
     """
     user_ids = _user_identities(pool)
     with pool.connection() as conn:
-        # Addresses touched by the (scoped) source rows.
-        cur = conn.execute(
-            """
-            WITH scoped AS (
-                SELECT sender_address, recipients
-                  FROM emails
-                 WHERE (%(import_id)s::uuid IS NULL OR import_id = %(import_id)s::uuid)
-            ),
-            from_addrs AS (
-                SELECT lower(btrim(sender_address)) AS address
-                  FROM scoped
-                 WHERE sender_address IS NOT NULL AND btrim(sender_address) <> ''
-            ),
-            to_addrs AS (
-                SELECT lower(btrim(r.addr)) AS address
-                  FROM scoped e
-                  CROSS JOIN LATERAL (
-                      SELECT jsonb_array_elements_text(
-                                 COALESCE(e.recipients->'to', '[]'::jsonb)
-                             ) AS addr
-                      UNION ALL
-                      SELECT jsonb_array_elements_text(
-                                 COALESCE(e.recipients->'cc', '[]'::jsonb)
-                             )
-                      UNION ALL
-                      SELECT jsonb_array_elements_text(
-                                 COALESCE(e.recipients->'bcc', '[]'::jsonb)
-                             )
-                  ) r
-                 WHERE e.recipients IS NOT NULL
-                   AND r.addr IS NOT NULL
-                   AND btrim(r.addr) <> ''
-            )
-            SELECT DISTINCT address FROM from_addrs
-            UNION
-            SELECT DISTINCT address FROM to_addrs
-            """,
-            {"import_id": import_id},
-        )
-        touched = [row[0] for row in cur.fetchall()]
-        if not touched:
-            return {"addresses": 0, "contacts_created": 0, "contact_ids": []}
-
-        # Stage full-corpus stats for touched addresses, then apply set-based.
         conn.execute(
             """CREATE TEMP TABLE contacts_staging (
                    address text PRIMARY KEY,
@@ -139,153 +96,17 @@ def build_contacts(
                    messages_to int
                ) ON COMMIT DROP"""
         )
-        cur = conn.execute(
-            """
-            INSERT INTO contacts_staging (
-                address, top_name, name_variants, is_user,
-                first_seen, last_seen, messages_from, messages_to
-            )
-            WITH touched AS (
-                SELECT unnest(%(addrs)s::text[]) AS address
-            ),
-            sender_names AS (
-                SELECT lower(btrim(e.sender_address)) AS address,
-                       e.sender_name,
-                       count(*) AS cnt
-                  FROM emails e
-                  JOIN touched t ON lower(btrim(e.sender_address)) = t.address
-                 WHERE e.sender_name IS NOT NULL AND btrim(e.sender_name) <> ''
-                 GROUP BY 1, 2
-            ),
-            name_variants AS (
-                SELECT address,
-                       array_agg(sender_name ORDER BY sender_name) AS name_variants
-                  FROM sender_names
-                 GROUP BY address
-            ),
-            top_names AS (
-                SELECT DISTINCT ON (address) address, sender_name AS top_name
-                  FROM sender_names
-                 ORDER BY address, cnt DESC, sender_name
-            ),
-            from_stats AS (
-                SELECT lower(btrim(e.sender_address)) AS address,
-                       count(*)::int AS messages_from,
-                       min(e.date) AS first_seen,
-                       max(e.date) AS last_seen
-                  FROM emails e
-                  JOIN touched t ON lower(btrim(e.sender_address)) = t.address
-                 GROUP BY 1
-            ),
-            to_stats AS (
-                SELECT t.address,
-                       count(*)::int AS messages_to
-                  FROM touched t
-                  JOIN emails e ON (
-                      lower(btrim(e.sender_address)) = ANY(%(user_emails)s)
-                      AND (
-                          e.recipients @> jsonb_build_object(
-                              'to', to_jsonb(ARRAY[t.address])
-                          )
-                          OR e.recipients @> jsonb_build_object(
-                              'cc', to_jsonb(ARRAY[t.address])
-                          )
-                          OR e.recipients @> jsonb_build_object(
-                              'bcc', to_jsonb(ARRAY[t.address])
-                          )
-                      )
-                  )
-                 GROUP BY t.address
-            ),
-            date_bounds AS (
-                -- first/last seen across both sent and received for recipient-only addrs
-                SELECT t.address,
-                       least(fs.first_seen, rs.first_seen) AS first_seen,
-                       greatest(fs.last_seen, rs.last_seen) AS last_seen
-                  FROM touched t
-                  LEFT JOIN from_stats fs ON fs.address = t.address
-                  LEFT JOIN (
-                      SELECT t2.address,
-                             min(e.date) AS first_seen,
-                             max(e.date) AS last_seen
-                        FROM touched t2
-                        JOIN emails e ON (
-                            e.recipients @> jsonb_build_object(
-                                'to', to_jsonb(ARRAY[t2.address])
-                            )
-                            OR e.recipients @> jsonb_build_object(
-                                'cc', to_jsonb(ARRAY[t2.address])
-                            )
-                            OR e.recipients @> jsonb_build_object(
-                                'bcc', to_jsonb(ARRAY[t2.address])
-                            )
-                        )
-                       GROUP BY t2.address
-                  ) rs ON rs.address = t.address
-            )
-            SELECT t.address,
-                   tn.top_name,
-                   coalesce(nv.name_variants, '{}'::text[]) AS name_variants,
-                   (t.address = ANY(%(user_emails)s)) AS is_user,
-                   db.first_seen,
-                   db.last_seen,
-                   coalesce(fs.messages_from, 0) AS messages_from,
-                   coalesce(ts.messages_to, 0) AS messages_to
-              FROM touched t
-              LEFT JOIN name_variants nv ON nv.address = t.address
-              LEFT JOIN top_names tn ON tn.address = t.address
-              LEFT JOIN from_stats fs ON fs.address = t.address
-              LEFT JOIN to_stats ts ON ts.address = t.address
-              LEFT JOIN date_bounds db ON db.address = t.address
-            """,
-            {"addrs": touched, "user_emails": user_ids},
-        )
-        addresses_count = max(cur.rowcount, 0)
 
-        # (c) refresh stats on existing address rows first
-        conn.execute(
-            """UPDATE contact_addresses ca
-                  SET name_variants = s.name_variants,
-                      is_user = s.is_user,
-                      first_seen = s.first_seen,
-                      last_seen = s.last_seen,
-                      messages_from = s.messages_from,
-                      messages_to = s.messages_to
-                 FROM contacts_staging s
-                WHERE ca.address = s.address"""
-        )
-        # (a) new singleton contacts for addresses not yet in contact_addresses
-        cur = conn.execute(
-            """INSERT INTO contacts (id, display_name)
-               SELECT s.new_contact_id, s.top_name
-                 FROM contacts_staging s
-                WHERE NOT EXISTS (
-                          SELECT 1 FROM contact_addresses ca
-                           WHERE ca.address = s.address
-                      )"""
-        )
-        contacts_created = max(cur.rowcount, 0)
-        # (b) matching address rows for those new contacts
-        conn.execute(
-            """INSERT INTO contact_addresses (
-                   address, contact_id, name_variants, is_user,
-                   first_seen, last_seen, messages_from, messages_to
-               )
-               SELECT s.address, s.new_contact_id, s.name_variants, s.is_user,
-                      s.first_seen, s.last_seen, s.messages_from, s.messages_to
-                 FROM contacts_staging s
-                WHERE NOT EXISTS (
-                          SELECT 1 FROM contact_addresses ca
-                           WHERE ca.address = s.address
-                      )"""
-        )
+        if import_id is None:
+            addresses_count = _populate_staging_full(conn, user_ids)
+        else:
+            addresses_count = _populate_staging_incremental(conn, user_ids, import_id)
 
-        cur = conn.execute(
-            """SELECT DISTINCT ca.contact_id
-                 FROM contacts_staging s
-                 JOIN contact_addresses ca ON ca.address = s.address"""
-        )
-        contact_ids = [row[0] for row in cur.fetchall()]
+        if addresses_count == 0:
+            conn.commit()
+            return {"addresses": 0, "contacts_created": 0, "contact_ids": []}
+
+        contacts_created, contact_ids = _apply_contacts_staging(conn)
         conn.commit()
 
     logger.info(
@@ -299,6 +120,296 @@ def build_contacts(
         "contacts_created": contacts_created,
         "contact_ids": contact_ids,
     }
+
+
+def _populate_staging_full(conn: Any, user_ids: list[str]) -> int:
+    """Full-corpus staging via single scans (no per-address probing)."""
+    cur = conn.execute(
+        """
+        INSERT INTO contacts_staging (
+            address, top_name, name_variants, is_user,
+            first_seen, last_seen, messages_from, messages_to
+        )
+        WITH sender_names AS (
+            SELECT lower(btrim(e.sender_address)) AS address,
+                   e.sender_name,
+                   count(*) AS cnt
+              FROM emails e
+             WHERE e.sender_address IS NOT NULL AND btrim(e.sender_address) <> ''
+               AND e.sender_name IS NOT NULL AND btrim(e.sender_name) <> ''
+             GROUP BY 1, 2
+        ),
+        name_variants AS (
+            SELECT address,
+                   array_agg(sender_name ORDER BY sender_name) AS name_variants
+              FROM sender_names
+             GROUP BY address
+        ),
+        top_names AS (
+            SELECT DISTINCT ON (address) address, sender_name AS top_name
+              FROM sender_names
+             ORDER BY address, cnt DESC, sender_name
+        ),
+        from_stats AS (
+            SELECT lower(btrim(e.sender_address)) AS address,
+                   count(*)::int AS messages_from,
+                   min(e.date) AS first_seen,
+                   max(e.date) AS last_seen
+              FROM emails e
+             WHERE e.sender_address IS NOT NULL AND btrim(e.sender_address) <> ''
+             GROUP BY 1
+        ),
+        recipient_rows AS (
+            -- Deduplicate to one row per (email, address) so multi-arm hits
+            -- (to AND cc of the same email) count as a single messages_to.
+            SELECT DISTINCT
+                   e.id AS email_id,
+                   lower(btrim(r.addr)) AS address,
+                   e.date,
+                   (lower(btrim(e.sender_address)) = ANY(%(user_emails)s)) AS from_user
+              FROM emails e
+              CROSS JOIN LATERAL (
+                  SELECT jsonb_array_elements_text(
+                             coalesce(e.recipients->'to', '[]'::jsonb)
+                         ) AS addr
+                  UNION ALL
+                  SELECT jsonb_array_elements_text(
+                             coalesce(e.recipients->'cc', '[]'::jsonb)
+                         )
+                  UNION ALL
+                  SELECT jsonb_array_elements_text(
+                             coalesce(e.recipients->'bcc', '[]'::jsonb)
+                         )
+              ) r
+             WHERE r.addr IS NOT NULL AND btrim(r.addr) <> ''
+        ),
+        to_stats AS (
+            SELECT address,
+                   count(*) FILTER (WHERE from_user)::int AS messages_to,
+                   min(date) AS first_seen,
+                   max(date) AS last_seen
+              FROM recipient_rows
+             GROUP BY address
+        )
+        SELECT coalesce(fs.address, ts.address) AS address,
+               tn.top_name,
+               coalesce(nv.name_variants, '{}'::text[]) AS name_variants,
+               (coalesce(fs.address, ts.address) = ANY(%(user_emails)s)) AS is_user,
+               least(fs.first_seen, ts.first_seen) AS first_seen,
+               greatest(fs.last_seen, ts.last_seen) AS last_seen,
+               coalesce(fs.messages_from, 0) AS messages_from,
+               coalesce(ts.messages_to, 0) AS messages_to
+          FROM from_stats fs
+          FULL OUTER JOIN to_stats ts ON ts.address = fs.address
+          LEFT JOIN name_variants nv
+            ON nv.address = coalesce(fs.address, ts.address)
+          LEFT JOIN top_names tn
+            ON tn.address = coalesce(fs.address, ts.address)
+        """,
+        {"user_emails": user_ids},
+    )
+    return max(int(cur.rowcount), 0)
+
+
+def _populate_staging_incremental(
+    conn: Any,
+    user_ids: list[str],
+    import_id: UUID | str,
+) -> int:
+    """Import-scoped staging: touched set + full-corpus per-address stats."""
+    cur = conn.execute(
+        """
+        WITH scoped AS (
+            SELECT sender_address, recipients
+              FROM emails
+             WHERE import_id = %(import_id)s::uuid
+        ),
+        from_addrs AS (
+            SELECT lower(btrim(sender_address)) AS address
+              FROM scoped
+             WHERE sender_address IS NOT NULL AND btrim(sender_address) <> ''
+        ),
+        to_addrs AS (
+            SELECT lower(btrim(r.addr)) AS address
+              FROM scoped e
+              CROSS JOIN LATERAL (
+                  SELECT jsonb_array_elements_text(
+                             COALESCE(e.recipients->'to', '[]'::jsonb)
+                         ) AS addr
+                  UNION ALL
+                  SELECT jsonb_array_elements_text(
+                             COALESCE(e.recipients->'cc', '[]'::jsonb)
+                         )
+                  UNION ALL
+                  SELECT jsonb_array_elements_text(
+                             COALESCE(e.recipients->'bcc', '[]'::jsonb)
+                         )
+              ) r
+             WHERE e.recipients IS NOT NULL
+               AND r.addr IS NOT NULL
+               AND btrim(r.addr) <> ''
+        )
+        SELECT DISTINCT address FROM from_addrs
+        UNION
+        SELECT DISTINCT address FROM to_addrs
+        """,
+        {"import_id": import_id},
+    )
+    touched = [row[0] for row in cur.fetchall()]
+    if not touched:
+        return 0
+
+    cur = conn.execute(
+        """
+        INSERT INTO contacts_staging (
+            address, top_name, name_variants, is_user,
+            first_seen, last_seen, messages_from, messages_to
+        )
+        WITH touched AS (
+            SELECT unnest(%(addrs)s::text[]) AS address
+        ),
+        sender_names AS (
+            SELECT lower(btrim(e.sender_address)) AS address,
+                   e.sender_name,
+                   count(*) AS cnt
+              FROM emails e
+              JOIN touched t ON lower(btrim(e.sender_address)) = t.address
+             WHERE e.sender_name IS NOT NULL AND btrim(e.sender_name) <> ''
+             GROUP BY 1, 2
+        ),
+        name_variants AS (
+            SELECT address,
+                   array_agg(sender_name ORDER BY sender_name) AS name_variants
+              FROM sender_names
+             GROUP BY address
+        ),
+        top_names AS (
+            SELECT DISTINCT ON (address) address, sender_name AS top_name
+              FROM sender_names
+             ORDER BY address, cnt DESC, sender_name
+        ),
+        from_stats AS (
+            SELECT lower(btrim(e.sender_address)) AS address,
+                   count(*)::int AS messages_from,
+                   min(e.date) AS first_seen,
+                   max(e.date) AS last_seen
+              FROM emails e
+              JOIN touched t ON lower(btrim(e.sender_address)) = t.address
+             GROUP BY 1
+        ),
+        to_stats AS (
+            SELECT t.address,
+                   count(*)::int AS messages_to
+              FROM touched t
+              JOIN emails e ON (
+                  lower(btrim(e.sender_address)) = ANY(%(user_emails)s)
+                  AND (
+                      e.recipients @> jsonb_build_object(
+                          'to', to_jsonb(ARRAY[t.address])
+                      )
+                      OR e.recipients @> jsonb_build_object(
+                          'cc', to_jsonb(ARRAY[t.address])
+                      )
+                      OR e.recipients @> jsonb_build_object(
+                          'bcc', to_jsonb(ARRAY[t.address])
+                      )
+                  )
+              )
+             GROUP BY t.address
+        ),
+        date_bounds AS (
+            -- first/last seen across both sent and received for recipient-only addrs
+            SELECT t.address,
+                   least(fs.first_seen, rs.first_seen) AS first_seen,
+                   greatest(fs.last_seen, rs.last_seen) AS last_seen
+              FROM touched t
+              LEFT JOIN from_stats fs ON fs.address = t.address
+              LEFT JOIN (
+                  SELECT t2.address,
+                         min(e.date) AS first_seen,
+                         max(e.date) AS last_seen
+                    FROM touched t2
+                    JOIN emails e ON (
+                        e.recipients @> jsonb_build_object(
+                            'to', to_jsonb(ARRAY[t2.address])
+                        )
+                        OR e.recipients @> jsonb_build_object(
+                            'cc', to_jsonb(ARRAY[t2.address])
+                        )
+                        OR e.recipients @> jsonb_build_object(
+                            'bcc', to_jsonb(ARRAY[t2.address])
+                        )
+                    )
+                   GROUP BY t2.address
+              ) rs ON rs.address = t.address
+        )
+        SELECT t.address,
+               tn.top_name,
+               coalesce(nv.name_variants, '{}'::text[]) AS name_variants,
+               (t.address = ANY(%(user_emails)s)) AS is_user,
+               db.first_seen,
+               db.last_seen,
+               coalesce(fs.messages_from, 0) AS messages_from,
+               coalesce(ts.messages_to, 0) AS messages_to
+          FROM touched t
+          LEFT JOIN name_variants nv ON nv.address = t.address
+          LEFT JOIN top_names tn ON tn.address = t.address
+          LEFT JOIN from_stats fs ON fs.address = t.address
+          LEFT JOIN to_stats ts ON ts.address = t.address
+          LEFT JOIN date_bounds db ON db.address = t.address
+        """,
+        {"addrs": touched, "user_emails": user_ids},
+    )
+    return max(int(cur.rowcount), 0)
+
+
+def _apply_contacts_staging(conn: Any) -> tuple[int, list[Any]]:
+    """Apply contacts_staging into contact_addresses + contacts. Shared by both paths."""
+    # (c) refresh stats on existing address rows first
+    conn.execute(
+        """UPDATE contact_addresses ca
+              SET name_variants = s.name_variants,
+                  is_user = s.is_user,
+                  first_seen = s.first_seen,
+                  last_seen = s.last_seen,
+                  messages_from = s.messages_from,
+                  messages_to = s.messages_to
+             FROM contacts_staging s
+            WHERE ca.address = s.address"""
+    )
+    # (a) new singleton contacts for addresses not yet in contact_addresses
+    cur = conn.execute(
+        """INSERT INTO contacts (id, display_name)
+           SELECT s.new_contact_id, s.top_name
+             FROM contacts_staging s
+            WHERE NOT EXISTS (
+                      SELECT 1 FROM contact_addresses ca
+                       WHERE ca.address = s.address
+                  )"""
+    )
+    contacts_created = max(int(cur.rowcount), 0)
+    # (b) matching address rows for those new contacts
+    conn.execute(
+        """INSERT INTO contact_addresses (
+               address, contact_id, name_variants, is_user,
+               first_seen, last_seen, messages_from, messages_to
+           )
+           SELECT s.address, s.new_contact_id, s.name_variants, s.is_user,
+                  s.first_seen, s.last_seen, s.messages_from, s.messages_to
+             FROM contacts_staging s
+            WHERE NOT EXISTS (
+                      SELECT 1 FROM contact_addresses ca
+                       WHERE ca.address = s.address
+                  )"""
+    )
+
+    cur = conn.execute(
+        """SELECT DISTINCT ca.contact_id
+             FROM contacts_staging s
+             JOIN contact_addresses ca ON ca.address = s.address"""
+    )
+    contact_ids = [row[0] for row in cur.fetchall()]
+    return contacts_created, contact_ids
 
 
 def _is_personal_name(name: str) -> bool:

--- a/tests/integration/test_contacts.py
+++ b/tests/integration/test_contacts.py
@@ -53,6 +53,8 @@ def _email(  # type: ignore[no-untyped-def]
     sender_address: str,
     sender_name: str | None = None,
     to: list[str] | None = None,
+    cc: list[str] | None = None,
+    bcc: list[str] | None = None,
     date: datetime | None = None,
     import_id=None,
     source_account: str = "me@example.com",
@@ -66,7 +68,7 @@ def _email(  # type: ignore[no-untyped-def]
         "sender_name": sender_name,
         "sender_address": sender_address,
         "sender_domain": domain,
-        "recipients": json.dumps({"to": to or [], "cc": [], "bcc": []}),
+        "recipients": json.dumps({"to": to or [], "cc": cc or [], "bcc": bcc or []}),
         "date": date or datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
         "body_text": "hello",
         "labels": ["INBOX"],
@@ -74,6 +76,18 @@ def _email(  # type: ignore[no-untyped-def]
         "import_id": import_id,
         "source_account": source_account,
     }
+
+
+def _snapshot_contact_addresses(pool) -> dict[str, tuple]:  # type: ignore[no-untyped-def]
+    """Stats snapshot keyed by address (excludes contact_id UUIDs)."""
+    with pool.connection() as conn:
+        rows = conn.execute(
+            """SELECT address, name_variants, is_user, first_seen, last_seen,
+                      messages_from, messages_to
+                 FROM contact_addresses
+                ORDER BY address"""
+        ).fetchall()
+    return {r[0]: (tuple(r[1] or []), r[2], r[3], r[4], r[5], r[6]) for r in rows}
 
 
 def _seed(pool, emails: list[dict]) -> None:  # type: ignore[no-untyped-def]
@@ -428,6 +442,102 @@ def test_build_and_classify_idempotent(test_pool) -> None:  # type: ignore[no-un
     assert c1 == c2
     assert probs_1 == probs_2
     assert r1["addresses"] == r2["addresses"]
+
+
+def test_full_and_incremental_build_equivalence(test_pool) -> None:  # type: ignore[no-untyped-def]
+    """Full one-pass build must match per-import incremental stats exactly.
+
+    Seeds multi-arm (same address in to AND cc of one user-sent email counts
+    once), sender-only, recipient-only, and mixed addresses across imports.
+    """
+    _clean_contacts(test_pool)
+    import_a = _insert_import(test_pool, "me@example.com")
+    import_b = _insert_import(test_pool, "me@example.com")
+
+    _seed(
+        test_pool,
+        [
+            # Multi-arm: multi@z.com in both to and cc of a single user-sent email
+            # → messages_to must be 1 (not 2).
+            _email(
+                message_id="eq-multi-arm@x.com",
+                sender_address="me@example.com",
+                sender_name="Me",
+                to=["multi@z.com"],
+                cc=["multi@z.com", "other-cc@z.com"],
+                date=datetime(2025, 1, 5, 10, 0, tzinfo=UTC),
+                import_id=import_a,
+            ),
+            # Sender-only: never a recipient of a user-sent email
+            _email(
+                message_id="eq-sender-only@x.com",
+                sender_address="senderonly@x.com",
+                sender_name="Sender Only",
+                to=["me@example.com"],
+                date=datetime(2025, 1, 10, 9, 0, tzinfo=UTC),
+                import_id=import_a,
+            ),
+            # Recipient-only (import B): user wrote to them; they never sent
+            _email(
+                message_id="eq-recip-only@x.com",
+                sender_address="me@example.com",
+                sender_name="Me",
+                to=["reciponly@y.com"],
+                date=datetime(2025, 1, 12, 11, 0, tzinfo=UTC),
+                import_id=import_b,
+            ),
+            # Mixed: alice sends and user replies
+            _email(
+                message_id="eq-alice-from@x.com",
+                sender_address="alice@x.com",
+                sender_name="Alice A",
+                to=["me@example.com"],
+                date=datetime(2025, 1, 15, 8, 0, tzinfo=UTC),
+                import_id=import_b,
+            ),
+            _email(
+                message_id="eq-alice-to@x.com",
+                sender_address="me@example.com",
+                sender_name="Me",
+                to=["alice@x.com"],
+                bcc=["bcc-only@z.com"],
+                date=datetime(2025, 1, 16, 14, 0, tzinfo=UTC),
+                import_id=import_b,
+            ),
+            # Second name variant for alice (name_variants / top_name)
+            _email(
+                message_id="eq-alice-from-2@x.com",
+                sender_address="alice@x.com",
+                sender_name="Alice",
+                to=["me@example.com"],
+                date=datetime(2025, 1, 20, 8, 0, tzinfo=UTC),
+                import_id=import_a,
+            ),
+        ],
+    )
+
+    build_contacts(test_pool)  # full path
+    full_snapshot = _snapshot_contact_addresses(test_pool)
+
+    # Prove multi-arm dedup: one user-sent email with address in to+cc → 1
+    assert full_snapshot["multi@z.com"][5] == 1  # messages_to
+    assert full_snapshot["senderonly@x.com"][4] == 1  # messages_from
+    assert full_snapshot["senderonly@x.com"][5] == 0  # messages_to
+    assert full_snapshot["reciponly@y.com"][4] == 0  # messages_from
+    assert full_snapshot["reciponly@y.com"][5] == 1  # messages_to
+    assert full_snapshot["alice@x.com"][4] == 2  # messages_from
+    assert full_snapshot["alice@x.com"][5] == 1  # messages_to
+
+    with test_pool.connection() as conn:
+        conn.execute("TRUNCATE contact_addresses, contacts")
+        conn.commit()
+
+    # Per-import incremental builds over the same data
+    for iid in (import_a, import_b):
+        build_contacts(test_pool, import_id=iid)
+
+    incremental_snapshot = _snapshot_contact_addresses(test_pool)
+    assert incremental_snapshot == full_snapshot
 
 
 def test_orchestrator_builds_and_classifies_contacts(test_pool, test_settings, tmp_path) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Objective

The first live `maildb contacts refresh` (PR #100's full-build path) was killed at the 80-minute hard stop — measured cause: per-address GIN containment probes (~11.6ms × ~300-500k addresses) plus unindexed expression joins.

## Change

Full build (import_id=None) now populates staging from two single scans: sender aggregates via one GROUP BY, recipient aggregates via one to/cc/bcc unnest pass with per-(email,address) dedup preserving exact messages_to semantics (multi-arm test). Incremental path unchanged (touched-set with corpus-wide stats). Apply logic shared.

## Acceptance criteria

- [x] No containment probes / touched-array join in the full path (probes remain only in the incremental CTE block, per spec)
- [x] Multi-arm dedup semantics test; full-vs-incremental equivalence test
- [x] `uv run just check` — exit 0 (631 tests, coverage 87.9%)

## Provenance

Implementer: Grok Build CLI, `grok-4.5` @ `max`, cheap-coder workflow. Architecture, spec, review: Claude. Live re-run timing to follow in comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)