### PR TITLE
Review remainders: opt-in exact totals, honest semantic totals, log_tool gate, CLI dedupe, CI, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv sync
+      - run: uv run ruff format --check .
+      - run: uv run ruff check .
+      - run: uv run mypy src/
+      - run: uv run pytest tests/unit/

--- a/skills/using-maildb/SKILL.md
+++ b/skills/using-maildb/SKILL.md
@@ -77,8 +77,7 @@ All list tools return a wrapper with pagination metadata:
 {"total": 147, "offset": 0, "limit": 50, "results": [...]}
 ```
 
-- `total` — full count matching filters (ignoring limit/offset)
-- For semantic tools (`search`, `search_attachments`, `search_all`), `total` is approximate (`offset + returned`, or a lower bound), not an exact count.
+- `total` — `null` by default for non-semantic list tools; pass `include_total: true` to get an exact count (costs an extra count query). For semantic tools (`search`, `search_attachments`, `search_all`, `topics_with`) `total` is a lower bound (`offset + returned`), not a corpus count.
 - `results` — the email objects (headers + `body_length`, no `body_text` by default)
 
 **Exceptions:** `get_thread` and `get_thread_for` return flat lists. `query` returns flat lists.
@@ -89,13 +88,13 @@ All list tools return a wrapper with pagination metadata:
 
 | Tool | Use When |
 |------|----------|
-| `find(sender, sender_domain, recipient, after, before, has_attachment, subject_contains, labels, max_to, max_cc, max_recipients, direct_only, account, limit, offset, order, fields)` | Exact attribute filtering |
+| `find(sender, sender_domain, recipient, after, before, has_attachment, subject_contains, labels, max_to, max_cc, max_recipients, direct_only, account, limit, offset, order, fields, include_total)` | Exact attribute filtering |
 | `search(query, ...same filters as find..., account, limit, offset, fields)` | Natural language topic search (needs Ollama); approximate total |
 | `get_emails(ids, body_max_chars, fields)` | Fetch full emails by message_id — includes `body_text` by default |
 | `get_thread(thread_id, fields)` | Full conversation by thread ID |
 | `get_thread_for(message_id, fields)` | Find thread containing a message |
-| `correspondence(address, after, before, account, limit, offset, order, fields)` | Bidirectional email history with a person |
-| `mention_search(text, sender, sender_domain, after, before, max_to, max_cc, max_recipients, direct_only, account, limit, offset, fields)` | Keyword search in body/subject (no Ollama) |
+| `correspondence(address, after, before, account, limit, offset, order, fields, include_total)` | Bidirectional email history with a person |
+| `mention_search(text, sender, sender_domain, after, before, max_to, max_cc, max_recipients, direct_only, account, limit, offset, fields, include_total)` | Keyword search in body/subject (no Ollama) |
 | `search_attachments(query, sender, sender_domain, recipient, after, before, labels, max_to, max_cc, max_recipients, direct_only, account, content_type, limit, offset)` | Semantic search over extracted attachment chunks; approximate total |
 | `search_all(query, ...email/recipient/account filters..., limit, offset)` | Unified semantic search across emails and extracted attachments; approximate total |
 | `get_attachment_markdown(attachment_id, account, max_chars, offset)` | Fetch extracted attachment markdown; page with `max_chars` + `offset` |
@@ -104,10 +103,10 @@ All list tools return a wrapper with pagination metadata:
 
 | Tool | Use When | Needs `user_email` |
 |------|----------|--------------------|
-| `top_contacts(period, limit, offset, direction, group_by, exclude_domains)` | Most frequent correspondents; `group_by="domain"` for domain view | Yes |
+| `top_contacts(period, limit, offset, direction, group_by, exclude_domains, include_total)` | Most frequent correspondents; `group_by="domain"` for domain view | Yes |
 | `topics_with(sender or sender_domain, limit, offset, fields)` | Diverse topic sample with a contact | No |
-| `unreplied(direction, recipient, after, before, sender, sender_domain, max_to, max_cc, max_recipients, direct_only, limit, offset, fields)` | Messages with no reply; `direction="outbound"` for sent | Yes |
-| `long_threads(min_messages, after, participant, limit, offset)` | Threads exceeding message count | No |
+| `unreplied(direction, recipient, after, before, sender, sender_domain, max_to, max_cc, max_recipients, direct_only, limit, offset, fields, include_total)` | Messages with no reply; `direction="outbound"` for sent | Yes |
+| `long_threads(min_messages, after, participant, limit, offset, include_total)` | Threads exceeding message count | No |
 | `cluster(where or message_ids, limit, offset, fields)` | Diverse topic extraction from any subset | No |
 | `query(spec)` | DSL: aggregation, grouping, custom selects | No |
 
@@ -117,6 +116,7 @@ All list tools return a wrapper with pagination metadata:
 |------|----------|
 | `accounts()` | Discover source accounts and counts before using `account=...` |
 | `import_history(account, limit, offset)` | Inspect ingest sessions, inserted/skipped counts, and status |
+| `contacts(query, kind, tag, min_human_probability, limit, offset, include_total)` | Resolve people/senders by name, address, kind, or tag |
 
 ### Recipient Count Filters
 
@@ -231,7 +231,7 @@ cluster(message_ids=ids, limit=5, fields=["subject", "body_text", "date"])
 
 - **No Python imports needed.** All interactions via MCP tools. Responses are JSON dicts.
 - **Headers by default.** List tools exclude `body_text` and include `body_length` instead. Use `get_emails` for bodies.
-- **`total` tells you the full count for non-semantic list tools.** Semantic totals are approximate; paginate until an empty or short page.
+- **`total` is `null` by default for non-semantic list tools.** Pass `include_total: true` for an exact count (extra query). Semantic tools (`search`, `search_attachments`, `search_all`, `topics_with`) return a lower bound (`offset + returned`); paginate until an empty or short page.
 - **`user_email` required** for `unreplied` and `top_contacts`. Set via `MAILDB_USER_EMAILS` env var.
 - **`search` needs Ollama running.** `find`, `mention_search`, and `correspondence` work without it.
 - **Attachment search needs extraction first.** Run `maildb process_attachments run`; then use `search_attachments`, `search_all`, and `get_attachment_markdown`.

--- a/src/maildb/cli.py
+++ b/src/maildb/cli.py
@@ -34,6 +34,7 @@ from maildb.ingest.process_attachments import (
     sweep_empty_extractions as pa_sweep_empty_extractions,
 )
 from maildb.ingest.threads import repair_thread_ids
+from maildb.maildb import MailDB
 from maildb.pii import scrub_pii
 from maildb.server import mcp
 
@@ -304,26 +305,18 @@ def ingest_status(
 
 def _print_imports_summary(pool, account: str | None) -> None:  # type: ignore[no-untyped-def]
     """Print a per-import breakdown to stdout."""
-    sql = (
-        "SELECT started_at, source_account, status, messages_inserted, messages_skipped "
-        "FROM imports "
-    )
-    params: dict = {}
-    if account is not None:
-        sql += "WHERE source_account = %(account)s "
-        params["account"] = account
-    sql += "ORDER BY started_at DESC LIMIT 20"
-    with pool.connection() as conn:
-        cur = conn.execute(sql, params)
-        rows = cur.fetchall()
-    if not rows:
+    db = MailDB._from_pool(pool)
+    records = db.import_history(account=account, limit=20)
+    if not records:
         return
     typer.echo("\nImports")
-    for started, acct, status, inserted, skipped in rows:
+    for rec in records:
+        started = rec.started_at
         ts = started.strftime("%Y-%m-%d %H:%M") if started else "?"
         typer.echo(
-            f"  {ts}  {acct:<24} {status:<10} "
-            f"{inserted or 0:>10,} inserted   {skipped or 0:>4} skipped"
+            f"  {ts}  {rec.source_account:<24} {rec.status:<10} "
+            f"{rec.messages_inserted or 0:>10,} inserted   "
+            f"{rec.messages_skipped or 0:>4} skipped"
         )
 
 

--- a/src/maildb/maildb.py
+++ b/src/maildb/maildb.py
@@ -687,9 +687,11 @@ class MailDB:
         limit: int = 5,
         offset: int = 0,
     ) -> tuple[list[Email], int]:
-        """Representative emails spanning different topics with a contact. Returns (emails, total_count).
+        """Representative emails spanning different topics with a contact.
 
-        Uses greedy farthest-point selection on embeddings.
+        Uses greedy farthest-point selection on embeddings. The candidate pool is
+        capped (LIMIT 500); ``total`` is a lower bound (``offset + returned``),
+        consistent with ``search`` / ``search_attachments``, not a corpus count.
 
         Args:
             sender: Exact sender email address.
@@ -722,10 +724,11 @@ class MailDB:
         if not rows:
             return [], 0
 
-        total = len(rows)
         emails = [Email.from_row(row) for row in rows]
         selected = self._farthest_point_select(emails, limit + offset)
-        return selected[offset:], total
+        page = selected[offset:]
+        total = offset + len(page)
+        return page, total
 
     @staticmethod
     def _farthest_point_select(emails: list[Email], limit: int) -> list[Email]:
@@ -1554,9 +1557,9 @@ class MailDB:
         Results are rank-fused across sources (reciprocal rank fusion, K=60) so
         neither corpus can crowd out the other by score-distribution differences.
         Per-result ``similarity`` values remain raw cosine similarities and are
-        NOT comparable across sources. The returned total is a lower-bound
-        approximation over the merged over-fetched results, not an exact count
-        across both corpora.
+        NOT comparable across sources. ``total`` is a lower bound
+        (``offset + returned``), consistent with ``search`` /
+        ``search_attachments``, not a corpus count across both corpora.
         """
         over_fetch = 2 * (limit + offset)
         email_hits, _ = self.search(
@@ -1626,8 +1629,9 @@ class MailDB:
 
         ranked.sort(key=lambda item: item[0])
         unified = [item[1] for item in ranked]
-        total = len(unified)
-        return unified[offset : offset + limit], total
+        page = unified[offset : offset + limit]
+        total = offset + len(page)
+        return page, total
 
     def query(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
         """Execute a Tier 2 DSL query and return results as dicts.

--- a/src/maildb/maildb.py
+++ b/src/maildb/maildb.py
@@ -90,6 +90,13 @@ def _query_dicts(
     return rows
 
 
+def _count(pool: ConnectionPool, base_sql: str, params: dict[str, Any]) -> int:
+    """Exact row count for a query body (no ORDER BY/LIMIT/OFFSET)."""
+    sql = f"SELECT COUNT(*) AS n FROM ({base_sql}) AS _count_sub"
+    row = _query_one_dict(pool, sql, params)
+    return int(row["n"]) if row is not None else 0
+
+
 def _query_dicts_with_hnsw_ef_search(
     pool: ConnectionPool,
     sql: str,
@@ -294,8 +301,13 @@ class MailDB:
         max_recipients: int | None = None,
         direct_only: bool = False,
         account: str | None = None,
-    ) -> tuple[list[Email], int]:
-        """Structured query with dynamic WHERE clauses. Returns (emails, total_count)."""
+        include_total: bool = False,
+    ) -> tuple[list[Email], int | None]:
+        """Structured query with dynamic WHERE clauses.
+
+        Returns (emails, total) where total is None unless include_total=True;
+        when present it is the exact count of matching rows regardless of offset.
+        """
         order_sql = _order_clause(order)
 
         conditions, params = self._build_filters(
@@ -315,15 +327,22 @@ class MailDB:
         )
 
         where = " AND ".join(conditions) if conditions else "TRUE"
-        query = f"SELECT {LIST_COLS}, COUNT(*) OVER() AS _total FROM emails WHERE {where} ORDER BY {order_sql} LIMIT %(limit)s OFFSET %(offset)s"
+        query = (
+            f"SELECT {LIST_COLS} FROM emails WHERE {where} "
+            f"ORDER BY {order_sql} LIMIT %(limit)s OFFSET %(offset)s"
+        )
         params["limit"] = limit
         params["offset"] = offset
 
         rows = _query_dicts(self._pool, query, params)
-        total = rows[0]["_total"] if rows else 0
-        for row in rows:
-            row.pop("_total", None)
-        return [Email.from_row(row) for row in rows], total
+        results = [Email.from_row(row) for row in rows]
+        if not include_total:
+            return results, None
+        count_row = _query_one_dict(
+            self._pool, f"SELECT COUNT(*) AS n FROM emails WHERE {where}", params
+        )
+        total = int(count_row["n"]) if count_row is not None else 0
+        return results, total
 
     def search(
         self,
@@ -461,8 +480,12 @@ class MailDB:
         group_by: str = "address",
         exclude_domains: list[str] | None = None,
         account: str | None = None,
-    ) -> tuple[list[dict[str, Any]], int]:
+        include_total: bool = False,
+    ) -> tuple[list[dict[str, Any]], int | None]:
         """Most frequent correspondents via GROUP BY aggregation.
+
+        Returns (results, total) where total is None unless include_total=True;
+        when present it is the exact count of matching rows regardless of offset.
 
         Args:
             period: Only count messages after this date (ISO format).
@@ -472,6 +495,7 @@ class MailDB:
             exclude_domains: List of domains to exclude from results.
             account: Scope to a single source_account. When provided,
                 "you" = that account. When omitted, "you" = any configured user_emails.
+            include_total: When True, compute an exact total via a separate count query.
         """
         if group_by not in ("address", "domain"):
             msg = f"group_by must be 'address' or 'domain', got {group_by!r}"
@@ -516,20 +540,18 @@ class MailDB:
             outbound_col = "r.addr"
 
         if direction == "inbound":
-            sql = f"""
-                SELECT {inbound_col} AS {label}, count(*) AS count, COUNT(*) OVER() AS _total
+            base_sql = f"""
+                SELECT {inbound_col} AS {label}, count(*) AS count
                 FROM emails
                 WHERE sender_address != ALL(%(user_emails)s)
                   {period_cond}
                   {exclude_inbound}
                   {account_cond}
                 GROUP BY {inbound_col}
-                ORDER BY count DESC
-                LIMIT %(limit)s OFFSET %(offset)s
             """
         elif direction == "outbound":
-            sql = f"""
-                SELECT {outbound_col} AS {label}, count(*) AS count, COUNT(*) OVER() AS _total
+            base_sql = f"""
+                SELECT {outbound_col} AS {label}, count(*) AS count
                 FROM emails,
                      LATERAL (
                          SELECT jsonb_array_elements_text(recipients->'to') AS addr
@@ -544,12 +566,10 @@ class MailDB:
                   {exclude_outbound}
                   {account_cond}
                 GROUP BY {outbound_col}
-                ORDER BY count DESC
-                LIMIT %(limit)s OFFSET %(offset)s
             """
         else:  # both
-            sql = f"""
-                SELECT {label}, sum(count) AS count, COUNT(*) OVER() AS _total
+            base_sql = f"""
+                SELECT {label}, sum(count) AS count
                 FROM (
                     SELECT {inbound_col} AS {label}, count(*) AS count
                     FROM emails
@@ -578,15 +598,18 @@ class MailDB:
                     GROUP BY {outbound_col}
                 ) AS combined
                 GROUP BY {label}
-                ORDER BY count DESC
-                LIMIT %(limit)s OFFSET %(offset)s
             """
 
+        sql = f"""
+            {base_sql}
+            ORDER BY count DESC
+            LIMIT %(limit)s OFFSET %(offset)s
+        """
+
         rows = _query_dicts(self._pool, sql, params)
-        total = rows[0]["_total"] if rows else 0
-        for row in rows:
-            row.pop("_total", None)
-        return rows, total
+        if not include_total:
+            return rows, None
+        return rows, _count(self._pool, base_sql, params)
 
     def accounts(self) -> list[AccountSummary]:
         """Summarize email counts per source_account.
@@ -817,8 +840,12 @@ class MailDB:
         max_recipients: int | None = None,
         direct_only: bool = False,
         account: str | None = None,
-    ) -> tuple[list[Email], int]:
+        include_total: bool = False,
+    ) -> tuple[list[Email], int | None]:
         """Messages with no reply in the same thread.
+
+        Returns (emails, total) where total is None unless include_total=True;
+        when present it is the exact count of matching rows regardless of offset.
 
         Args:
             direction: "inbound" (default) — messages FROM others where user never
@@ -837,6 +864,7 @@ class MailDB:
             direct_only: shorthand for max_to=1, max_cc=0 (cannot combine with max_to/max_cc).
             account: Scope to a single source_account. When provided,
                 "you" = that account. When omitted, "you" = any configured user_emails.
+            include_total: When True, compute an exact total via a separate count query.
         """
         if direction not in ("inbound", "outbound"):
             msg = f"Invalid direction: {direction!r}. Must be 'inbound' or 'outbound'."
@@ -893,8 +921,8 @@ class MailDB:
             where = " AND ".join(conditions)
             params["limit"] = limit
             params["offset"] = offset
-            sql = f"""
-                SELECT {select_cols_aliased}, COUNT(*) OVER() AS _total
+            base_sql = f"""
+                SELECT {select_cols_aliased}
                 FROM emails e
                 WHERE {where}
                   AND NOT EXISTS (
@@ -903,8 +931,6 @@ class MailDB:
                         AND reply.sender_address = ANY(%(user_emails)s)
                         AND reply.date > e.date
                   )
-                ORDER BY e.date DESC NULLS LAST, e.id
-                LIMIT %(limit)s OFFSET %(offset)s
             """
         else:
             # Outbound: messages FROM user where recipients never replied
@@ -955,20 +981,24 @@ class MailDB:
             where = " AND ".join(conditions)
             params["limit"] = limit
             params["offset"] = offset
-            sql = f"""
-                SELECT {select_cols_aliased}, COUNT(*) OVER() AS _total
+            base_sql = f"""
+                SELECT {select_cols_aliased}
                 FROM emails e
                 WHERE {where}
                   {not_exists}
-                ORDER BY e.date DESC NULLS LAST, e.id
-                LIMIT %(limit)s OFFSET %(offset)s
             """
 
+        sql = f"""
+            {base_sql}
+            ORDER BY e.date DESC NULLS LAST, e.id
+            LIMIT %(limit)s OFFSET %(offset)s
+        """
+
         rows = _query_dicts(self._pool, sql, params)
-        total = rows[0]["_total"] if rows else 0
-        for row in rows:
-            row.pop("_total", None)
-        return [Email.from_row(row) for row in rows], total
+        results = [Email.from_row(row) for row in rows]
+        if not include_total:
+            return results, None
+        return results, _count(self._pool, base_sql, params)
 
     def correspondence(
         self,
@@ -980,10 +1010,14 @@ class MailDB:
         limit: int = 500,
         offset: int = 0,
         order: str = "date ASC",
-    ) -> tuple[list[Email], int]:
-        """All emails exchanged with a specific person. Returns (emails, total_count).
+        include_total: bool = False,
+    ) -> tuple[list[Email], int | None]:
+        """All emails exchanged with a specific person.
+
         Returns emails where address is sender OR is in recipients (to/cc/bcc).
         Default chronological order, higher limit than find().
+        Returns (emails, total) where total is None unless include_total=True;
+        when present it is the exact count of matching rows regardless of offset.
 
         Args:
             address: Email address to match as sender or recipient.
@@ -993,6 +1027,7 @@ class MailDB:
             limit: Max results to return.
             offset: Skip first N results.
             order: Result ordering.
+            include_total: When True, compute an exact total via a separate count query.
         """
         order_sql = _order_clause(order)
 
@@ -1021,13 +1056,20 @@ class MailDB:
         params.update(account_params)
 
         where = " AND ".join(conditions)
-        sql = f"SELECT {LIST_COLS}, COUNT(*) OVER() AS _total FROM emails WHERE {where} ORDER BY {order_sql} LIMIT %(limit)s OFFSET %(offset)s"
+        sql = (
+            f"SELECT {LIST_COLS} FROM emails WHERE {where} "
+            f"ORDER BY {order_sql} LIMIT %(limit)s OFFSET %(offset)s"
+        )
 
         rows = _query_dicts(self._pool, sql, params)
-        total = rows[0]["_total"] if rows else 0
-        for row in rows:
-            row.pop("_total", None)
-        return [Email.from_row(row) for row in rows], total
+        results = [Email.from_row(row) for row in rows]
+        if not include_total:
+            return results, None
+        count_row = _query_one_dict(
+            self._pool, f"SELECT COUNT(*) AS n FROM emails WHERE {where}", params
+        )
+        total = int(count_row["n"]) if count_row is not None else 0
+        return results, total
 
     def mention_search(
         self,
@@ -1044,9 +1086,13 @@ class MailDB:
         max_recipients: int | None = None,
         direct_only: bool = False,
         account: str | None = None,
-    ) -> tuple[list[Email], int]:
-        """Case-insensitive keyword search in body_text and subject. Returns (emails, total_count).
+        include_total: bool = False,
+    ) -> tuple[list[Email], int | None]:
+        """Case-insensitive keyword search in body_text and subject.
+
         Unlike search(), uses ILIKE (substring match) and does not require Ollama.
+        Returns (emails, total) where total is None unless include_total=True;
+        when present it is the exact count of matching rows regardless of offset.
         """
         escaped = text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         pattern = f"%{escaped}%"
@@ -1082,12 +1128,19 @@ class MailDB:
         conditions.extend(rcpt_conditions)
         params.update(rcpt_params)
         where = " AND ".join(conditions)
-        sql = f"SELECT {LIST_COLS}, COUNT(*) OVER() AS _total FROM emails WHERE {where} ORDER BY date DESC NULLS LAST, id LIMIT %(limit)s OFFSET %(offset)s"
+        sql = (
+            f"SELECT {LIST_COLS} FROM emails WHERE {where} "
+            f"ORDER BY date DESC NULLS LAST, id LIMIT %(limit)s OFFSET %(offset)s"
+        )
         rows = _query_dicts(self._pool, sql, params)
-        total = rows[0]["_total"] if rows else 0
-        for row in rows:
-            row.pop("_total", None)
-        return [Email.from_row(row) for row in rows], total
+        results = [Email.from_row(row) for row in rows]
+        if not include_total:
+            return results, None
+        count_row = _query_one_dict(
+            self._pool, f"SELECT COUNT(*) AS n FROM emails WHERE {where}", params
+        )
+        total = int(count_row["n"]) if count_row is not None else 0
+        return results, total
 
     def search_attachments(
         self,
@@ -1210,12 +1263,15 @@ class MailDB:
         min_human_probability: float | None = None,
         limit: int = 20,
         offset: int = 0,
-    ) -> tuple[list[dict[str, Any]], int]:
-        """Search the contacts address book. Returns (contacts, total_count).
+        include_total: bool = False,
+    ) -> tuple[list[dict[str, Any]], int | None]:
+        """Search the contacts address book.
 
         Joins contacts ← contact_addresses (aggregated per contact). Excludes
         contacts whose every address is the user. Order is by total message
         volume DESC, then last_seen DESC NULLS LAST, then id.
+        Returns (contacts, total) where total is None unless include_total=True;
+        when present it is the exact count of matching rows regardless of offset.
         """
         conditions: list[str] = ["NOT only_user"]
         params: dict[str, Any] = {"limit": limit, "offset": offset}
@@ -1247,7 +1303,7 @@ class MailDB:
             )
 
         where = " AND ".join(conditions)
-        sql = f"""
+        base_sql = f"""
             WITH contact_stats AS (
                 SELECT
                     c.id,
@@ -1278,22 +1334,22 @@ class MailDB:
             SELECT
                 id, display_name, kind, kind_source, tags, human_probability,
                 addresses, name_variants, messages_from, messages_to,
-                first_seen, last_seen,
-                COUNT(*) OVER() AS _total
+                first_seen, last_seen
               FROM contact_stats
              WHERE {where}
+        """
+        sql = f"""
+            {base_sql}
              ORDER BY (messages_from + messages_to) DESC,
                       last_seen DESC NULLS LAST,
                       id
              LIMIT %(limit)s OFFSET %(offset)s
         """
         rows = _query_dicts(self._pool, sql, params)
-        total = rows[0]["_total"] if rows else 0
-        results: list[dict[str, Any]] = []
-        for row in rows:
-            row.pop("_total", None)
-            results.append(self._format_contact_row(row, full=False))
-        return results, total
+        results: list[dict[str, Any]] = [self._format_contact_row(row, full=False) for row in rows]
+        if not include_total:
+            return results, None
+        return results, _count(self._pool, base_sql, params)
 
     def get_contact(
         self,
@@ -1611,8 +1667,12 @@ class MailDB:
         limit: int = 50,
         offset: int = 0,
         account: str | None = None,
-    ) -> tuple[list[dict[str, Any]], int]:
-        """Threads exceeding a message count threshold. Returns (threads, total_count).
+        include_total: bool = False,
+    ) -> tuple[list[dict[str, Any]], int | None]:
+        """Threads exceeding a message count threshold.
+
+        Returns (threads, total) where total is None unless include_total=True;
+        when present it is the exact count of matching rows regardless of offset.
         participant: only threads where this address appears as sender.
         account: scope to a single source_account.
         """
@@ -1632,19 +1692,20 @@ class MailDB:
         if participant:
             having_participant = "AND %(participant)s = ANY(array_agg(sender_address))"
             params["participant"] = participant
-        sql = f"""
+        base_sql = f"""
             SELECT thread_id, count(*) AS message_count,
                    min(date) AS first_date, max(date) AS last_date,
-                   array_agg(DISTINCT sender_address) AS participants,
-                   COUNT(*) OVER() AS _total
+                   array_agg(DISTINCT sender_address) AS participants
             FROM emails WHERE {where}
             GROUP BY thread_id
             HAVING count(*) >= %(min_messages)s {having_participant}
+        """
+        sql = f"""
+            {base_sql}
             ORDER BY count(*) DESC
             LIMIT %(limit)s OFFSET %(offset)s
         """
         rows = _query_dicts(self._pool, sql, params)
-        total = rows[0]["_total"] if rows else 0
-        for row in rows:
-            row.pop("_total", None)
-        return rows, total
+        if not include_total:
+            return rows, None
+        return rows, _count(self._pool, base_sql, params)

--- a/src/maildb/server.py
+++ b/src/maildb/server.py
@@ -151,7 +151,7 @@ def _serialize_email(
 def _wrap_response(
     results: list[dict[str, Any]],
     *,
-    total: int,
+    total: int | None,
     offset: int,
     limit: int,
 ) -> dict[str, Any]:
@@ -222,6 +222,7 @@ def find(
     limit: int = 50,
     offset: int = 0,
     order: str = "date DESC",
+    include_total: bool = False,
     fields: list[str] | None = None,
 ) -> dict[str, Any]:
     """Search emails by structured attribute filters.
@@ -244,12 +245,11 @@ def find(
       limit: max results (default 50)
       offset: skip first N results for pagination (default 0)
       order: "date DESC" | "date ASC" | "sender_address ASC" | "sender_address DESC"
+      include_total: set true to compute an exact total (extra count query); by default total is null.
       fields: list of field names to return. Default returns headers + body_length (no body_text).
         Pass ["body_text", ...] to include body content.
 
     Returns {total, offset, limit, results: [{email headers + body_length}, ...]}.
-    total is 0 when offset is past the last matching row — stop paginating on an
-    empty page rather than comparing offset to total.
 
     Example: find(sender="disney@postmates.com", direct_only=True, limit=100)
     """
@@ -271,6 +271,7 @@ def find(
         max_recipients=max_recipients,
         direct_only=direct_only,
         account=account,
+        include_total=include_total,
     )
     valid = _validate_fields(fields)
     serialized = [_serialize_email(e, valid) for e in results]
@@ -400,6 +401,7 @@ def top_contacts(
     account: str | None = None,
     limit: int = 10,
     offset: int = 0,
+    include_total: bool = False,
 ) -> dict[str, Any]:
     """Find most frequent email correspondents by message count.
 
@@ -412,6 +414,7 @@ def top_contacts(
         Omit to query across all accounts.
       limit: max results (default 10)
       offset: skip first N results for pagination (default 0)
+      include_total: set true to compute an exact total (extra count query); by default total is null.
 
     Returns {total, offset, limit, results: [{address: str, count: int}, ...]}
     (or {domain: str, count: int} results when group_by="domain").
@@ -427,6 +430,7 @@ def top_contacts(
         group_by=group_by,
         exclude_domains=exclude_domains,
         account=account,
+        include_total=include_total,
     )
     return _wrap_response(results, total=total, offset=offset, limit=limit)
 
@@ -490,6 +494,7 @@ def unreplied(
     account: str | None = None,
     limit: int = 100,
     offset: int = 0,
+    include_total: bool = False,
     fields: list[str] | None = None,
 ) -> dict[str, Any]:
     """Find emails with no reply in the same thread.
@@ -505,6 +510,7 @@ def unreplied(
         Omit to query across all accounts.
       limit: max results (default 100)
       offset: skip first N results for pagination (default 0)
+      include_total: set true to compute an exact total (extra count query); by default total is null.
       fields: list of field names to return. Default returns headers + body_length (no body_text).
 
     Returns {total, offset, limit, results: [{email headers + body_length}, ...]}.
@@ -526,6 +532,7 @@ def unreplied(
         limit=limit,
         offset=offset,
         account=account,
+        include_total=include_total,
     )
     valid = _validate_fields(fields)
     serialized = [_serialize_email(e, valid) for e in results]
@@ -543,6 +550,7 @@ def correspondence(
     limit: int = 500,
     offset: int = 0,
     order: str = "date ASC",
+    include_total: bool = False,
     fields: list[str] | None = None,
 ) -> dict[str, Any]:
     """Get all emails exchanged with a specific person (sent by them or to them).
@@ -555,6 +563,7 @@ def correspondence(
       limit: max results (default 500, higher for full relationship history)
       offset: skip first N results for pagination (default 0)
       order: "date ASC" (default, chronological) or "date DESC"
+      include_total: set true to compute an exact total (extra count query); by default total is null.
       fields: list of field names to return. Default returns headers + body_length (no body_text).
 
     Returns {total, offset, limit, results: [{email headers + body_length}, ...]}.
@@ -570,6 +579,7 @@ def correspondence(
         limit=limit,
         offset=offset,
         order=order,
+        include_total=include_total,
     )
     valid = _validate_fields(fields)
     serialized = [_serialize_email(e, valid) for e in results]
@@ -592,6 +602,7 @@ def mention_search(
     account: str | None = None,
     limit: int = 50,
     offset: int = 0,
+    include_total: bool = False,
     fields: list[str] | None = None,
 ) -> dict[str, Any]:
     """Search for emails containing specific text in body or subject (case-insensitive).
@@ -607,6 +618,7 @@ def mention_search(
         Omit to query across all accounts.
       limit: max results (default 50)
       offset: skip first N results for pagination (default 0)
+      include_total: set true to compute an exact total (extra count query); by default total is null.
       fields: list of field names to return. Default returns headers + body_length (no body_text).
 
     Returns {total, offset, limit, results: [{email headers + body_length}, ...]}.
@@ -627,6 +639,7 @@ def mention_search(
         max_recipients=max_recipients,
         direct_only=direct_only,
         account=account,
+        include_total=include_total,
     )
     valid = _validate_fields(fields)
     serialized = [_serialize_email(e, valid) for e in results]
@@ -676,6 +689,7 @@ def long_threads(
     account: str | None = None,
     limit: int = 50,
     offset: int = 0,
+    include_total: bool = False,
 ) -> dict[str, Any]:
     """Find email threads with many messages.
 
@@ -687,6 +701,7 @@ def long_threads(
         Omit to query across all accounts.
       limit: maximum number of threads to return (default 50)
       offset: skip first N results for pagination (default 0)
+      include_total: set true to compute an exact total (extra count query); by default total is null.
 
     Returns {total, offset, limit, results: [{thread_id, message_count, first_date, last_date, participants[]}, ...]}.
 
@@ -700,6 +715,7 @@ def long_threads(
         limit=limit,
         offset=offset,
         account=account,
+        include_total=include_total,
     )
     return _wrap_response(results, total=total, offset=offset, limit=limit)
 
@@ -942,6 +958,7 @@ def contacts(
     min_human_probability: float | None = None,
     limit: int = 20,
     offset: int = 0,
+    include_total: bool = False,
 ) -> dict[str, Any]:
     """Resolve people and senders: search the address book by name fragment,
     address fragment, kind, or tag.
@@ -961,12 +978,11 @@ def contacts(
         always manually curated and may disagree with the score.
       limit: max results (default 20)
       offset: skip first N results for pagination (default 0)
+      include_total: set true to compute an exact total (extra count query); by default total is null.
 
     Returns {total, offset, limit, results: [{id, display_name, kind,
     kind_source, tags, human_probability, addresses, name_variants,
     messages_from, messages_to, first_seen, last_seen}, ...]}.
-    total is 0 when offset is past the last matching row — stop paginating
-    on an empty page rather than comparing offset to total.
     """
     db = _get_db(ctx)
     results, total = db.contacts_search(
@@ -976,6 +992,7 @@ def contacts(
         min_human_probability=min_human_probability,
         limit=limit,
         offset=offset,
+        include_total=include_total,
     )
     return _wrap_response(results, total=total, offset=offset, limit=limit)
 

--- a/src/maildb/server.py
+++ b/src/maildb/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import logging
 import time
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass
@@ -48,23 +49,38 @@ def log_tool[F: Callable[..., Any]](func: F) -> F:
             row_count = len(result)
         else:
             row_count = 1
-        response_bytes = len(json.dumps(result, default=str).encode())
 
-        if response_bytes > RESPONSE_SIZE_WARNING_BYTES:
-            logger.warning(
-                "tool_exit",
-                tool=tool_name,
-                rows=row_count,
-                response_bytes=response_bytes,
-                elapsed_ms=elapsed_ms,
-                warning="response exceeds 50KB",
-            )
+        # Measurement costs a full re-serialization; only when a sink will record
+        # the debug line (CLI: root is always DEBUG; handler levels gate — file sink
+        # is the DEBUG path, so MAILDB_DEBUG_LOG_LEVEL > DEBUG disables measurement).
+        root = logging.getLogger()
+        debug_enabled = root.isEnabledFor(logging.DEBUG) and any(
+            h.level <= logging.DEBUG for h in root.handlers
+        )
+        if debug_enabled:
+            response_bytes = len(json.dumps(result, default=str).encode())
+            if response_bytes > RESPONSE_SIZE_WARNING_BYTES:
+                logger.warning(
+                    "tool_exit",
+                    tool=tool_name,
+                    rows=row_count,
+                    response_bytes=response_bytes,
+                    elapsed_ms=elapsed_ms,
+                    warning="response exceeds 50KB",
+                )
+            else:
+                logger.debug(
+                    "tool_exit",
+                    tool=tool_name,
+                    rows=row_count,
+                    response_bytes=response_bytes,
+                    elapsed_ms=elapsed_ms,
+                )
         else:
             logger.debug(
                 "tool_exit",
                 tool=tool_name,
                 rows=row_count,
-                response_bytes=response_bytes,
                 elapsed_ms=elapsed_ms,
             )
 

--- a/tests/integration/test_maildb.py
+++ b/tests/integration/test_maildb.py
@@ -204,7 +204,51 @@ def test_find_returns_total(test_pool, seed_emails) -> None:  # type: ignore[no-
     db = MailDB._from_pool(test_pool)
     results, total = db.find(limit=1)
     assert len(results) == 1
+    assert total is None
+
+    results, total = db.find(limit=1, include_total=True)
+    assert len(results) == 1
     assert total == 3  # seed_emails has 3 emails
+
+    results, total = db.find(limit=1, offset=100, include_total=True)
+    assert results == []
+    assert total == 3
+
+
+def test_unreplied_include_total(test_pool, seed_advanced) -> None:  # type: ignore[no-untyped-def]
+    config = Settings(user_email="alice@example.com", _env_file=None)  # type: ignore[call-arg]
+    db = MailDB._from_pool(test_pool, config=config)
+
+    results, total = db.unreplied()
+    assert total is None
+    assert len(results) >= 2
+
+    results, total = db.unreplied(include_total=True)
+    assert total == len(results)
+    assert total >= 2
+
+    results, total = db.unreplied(limit=1, offset=1000, include_total=True)
+    assert results == []
+    assert total is not None and total >= 2
+
+
+def test_top_contacts_include_total(test_pool, seed_advanced) -> None:  # type: ignore[no-untyped-def]
+    config = Settings(user_email="alice@example.com", _env_file=None)  # type: ignore[call-arg]
+    db = MailDB._from_pool(test_pool, config=config)
+
+    contacts, total = db.top_contacts(limit=5, direction="inbound")
+    assert total is None
+    assert len(contacts) >= 2
+
+    contacts, total = db.top_contacts(limit=5, direction="inbound", include_total=True)
+    assert total == len(contacts)
+    assert total >= 2
+
+    contacts, total = db.top_contacts(
+        limit=1, offset=1000, direction="inbound", include_total=True
+    )
+    assert contacts == []
+    assert total is not None and total >= 2
 
 
 @pytest.fixture
@@ -303,7 +347,7 @@ def seed_recipient_counts(test_pool):  # type: ignore[no-untyped-def]
 
 def test_find_direct_only(test_pool, seed_recipient_counts) -> None:  # type: ignore[no-untyped-def]
     db = MailDB._from_pool(test_pool)
-    results, total = db.find(sender="alice@example.com", direct_only=True)
+    results, total = db.find(sender="alice@example.com", direct_only=True, include_total=True)
     # rcpt-1 (1 To, 0 CC) and rcpt-3 (1 To, 0 CC, 1 BCC — BCC unconstrained)
     message_ids = [e.message_id for e in results]
     assert "rcpt-1@example.com" in message_ids
@@ -1300,12 +1344,16 @@ def test_correspondence_filters_by_account(test_pool, test_settings) -> None:  #
             )
         conn.commit()
 
-    a_only, a_total = db.correspondence(address="bob@corp.com", account="a@example.com")
+    a_only, a_total = db.correspondence(
+        address="bob@corp.com", account="a@example.com", include_total=True
+    )
     assert {e.message_id for e in a_only} == {"correspondence-account-0@corp.com"}
     assert a_total == 1
 
-    unscoped, unscoped_total = db.correspondence(address="bob@corp.com")
-    none_scoped, none_scoped_total = db.correspondence(address="bob@corp.com", account=None)
+    unscoped, unscoped_total = db.correspondence(address="bob@corp.com", include_total=True)
+    none_scoped, none_scoped_total = db.correspondence(
+        address="bob@corp.com", account=None, include_total=True
+    )
     assert {e.message_id for e in unscoped} == {
         "correspondence-account-0@corp.com",
         "correspondence-account-1@corp.com",
@@ -1973,8 +2021,8 @@ def _seed_contacts_corpus(test_pool):  # type: ignore[no-untyped-def]
 
 def test_contacts_search_by_name_fragment(test_pool) -> None:  # type: ignore[no-untyped-def]
     db = _seed_contacts_corpus(test_pool)
-    results, total = db.contacts_search(query="Alice")
-    assert total >= 1
+    results, total = db.contacts_search(query="Alice", include_total=True)
+    assert total is not None and total >= 1
     assert any("alice@x.com" in (r["addresses"] or []) for r in results)
     alice = next(r for r in results if "alice@x.com" in r["addresses"])
     assert alice["display_name"] is not None
@@ -1985,7 +2033,7 @@ def test_contacts_search_by_name_fragment(test_pool) -> None:  # type: ignore[no
 
 def test_contacts_search_by_address_fragment(test_pool) -> None:  # type: ignore[no-untyped-def]
     db = _seed_contacts_corpus(test_pool)
-    results, total = db.contacts_search(query="bob@y")
+    results, total = db.contacts_search(query="bob@y", include_total=True)
     assert total == 1
     assert results[0]["addresses"] == ["bob@y.com"]
 
@@ -2003,7 +2051,7 @@ def test_contacts_search_by_tag(test_pool) -> None:  # type: ignore[no-untyped-d
         )
         conn.commit()
 
-    results, total = db.contacts_search(tag="vip")
+    results, total = db.contacts_search(tag="vip", include_total=True)
     assert total == 1
     assert results[0]["addresses"] == ["alice@x.com"]
     assert "vip" in results[0]["tags"]
@@ -2013,7 +2061,7 @@ def test_contacts_search_by_min_human_probability(test_pool) -> None:  # type: i
     db = _seed_contacts_corpus(test_pool)
     # All classified contacts have some probability; high threshold should
     # prefer Alice (personal name + inbound) over noreply.
-    results, total = db.contacts_search(min_human_probability=0.5)
+    results, total = db.contacts_search(min_human_probability=0.5, include_total=True)
     addresses = {a for r in results for a in r["addresses"]}
     assert "noreply@shop.com" not in addresses or all(
         r["human_probability"] is not None and r["human_probability"] >= 0.5 for r in results
@@ -2021,7 +2069,7 @@ def test_contacts_search_by_min_human_probability(test_pool) -> None:  # type: i
     assert all(
         r["human_probability"] is not None and r["human_probability"] >= 0.5 for r in results
     )
-    assert total == len(results) or total >= len(results)
+    assert total == len(results) or (total is not None and total >= len(results))
 
 
 def test_contacts_search_excludes_user_only(test_pool) -> None:  # type: ignore[no-untyped-def]
@@ -2033,7 +2081,7 @@ def test_contacts_search_excludes_user_only(test_pool) -> None:  # type: ignore[
 
 def test_contacts_search_deterministic_ordering(test_pool) -> None:  # type: ignore[no-untyped-def]
     db = _seed_contacts_corpus(test_pool)
-    results, total = db.contacts_search(limit=100)
+    results, total = db.contacts_search(limit=100, include_total=True)
     assert total == len(results)
     # Ordered by (messages_from + messages_to) DESC
     volumes = [r["messages_from"] + r["messages_to"] for r in results]

--- a/tests/integration/test_maildb.py
+++ b/tests/integration/test_maildb.py
@@ -457,6 +457,19 @@ def test_search_total_counts_seen_results(test_pool, seed_emails) -> None:  # ty
     assert total == 1 + len(results)
 
 
+def test_search_all_total_is_offset_plus_returned(test_pool, seed_emails) -> None:  # type: ignore[no-untyped-def]
+    """search_all total is a lower bound: offset + len(results), not unified pool size."""
+    mock_ec = MagicMock()
+    mock_ec.embed.return_value = [0.1] * 768
+    db = MailDB._from_pool(test_pool, embedding_client=mock_ec)
+
+    results, total = db.search_all("budget discussion", limit=1, offset=0)
+    assert total == len(results)
+
+    results, total = db.search_all("budget discussion", limit=1, offset=1)
+    assert total == 1 + len(results)
+
+
 def test_search_with_filters(test_pool, seed_emails) -> None:  # type: ignore[no-untyped-def]
     mock_ec = MagicMock()
     mock_ec.embed.return_value = [0.1] * 768
@@ -755,7 +768,9 @@ def test_topics_with_selection_sequence_matches_python_implementation(test_pool)
         "topics-seq-2@example.com",
         "topics-seq-1@example.com",
     ]
-    assert total == 4
+    # total is lower bound: offset + returned (not candidate-pool size)
+    assert total == 0 + len(topics)
+    assert total == 3
 
 
 # ---------------------------------------------------------------------------
@@ -836,6 +851,32 @@ def test_topics_with_no_args_raises(test_pool, seed_advanced) -> None:  # type: 
     db = MailDB._from_pool(test_pool)
     with pytest.raises(ValueError, match="sender or sender_domain"):
         db.topics_with()
+
+
+def test_topics_with_total_is_offset_plus_returned(test_pool) -> None:  # type: ignore[no-untyped-def]
+    """topics_with total is a lower bound: offset + len(results), not pool size."""
+    with test_pool.connection() as conn:
+        for i, first_dims in enumerate([[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]):
+            conn.execute(
+                """INSERT INTO emails (message_id, thread_id, sender_address, sender_domain,
+                       date, embedding)
+                   VALUES (%(mid)s, 'topics-total', 'topictotal@example.com', 'example.com',
+                       %(date)s, %(embedding)s)""",
+                {
+                    "mid": f"topics-total-{i}@example.com",
+                    "date": datetime(2025, 6, 4 - i, tzinfo=UTC),
+                    "embedding": first_dims + [0.0] * 766,
+                },
+            )
+        conn.commit()
+
+    db = MailDB._from_pool(test_pool)
+
+    results, total = db.topics_with(sender="topictotal@example.com", limit=2, offset=0)
+    assert total == len(results)
+
+    results, total = db.topics_with(sender="topictotal@example.com", limit=2, offset=1)
+    assert total == 1 + len(results)
 
 
 def test_long_threads_with_after(test_pool, seed_advanced) -> None:  # type: ignore[no-untyped-def]

--- a/tests/integration/test_multi_account_queries.py
+++ b/tests/integration/test_multi_account_queries.py
@@ -59,10 +59,10 @@ def test_duplicate_emails_surface_under_both_accounts(
 
 def test_find_no_account_returns_all(test_pool, test_settings, multi_account_seed):
     db = _db(test_pool, test_settings)
-    results, total = db.find(limit=100)
+    results, total = db.find(limit=100, include_total=True)
     accounts = {e.source_account for e in results}
     assert accounts == {"a@example.com", "b@example.com"}
-    assert total >= 6
+    assert total is not None and total >= 6
 
 
 def test_accounts_summary(test_pool, test_settings, multi_account_seed):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 from typer.testing import CliRunner
 
 from maildb.cli import app
+from maildb.models import ImportRecord
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -82,26 +84,24 @@ def test_ingest_run_skip_embed_flag(tmp_path: Path):
 
 
 def test_ingest_status_invokes_get_status():
+    record = ImportRecord(
+        id=uuid4(),
+        source_account="you@example.com",
+        source_file=None,
+        started_at=datetime(2026, 4, 16, 12, 0, tzinfo=UTC),
+        completed_at=None,
+        messages_total=45,
+        messages_inserted=42,
+        messages_skipped=3,
+        status="completed",
+    )
     with (
         patch("maildb.cli.get_status") as mock_status,
         patch("maildb.cli.create_pool") as mock_pool,
         patch("maildb.cli.init_db"),
+        patch("maildb.cli.MailDB.import_history", return_value=[record]) as mock_history,
     ):
-        # Arrange: pool.connection() → cursor → execute() → fetchall returns a row.
-        pool_instance = MagicMock()
-        cursor = MagicMock()
-        cursor.fetchall.return_value = [
-            (
-                datetime(2026, 4, 16, 12, 0, tzinfo=UTC),
-                "you@example.com",
-                "completed",
-                42,
-                3,
-            )
-        ]
-        pool_instance.connection.return_value.__enter__.return_value.execute.return_value = cursor
-        mock_pool.return_value = pool_instance
-
+        mock_pool.return_value = MagicMock()
         mock_status.return_value = {
             "split": {},
             "parse": {},
@@ -113,6 +113,7 @@ def test_ingest_status_invokes_get_status():
 
     assert result.exit_code == 0, result.output
     mock_status.assert_called_once()
+    mock_history.assert_called_once_with(account=None, limit=20)
     # Confirms _print_imports_summary actually ran the loop body.
     assert "Imports" in result.output
     assert "you@example.com" in result.output
@@ -121,19 +122,14 @@ def test_ingest_status_invokes_get_status():
 
 
 def test_ingest_status_filters_by_account():
-    """--account adds source_account filter to the imports query."""
+    """--account is passed through to import_history."""
     with (
         patch("maildb.cli.get_status") as mock_status,
         patch("maildb.cli.create_pool") as mock_pool,
         patch("maildb.cli.init_db"),
+        patch("maildb.cli.MailDB.import_history", return_value=[]) as mock_history,
     ):
-        pool_instance = MagicMock()
-        cursor = MagicMock()
-        cursor.fetchall.return_value = []
-        execute_mock = pool_instance.connection.return_value.__enter__.return_value.execute
-        execute_mock.return_value = cursor
-        mock_pool.return_value = pool_instance
-
+        mock_pool.return_value = MagicMock()
         mock_status.return_value = {
             "split": {},
             "parse": {},
@@ -144,11 +140,7 @@ def test_ingest_status_filters_by_account():
         result = runner.invoke(app, ["ingest", "status", "--account", "you@example.com"])
 
     assert result.exit_code == 0, result.output
-    # Verify the account filter was applied in the SQL params.
-    calls = execute_mock.call_args_list
-    assert any(
-        len(call.args) >= 2 and call.args[1].get("account") == "you@example.com" for call in calls
-    )
+    mock_history.assert_called_once_with(account="you@example.com", limit=20)
 
 
 def test_ingest_reset_requires_yes_or_aborts():

--- a/tests/unit/test_log_tool.py
+++ b/tests/unit/test_log_tool.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
+import maildb.server as server_mod
 from maildb.cli import _configure_logging
 from maildb.config import Settings
 from maildb.server import log_tool
@@ -42,6 +43,7 @@ def test_log_tool_logs_entry_and_exit(
     assert "stripe.com" in content
     assert "tool_exit" in content
     assert "rows" in content
+    assert "response_bytes" in content
     assert result == [{"id": "1", "subject": "test"}]
 
 
@@ -49,26 +51,79 @@ def test_log_tool_warns_on_large_response(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """@log_tool emits a warning when response exceeds 50KB."""
-    log_path = tmp_path / "debug.log"
-    settings = Settings(
-        _env_file=None,  # type: ignore[call-arg]
-        debug_log=str(log_path),
-    )
-    _configure_logging(settings)
+    """Root DEBUG + handler at DEBUG: response_bytes present; 50KB warning fires."""
+    # CLI shape: root always DEBUG; handler levels do the gating.
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
+    root.addHandler(handler)
+
+    warning_events: list[dict[str, Any]] = []
+    real_warning = server_mod.logger.warning
+
+    def spy_warning(event: str, *args: Any, **kwargs: Any) -> Any:
+        if event == "tool_exit":
+            warning_events.append(dict(kwargs))
+        return real_warning(event, *args, **kwargs)
+
+    monkeypatch.setattr(server_mod.logger, "warning", spy_warning)
 
     @log_tool
     def big_result(ctx: Any) -> list[dict[str, Any]]:
         return [{"body": "x" * 100_000}]
 
-    mock_ctx = MagicMock()
-    big_result(mock_ctx)
+    big_result(MagicMock())
 
-    for handler in logging.getLogger().handlers:
-        handler.flush()
+    assert warning_events
+    assert "response_bytes" in warning_events[0]
+    assert warning_events[0].get("warning") == "response exceeds 50KB"
 
-    content = log_path.read_text()
-    assert "response exceeds 50KB" in content
+
+def test_log_tool_skips_response_measurement_when_not_debug(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Root DEBUG + handler at INFO: no json.dumps, exit omits response_bytes."""
+    # CLI shape: root always DEBUG; handler levels do the gating.
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    root.addHandler(handler)
+
+    dumps_calls: list[Any] = []
+    real_dumps = server_mod.json.dumps
+
+    def spy_dumps(obj: Any, *args: Any, **kwargs: Any) -> str:
+        dumps_calls.append(obj)
+        return real_dumps(obj, *args, **kwargs)
+
+    monkeypatch.setattr(server_mod.json, "dumps", spy_dumps)
+
+    exit_events: list[dict[str, Any]] = []
+    real_debug = server_mod.logger.debug
+
+    def spy_debug(event: str, *args: Any, **kwargs: Any) -> Any:
+        if event == "tool_exit":
+            exit_events.append(dict(kwargs))
+        return real_debug(event, *args, **kwargs)
+
+    monkeypatch.setattr(server_mod.logger, "debug", spy_debug)
+
+    @log_tool
+    def find(ctx: Any) -> list[dict[str, Any]]:
+        return [{"id": "1"}]
+
+    find(MagicMock())
+
+    assert dumps_calls == []
+    assert exit_events
+    assert "response_bytes" not in exit_events[0]
+    assert "rows" in exit_events[0]
+    assert "elapsed_ms" in exit_events[0]
 
 
 def test_log_tool_excludes_ctx_from_params(

--- a/tests/unit/test_maildb_sql.py
+++ b/tests/unit/test_maildb_sql.py
@@ -95,6 +95,43 @@ def test_find_uses_deterministic_order_clauses(monkeypatch) -> None:
     assert "ORDER BY sender_address DESC, id LIMIT" in capture.sql[2]
 
 
+def test_find_default_sql_has_no_window_count(monkeypatch) -> None:
+    capture = QueryCapture()
+    monkeypatch.setattr(maildb_module, "_query_dicts", capture)
+    db = _db()
+
+    results, total = db.find()
+
+    assert "COUNT(*) OVER()" not in capture.sql[0]
+    assert "COUNT(*)" not in capture.sql[0]
+    assert total is None
+    assert results == []
+
+
+def test_find_include_total_issues_count_query(monkeypatch) -> None:
+    dicts_capture = QueryCapture()
+    monkeypatch.setattr(maildb_module, "_query_dicts", dicts_capture)
+
+    def fake_one(
+        pool: object,
+        sql: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        dicts_capture.sql.append(" ".join(sql.split()))
+        dicts_capture.params.append(params)
+        return {"n": 7}
+
+    monkeypatch.setattr(maildb_module, "_query_one_dict", fake_one)
+    db = _db()
+
+    results, total = db.find(include_total=True)
+
+    assert "COUNT(*) OVER()" not in dicts_capture.sql[0]
+    assert "SELECT COUNT(*) AS n FROM emails WHERE" in dicts_capture.sql[1]
+    assert total == 7
+    assert results == []
+
+
 def test_correspondence_uses_deterministic_order_clause(monkeypatch) -> None:
     capture = QueryCapture()
     monkeypatch.setattr(maildb_module, "_query_dicts", capture)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -221,6 +221,12 @@ def test_wrap_response_empty() -> None:
     assert wrapped == {"total": 0, "offset": 0, "limit": 50, "results": []}
 
 
+def test_wrap_response_null_total() -> None:
+    wrapped = _wrap_response([], total=None, offset=0, limit=50)
+    assert wrapped == {"total": None, "offset": 0, "limit": 50, "results": []}
+    assert "total" in wrapped
+
+
 def test_mcp_has_all_tools() -> None:
     tool_names = set(mcp._tool_manager._tools.keys())
 
@@ -245,13 +251,28 @@ def test_mcp_has_all_tools() -> None:
 
 def test_find_passes_account_to_db() -> None:
     mock_db = MagicMock()
-    mock_db.find.return_value = ([], 0)
+    mock_db.find.return_value = ([], None)
     ctx = MagicMock()
     ctx.request_context.lifespan_context.db = mock_db
 
-    server.find(ctx, account="you@example.com")
+    result = server.find(ctx, account="you@example.com")
     kwargs = mock_db.find.call_args.kwargs
     assert kwargs["account"] == "you@example.com"
+    assert kwargs["include_total"] is False
+    assert result["total"] is None
+
+
+def test_find_include_total_envelope() -> None:
+    mock_db = MagicMock()
+    mock_db.find.return_value = ([], 3)
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context.db = mock_db
+
+    result = server.find(ctx, include_total=True)
+    kwargs = mock_db.find.call_args.kwargs
+    assert kwargs["include_total"] is True
+    assert result["total"] == 3
+    assert "total" in result
 
 
 def test_accounts_tool_serializes_summaries() -> None:
@@ -416,6 +437,7 @@ def test_contacts_tool_passes_params_and_uses_envelope() -> None:
         min_human_probability=0.5,
         limit=10,
         offset=5,
+        include_total=True,
     )
     kwargs = mock_db.contacts_search.call_args.kwargs
     assert kwargs["query"] == "Alice"
@@ -424,6 +446,7 @@ def test_contacts_tool_passes_params_and_uses_envelope() -> None:
     assert kwargs["min_human_probability"] == 0.5
     assert kwargs["limit"] == 10
     assert kwargs["offset"] == 5
+    assert kwargs["include_total"] is True
     assert result["total"] == 1
     assert result["offset"] == 5
     assert result["limit"] == 10


### PR DESCRIPTION
## Objective

Close out the remaining open findings from the 2026-06-10 deep review as one bundled PR (three task commits).

## Tasks

- [x] **Task 1** (4fc28b6) — `include_total: bool = False` on the seven non-semantic list endpoints; no `COUNT(*) OVER()` by default; opt-in exact count via separate COUNT query (correct at any offset). Fixes the MEDIUM pagination-materialization finding and the LOW offset-past-end total bug.
- [x] **Task 2** (d237eb9) — honest semantic totals (`search_all`, `topics_with` → `offset + returned` lower bound); `log_tool` response measurement gated on a root handler actually emitting DEBUG. **1 revision round:** the first attempt gated on `isEnabledFor(DEBUG)`, which is always true because the CLI keeps the root logger at DEBUG and gates via handler levels — a production no-op, caught in review.
- [x] **Task 3** — CLI `_print_imports_summary` → `import_history()` (raw SQL removed, output identical); minimal GitHub Actions CI (ruff format/check, mypy, unit tests); SKILL.md updated for the new totals semantics + missing `contacts` tool row.

## Gate

`uv run just check` green after every task commit. Final: 640 passed, coverage 87.83%.

## Reviews

Per-task written reviews (correctness/security/performance/quality) are recorded in the session's `.cheap-coder/review-0{1,2,3}.md` artifacts; task 1 & 3 approved as-is, task 2 approved after revision round 1. Residual MINOR left as-is: `find`/`correspondence`/`mention_search` inline their count queries instead of reusing the `_count` helper.

## Provenance

Implementer: Grok Build CLI, `grok-4.5` @ **minimal** reasoning effort (deliberate lowest-effort test; the API rejects `none`). Architecture, spec, review: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP7M17NHxw6mjpTFtMqwZu