### PR TITLE
refactor(query): reuse _count helper for inline total queries

### DIFF
--- a/src/maildb/maildb.py
+++ b/src/maildb/maildb.py
@@ -338,11 +338,7 @@ class MailDB:
         results = [Email.from_row(row) for row in rows]
         if not include_total:
             return results, None
-        count_row = _query_one_dict(
-            self._pool, f"SELECT COUNT(*) AS n FROM emails WHERE {where}", params
-        )
-        total = int(count_row["n"]) if count_row is not None else 0
-        return results, total
+        return results, _count(self._pool, f"SELECT 1 FROM emails WHERE {where}", params)
 
     def search(
         self,
@@ -1068,11 +1064,7 @@ class MailDB:
         results = [Email.from_row(row) for row in rows]
         if not include_total:
             return results, None
-        count_row = _query_one_dict(
-            self._pool, f"SELECT COUNT(*) AS n FROM emails WHERE {where}", params
-        )
-        total = int(count_row["n"]) if count_row is not None else 0
-        return results, total
+        return results, _count(self._pool, f"SELECT 1 FROM emails WHERE {where}", params)
 
     def mention_search(
         self,
@@ -1139,11 +1131,7 @@ class MailDB:
         results = [Email.from_row(row) for row in rows]
         if not include_total:
             return results, None
-        count_row = _query_one_dict(
-            self._pool, f"SELECT COUNT(*) AS n FROM emails WHERE {where}", params
-        )
-        total = int(count_row["n"]) if count_row is not None else 0
-        return results, total
+        return results, _count(self._pool, f"SELECT 1 FROM emails WHERE {where}", params)
 
     def search_attachments(
         self,

--- a/tests/unit/test_maildb_sql.py
+++ b/tests/unit/test_maildb_sql.py
@@ -127,7 +127,10 @@ def test_find_include_total_issues_count_query(monkeypatch) -> None:
     results, total = db.find(include_total=True)
 
     assert "COUNT(*) OVER()" not in dicts_capture.sql[0]
-    assert "SELECT COUNT(*) AS n FROM emails WHERE" in dicts_capture.sql[1]
+    assert (
+        "SELECT COUNT(*) AS n FROM (SELECT 1 FROM emails WHERE TRUE) AS _count_sub"
+        in dicts_capture.sql[1]
+    )
     assert total == 7
     assert results == []
 


### PR DESCRIPTION
## Objective

Close out the residual MINOR from #102: `find`, `correspondence`, and `mention_search` inlined near-identical count blocks instead of reusing the `_count` helper. All `include_total` paths now go through `_count` (counting over `SELECT 1 FROM emails WHERE ...` — same rows, no column materialization). Net −12 lines, behavior unchanged.

## Gate

`uv run just check` — exit 0, 640 passed, coverage 87.86%. No inline `SELECT COUNT(*) AS n FROM emails` remains (grep-verified).

## Provenance

Implementer: Grok Build CLI, `grok-4.5` @ minimal reasoning effort. Architecture, spec, review: Claude. Review recorded in session `.cheap-coder/review-01.md`; merge authorized by the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP7M17NHxw6mjpTFtMqwZu