### PR TITLE
feat(chronicle): Phase 1 — Chronicle foundation

### DIFF
--- a/apps/chronicle/server/src/chronicle_server/app.py
+++ b/apps/chronicle/server/src/chronicle_server/app.py
@@ -10,6 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 
 from chronicle_server.archive import router as archive_router
 from chronicle_server.auth import router as auth_router
+from chronicle_server.chronicle import router as chronicle_router
 from chronicle_server.config import ChronicleSettings
 from chronicle_server.db import create_pool, ensure_user, init_app_tables
 from chronicle_server.health import router as health_router
@@ -59,6 +60,7 @@ def create_app(settings: ChronicleSettings | None = None) -> FastAPI:
     app.add_middleware(SecurityHeadersMiddleware)
     app.include_router(auth_router, prefix="/api/auth")
     app.include_router(archive_router, prefix="/api/archive")
+    app.include_router(chronicle_router, prefix="/api/chronicle")
     app.include_router(health_router, prefix="/api/health")
     app.include_router(sources_router, prefix="/api")
     # Stash settings early so tests can inspect before lifespan if needed.

--- a/apps/chronicle/server/src/chronicle_server/chronicle.py
+++ b/apps/chronicle/server/src/chronicle_server/chronicle.py
@@ -1,0 +1,462 @@
+# src/chronicle_server/chronicle.py
+"""Chronicle time-bucket aggregates: lanes, density navigator, extent.
+
+Null-date records are excluded from all timeline aggregates (``date IS NOT NULL``);
+they remain reachable via list endpoints.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from chronicle_server.auth import require_user
+from chronicle_server.scope import QueryScope, scope_filters, scope_fingerprint
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = structlog.get_logger()
+
+router = APIRouter(tags=["chronicle"])
+
+VALID_UNITS: tuple[str, ...] = ("hour", "day", "week", "month", "quarter", "year")
+VALID_LANES = frozenset({"messages", "attachments", "people"})
+MAX_BUCKETS = 2000
+MIN_PIXEL_WIDTH = 320
+MAX_PIXEL_WIDTH = 8192
+DENSITY_PIXEL_WIDTH = 1600
+
+# Approximate unit widths for bucket-count estimation (pixel-width rule).
+_UNIT_SECONDS: dict[str, float] = {
+    "hour": 3600.0,
+    "day": 86400.0,
+    "week": 7 * 86400.0,
+    "month": 30 * 86400.0,
+    "quarter": 91 * 86400.0,
+    "year": 365 * 86400.0,
+}
+
+
+class AggregationTooFineError(ValueError):
+    """Explicit aggregation would exceed the 2000-bucket ceiling."""
+
+    def __init__(self, requested: str, smallest_valid_unit: str) -> None:
+        self.requested = requested
+        self.smallest_valid_unit = smallest_valid_unit
+        super().__init__(
+            f"aggregation {requested!r} exceeds {MAX_BUCKETS} buckets; "
+            f"smallest valid unit is {smallest_valid_unit!r}"
+        )
+
+
+# --- request / response models ---
+
+
+class TimeRange(BaseModel):
+    from_: str = Field(..., alias="from")
+    to: str
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ExtentRange(BaseModel):
+    from_: str | None = Field(None, alias="from")
+    to: str | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class BucketPoint(BaseModel):
+    bucket: str
+    count: int
+
+
+class DensitySeries(BaseModel):
+    unit: str
+    buckets: list[BucketPoint]
+
+
+class BucketsRequest(BaseModel):
+    scope: QueryScope = Field(default_factory=QueryScope)
+    viewport: TimeRange
+    pixel_width: int = 920
+    aggregation: str = "auto"
+    lanes: list[str] = Field(default_factory=lambda: ["messages", "attachments", "people"])
+
+    @field_validator("aggregation")
+    @classmethod
+    def _check_aggregation(cls, value: str) -> str:
+        allowed = {"auto", *VALID_UNITS}
+        if value not in allowed:
+            raise ValueError(f"aggregation must be one of {sorted(allowed)}; got {value!r}")
+        return value
+
+    @field_validator("lanes")
+    @classmethod
+    def _check_lanes(cls, value: list[str]) -> list[str]:
+        unknown = [lane for lane in value if lane not in VALID_LANES]
+        if unknown:
+            raise ValueError(f"lanes must be subset of {sorted(VALID_LANES)}; unknown: {unknown}")
+        return value
+
+
+class BucketsResponse(BaseModel):
+    scope_fingerprint: str
+    aggregation: str
+    unit: str
+    viewport: TimeRange
+    lanes: dict[str, list[BucketPoint]]
+    density: DensitySeries
+    extent: ExtentRange
+    generated_at: str
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+# --- pure helpers ---
+
+
+def clamp_pixel_width(pixel_width: int) -> int:
+    """Clamp pixel width to the allowed server range [320, 8192]."""
+    return max(MIN_PIXEL_WIDTH, min(MAX_PIXEL_WIDTH, pixel_width))
+
+
+def estimated_bucket_count(duration: timedelta, unit: str) -> float:
+    """Approximate number of *unit* buckets spanning *duration*."""
+    seconds = max(duration.total_seconds(), 0.0)
+    return seconds / _UNIT_SECONDS[unit]
+
+
+def choose_aggregation(viewport_duration: timedelta, pixel_width: int) -> str:
+    """Pick aggregation unit from viewport duration and pixel width.
+
+    Target bucket width ≈ 8 px: ``target_buckets = pixel_width / 8``.
+    Choose the smallest (finest) unit from
+    ``[hour, day, week, month, quarter, year]`` whose estimated bucket count
+    is ≤ ``max(target_buckets, 32)``. If even ``year`` exceeds that (or the
+    2000-bucket soft ceiling), still return ``year``.
+    """
+    target_buckets = pixel_width / 8.0
+    max_allowed = max(target_buckets, 32.0)
+    for unit in VALID_UNITS:
+        if estimated_bucket_count(viewport_duration, unit) <= max_allowed:
+            return unit
+    return "year"
+
+
+def resolve_aggregation(
+    aggregation: str,
+    viewport_duration: timedelta,
+    pixel_width: int,
+) -> str:
+    """Resolve ``auto`` or validate an explicit unit against the 2000 ceiling.
+
+    Raises :class:`AggregationTooFineError` when an explicit unit would produce
+    more than 2000 buckets (naming the finest unit that fits).
+    """
+    if aggregation == "auto":
+        return choose_aggregation(viewport_duration, pixel_width)
+
+    if estimated_bucket_count(viewport_duration, aggregation) <= MAX_BUCKETS:
+        return aggregation
+
+    smallest_valid = "year"
+    for unit in VALID_UNITS:
+        if estimated_bucket_count(viewport_duration, unit) <= MAX_BUCKETS:
+            smallest_valid = unit
+            break
+    raise AggregationTooFineError(aggregation, smallest_valid)
+
+
+def parse_iso_datetime(value: str) -> datetime:
+    """Parse an ISO date or datetime string into an aware UTC datetime."""
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    # Date-only: treat as midnight UTC.
+    if len(text) == 10 and text[4] == "-" and text[7] == "-":
+        text = text + "T00:00:00+00:00"
+    dt = datetime.fromisoformat(text)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _iso_utc(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt: datetime = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+        return dt.isoformat().replace("+00:00", "Z")
+    if hasattr(value, "isoformat"):
+        return value.isoformat()  # type: ignore[no-any-return]
+    return str(value)
+
+
+def _and_clause(conditions: list[str]) -> str:
+    if not conditions:
+        return ""
+    return " AND " + " AND ".join(conditions)
+
+
+# --- SQL lane queries ---
+
+
+def _fetch_bucket_rows(
+    pool: ConnectionPool,
+    sql: str,
+    params: dict[str, Any],
+) -> list[BucketPoint]:
+    with pool.connection() as conn:
+        rows = conn.execute(sql, params).fetchall()
+    points: list[BucketPoint] = []
+    for row in rows:
+        bucket = _iso_utc(row[0])
+        if bucket is None:
+            continue
+        points.append(BucketPoint(bucket=bucket, count=int(row[1])))
+    return points
+
+
+def _messages_buckets(
+    pool: ConnectionPool,
+    *,
+    unit: str,
+    viewport_from: str,
+    viewport_to: str,
+    scope_conds: list[str],
+    scope_params: dict[str, Any],
+) -> list[BucketPoint]:
+    where = [
+        "date IS NOT NULL",
+        "date >= %(viewport_from)s",
+        "date < %(viewport_to)s",
+        *scope_conds,
+    ]
+    sql = f"""
+        SELECT date_trunc(%(unit)s, date) AS bucket, count(*)::int AS count
+        FROM emails
+        WHERE {" AND ".join(where)}
+        GROUP BY 1
+        ORDER BY 1
+    """
+    params = {
+        **scope_params,
+        "unit": unit,
+        "viewport_from": viewport_from,
+        "viewport_to": viewport_to,
+    }
+    return _fetch_bucket_rows(pool, sql, params)
+
+
+def _attachments_buckets(
+    pool: ConnectionPool,
+    *,
+    unit: str,
+    viewport_from: str,
+    viewport_to: str,
+    scope_conds: list[str],
+    scope_params: dict[str, Any],
+) -> list[BucketPoint]:
+    # Scope filters target emails columns; unqualified names are unambiguous
+    # because email_attachments has no date/source_account/sender_address.
+    where = [
+        "date IS NOT NULL",
+        "date >= %(viewport_from)s",
+        "date < %(viewport_to)s",
+        *scope_conds,
+    ]
+    sql = f"""
+        SELECT date_trunc(%(unit)s, e.date) AS bucket,
+               count(ea.attachment_id)::int AS count
+        FROM emails e
+        JOIN email_attachments ea ON ea.email_id = e.id
+        WHERE {" AND ".join(where)}
+        GROUP BY 1
+        ORDER BY 1
+    """
+    params = {
+        **scope_params,
+        "unit": unit,
+        "viewport_from": viewport_from,
+        "viewport_to": viewport_to,
+    }
+    return _fetch_bucket_rows(pool, sql, params)
+
+
+def _people_buckets(
+    pool: ConnectionPool,
+    *,
+    unit: str,
+    viewport_from: str,
+    viewport_to: str,
+    scope_conds: list[str],
+    scope_params: dict[str, Any],
+) -> list[BucketPoint]:
+    where = [
+        "date IS NOT NULL",
+        "date >= %(viewport_from)s",
+        "date < %(viewport_to)s",
+        *scope_conds,
+    ]
+    sql = f"""
+        SELECT date_trunc(%(unit)s, date) AS bucket,
+               count(DISTINCT sender_address)::int AS count
+        FROM emails
+        WHERE {" AND ".join(where)}
+        GROUP BY 1
+        ORDER BY 1
+    """
+    params = {
+        **scope_params,
+        "unit": unit,
+        "viewport_from": viewport_from,
+        "viewport_to": viewport_to,
+    }
+    return _fetch_bucket_rows(pool, sql, params)
+
+
+def _extent(
+    pool: ConnectionPool,
+    scope_conds: list[str],
+    scope_params: dict[str, Any],
+) -> tuple[datetime | None, datetime | None]:
+    sql = f"""
+        SELECT min(date), max(date)
+        FROM emails
+        WHERE date IS NOT NULL{_and_clause(scope_conds)}
+    """
+    with pool.connection() as conn:
+        row = conn.execute(sql, scope_params).fetchone()
+    if row is None:
+        return None, None
+    return row[0], row[1]
+
+
+def _density_buckets(
+    pool: ConnectionPool,
+    *,
+    unit: str,
+    scope_conds: list[str],
+    scope_params: dict[str, Any],
+) -> list[BucketPoint]:
+    sql = f"""
+        SELECT date_trunc(%(unit)s, date) AS bucket, count(*)::int AS count
+        FROM emails
+        WHERE date IS NOT NULL{_and_clause(scope_conds)}
+        GROUP BY 1
+        ORDER BY 1
+    """
+    params = {**scope_params, "unit": unit}
+    return _fetch_bucket_rows(pool, sql, params)
+
+
+_LANE_HANDLERS = {
+    "messages": _messages_buckets,
+    "attachments": _attachments_buckets,
+    "people": _people_buckets,
+}
+
+
+def get_buckets(pool: ConnectionPool, body: BucketsRequest) -> BucketsResponse:
+    """Compute lane aggregates, density series, and scope extent (read-only)."""
+    pixel_width = clamp_pixel_width(body.pixel_width)
+    vp_from = parse_iso_datetime(body.viewport.from_)
+    vp_to = parse_iso_datetime(body.viewport.to)
+    if vp_to <= vp_from:
+        raise HTTPException(
+            status_code=422,
+            detail="viewport.to must be after viewport.from",
+        )
+    duration = vp_to - vp_from
+
+    try:
+        unit = resolve_aggregation(body.aggregation, duration, pixel_width)
+    except AggregationTooFineError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "aggregation_exceeds_max_buckets",
+                "max_buckets": MAX_BUCKETS,
+                "requested": exc.requested,
+                "smallest_valid_unit": exc.smallest_valid_unit,
+            },
+        ) from exc
+
+    scope_conds, scope_params = scope_filters(body.scope)
+    # Qualify scope column refs for the attachments join path that aliases emails.
+    # Unqualified names work (email_attachments has no colliding columns), so we
+    # pass the same conditions to every lane.
+
+    viewport_from_s = body.viewport.from_
+    viewport_to_s = body.viewport.to
+
+    lane_data: dict[str, list[BucketPoint]] = {}
+    for lane in body.lanes:
+        handler = _LANE_HANDLERS[lane]
+        lane_data[lane] = handler(
+            pool,
+            unit=unit,
+            viewport_from=viewport_from_s,
+            viewport_to=viewport_to_s,
+            scope_conds=scope_conds,
+            scope_params=scope_params,
+        )
+
+    extent_min, extent_max = _extent(pool, scope_conds, scope_params)
+    if extent_min is not None and extent_max is not None:
+        # Inclusive max date: use a 1-second span at least so duration > 0.
+        extent_duration = max(extent_max - extent_min, timedelta(seconds=1))
+        density_unit = choose_aggregation(extent_duration, DENSITY_PIXEL_WIDTH)
+    else:
+        density_unit = "year"
+
+    density_points = _density_buckets(
+        pool,
+        unit=density_unit,
+        scope_conds=scope_conds,
+        scope_params=scope_params,
+    )
+
+    generated_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    fingerprint = scope_fingerprint(body.scope)
+
+    logger.info(
+        "chronicle_buckets",
+        unit=unit,
+        lanes=list(body.lanes),
+        pixel_width=pixel_width,
+        scope_fingerprint=fingerprint,
+    )
+
+    return BucketsResponse(
+        scope_fingerprint=fingerprint,
+        aggregation=unit,
+        unit=unit,
+        viewport=body.viewport,
+        lanes=lane_data,
+        density=DensitySeries(unit=density_unit, buckets=density_points),
+        extent=ExtentRange(
+            **{
+                "from": _iso_utc(extent_min),
+                "to": _iso_utc(extent_max),
+            }
+        ),
+        generated_at=generated_at,
+    )
+
+
+@router.post("/buckets", response_model=BucketsResponse)
+def chronicle_buckets(
+    body: BucketsRequest,
+    request: Request,
+    _user: str = Depends(require_user),
+) -> BucketsResponse:
+    """Time-bucketed lane aggregates for a working-set scope and viewport."""
+    pool: ConnectionPool = request.app.state.pool
+    return get_buckets(pool, body)

--- a/apps/chronicle/server/src/chronicle_server/chronicle.py
+++ b/apps/chronicle/server/src/chronicle_server/chronicle.py
@@ -25,11 +25,12 @@ logger = structlog.get_logger()
 router = APIRouter(tags=["chronicle"])
 
 VALID_UNITS: tuple[str, ...] = ("hour", "day", "week", "month", "quarter", "year")
-VALID_LANES = frozenset({"messages", "attachments", "people"})
+VALID_LANES = frozenset({"messages", "attachments", "people", "top_people"})
 MAX_BUCKETS = 2000
 MIN_PIXEL_WIDTH = 320
 MAX_PIXEL_WIDTH = 8192
 DENSITY_PIXEL_WIDTH = 1600
+TOP_PEOPLE_LIMIT = 8
 
 # Approximate unit widths for bucket-count estimation (pixel-width rule).
 _UNIT_SECONDS: dict[str, float] = {
@@ -76,6 +77,20 @@ class BucketPoint(BaseModel):
     count: int
 
 
+class TopPeopleContactSeries(BaseModel):
+    """Activity bucket series for one contact (activity spans only)."""
+
+    contact_id: str
+    display_name: str
+    buckets: list[BucketPoint]
+
+
+class TopPeopleLaneData(BaseModel):
+    """top_people lane payload: top contacts by volume within viewport+scope."""
+
+    contacts: list[TopPeopleContactSeries]
+
+
 class DensitySeries(BaseModel):
     unit: str
     buckets: list[BucketPoint]
@@ -110,7 +125,7 @@ class BucketsResponse(BaseModel):
     aggregation: str
     unit: str
     viewport: TimeRange
-    lanes: dict[str, list[BucketPoint]]
+    lanes: dict[str, list[BucketPoint] | TopPeopleLaneData]
     density: DensitySeries
     extent: ExtentRange
     generated_at: str
@@ -321,6 +336,121 @@ def _people_buckets(
     return _fetch_bucket_rows(pool, sql, params)
 
 
+def _top_people_buckets(
+    pool: ConnectionPool,
+    *,
+    unit: str,
+    viewport_from: str,
+    viewport_to: str,
+    scope_conds: list[str],
+    scope_params: dict[str, Any],
+) -> TopPeopleLaneData:
+    """Top contacts by sent-message volume within viewport+scope (activity spans).
+
+    One set-based statement: emails ⨝ contact_addresses, ranked by volume,
+    limited to top 8, excluding contacts whose every address is the user.
+    Display name falls back to the address with the highest volume.
+    """
+    # Scope filters target emails columns (date/source_account/sender_address).
+    # contact_addresses has none of those, so bare names stay unambiguous with
+    # the emails alias — same pattern as the attachments lane.
+    email_where = [
+        "date IS NOT NULL",
+        "date >= %(viewport_from)s",
+        "date < %(viewport_to)s",
+        *scope_conds,
+    ]
+    sql = f"""
+        WITH filtered AS (
+            SELECT ca.contact_id, e.date, e.sender_address
+            FROM emails e
+            JOIN contact_addresses ca ON ca.address = e.sender_address
+            WHERE {" AND ".join(email_where)}
+        ),
+        eligible AS (
+            SELECT ca.contact_id
+            FROM contact_addresses ca
+            GROUP BY ca.contact_id
+            HAVING NOT bool_and(ca.is_user)
+        ),
+        ranked AS (
+            SELECT f.contact_id, count(*)::int AS total
+            FROM filtered f
+            JOIN eligible el ON el.contact_id = f.contact_id
+            GROUP BY f.contact_id
+            ORDER BY total DESC, f.contact_id
+            LIMIT %(top_limit)s
+        ),
+        bucketed AS (
+            SELECT
+                f.contact_id,
+                date_trunc(%(unit)s, f.date) AS bucket,
+                count(*)::int AS count
+            FROM filtered f
+            JOIN ranked r ON r.contact_id = f.contact_id
+            GROUP BY f.contact_id, 2
+        ),
+        top_addr AS (
+            SELECT contact_id, sender_address
+            FROM (
+                SELECT
+                    f.contact_id,
+                    f.sender_address,
+                    count(*) AS vol,
+                    row_number() OVER (
+                        PARTITION BY f.contact_id
+                        ORDER BY count(*) DESC, f.sender_address
+                    ) AS rn
+                FROM filtered f
+                JOIN ranked r ON r.contact_id = f.contact_id
+                GROUP BY f.contact_id, f.sender_address
+            ) x
+            WHERE rn = 1
+        )
+        SELECT
+            r.contact_id::text,
+            coalesce(nullif(c.display_name, ''), ta.sender_address) AS display_name,
+            b.bucket,
+            coalesce(b.count, 0)::int AS count,
+            r.total
+        FROM ranked r
+        JOIN contacts c ON c.id = r.contact_id
+        JOIN top_addr ta ON ta.contact_id = r.contact_id
+        LEFT JOIN bucketed b ON b.contact_id = r.contact_id
+        ORDER BY r.total DESC, r.contact_id, b.bucket
+    """
+    params = {
+        **scope_params,
+        "unit": unit,
+        "viewport_from": viewport_from,
+        "viewport_to": viewport_to,
+        "top_limit": TOP_PEOPLE_LIMIT,
+    }
+    with pool.connection() as conn:
+        rows = conn.execute(sql, params).fetchall()
+
+    # Group rows into contact series preserving rank order.
+    by_contact: dict[str, TopPeopleContactSeries] = {}
+    order: list[str] = []
+    for row in rows:
+        contact_id = str(row[0])
+        display_name = str(row[1]) if row[1] is not None else contact_id
+        if contact_id not in by_contact:
+            by_contact[contact_id] = TopPeopleContactSeries(
+                contact_id=contact_id,
+                display_name=display_name,
+                buckets=[],
+            )
+            order.append(contact_id)
+        bucket = _iso_utc(row[2])
+        if bucket is None:
+            continue
+        by_contact[contact_id].buckets.append(
+            BucketPoint(bucket=bucket, count=int(row[3])),
+        )
+    return TopPeopleLaneData(contacts=[by_contact[cid] for cid in order])
+
+
 def _extent(
     pool: ConnectionPool,
     scope_conds: list[str],
@@ -396,17 +526,27 @@ def get_buckets(pool: ConnectionPool, body: BucketsRequest) -> BucketsResponse:
     viewport_from_s = body.viewport.from_
     viewport_to_s = body.viewport.to
 
-    lane_data: dict[str, list[BucketPoint]] = {}
+    lane_data: dict[str, list[BucketPoint] | TopPeopleLaneData] = {}
     for lane in body.lanes:
-        handler = _LANE_HANDLERS[lane]
-        lane_data[lane] = handler(
-            pool,
-            unit=unit,
-            viewport_from=viewport_from_s,
-            viewport_to=viewport_to_s,
-            scope_conds=scope_conds,
-            scope_params=scope_params,
-        )
+        if lane == "top_people":
+            lane_data[lane] = _top_people_buckets(
+                pool,
+                unit=unit,
+                viewport_from=viewport_from_s,
+                viewport_to=viewport_to_s,
+                scope_conds=scope_conds,
+                scope_params=scope_params,
+            )
+        else:
+            handler = _LANE_HANDLERS[lane]
+            lane_data[lane] = handler(
+                pool,
+                unit=unit,
+                viewport_from=viewport_from_s,
+                viewport_to=viewport_to_s,
+                scope_conds=scope_conds,
+                scope_params=scope_params,
+            )
 
     extent_min, extent_max = _extent(pool, scope_conds, scope_params)
     if extent_min is not None and extent_max is not None:

--- a/apps/chronicle/server/src/chronicle_server/scope.py
+++ b/apps/chronicle/server/src/chronicle_server/scope.py
@@ -1,0 +1,70 @@
+# src/chronicle_server/scope.py
+"""QueryScope v1: working-set filter model, SQL builder, and fingerprint."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DateRange(BaseModel):
+    from_: str | None = Field(None, alias="from")  # ISO date or datetime
+    to: str | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class QueryScope(BaseModel):
+    version: int = 1
+    date: DateRange | None = None
+    mailboxes: list[str] = []  # source_account values
+    senders: list[str] = []  # exact sender_address values
+    model_config = ConfigDict(populate_by_name=True)
+
+
+def scope_filters(scope: QueryScope) -> tuple[list[str], dict[str, Any]]:
+    """Build WHERE conditions and named params over the ``emails`` table.
+
+    Emits conditions only for provided fields:
+
+    - ``date >= %(scope_from)s`` / ``date < %(scope_to)s``
+    - ``source_account = ANY(%(mailboxes)s)``
+    - ``sender_address = ANY(%(senders)s)``
+
+    Parameterized; never interpolates values into SQL.
+    """
+    conditions: list[str] = []
+    params: dict[str, Any] = {}
+
+    if scope.date is not None:
+        if scope.date.from_ is not None:
+            conditions.append("date >= %(scope_from)s")
+            params["scope_from"] = scope.date.from_
+        if scope.date.to is not None:
+            conditions.append("date < %(scope_to)s")
+            params["scope_to"] = scope.date.to
+
+    if scope.mailboxes:
+        conditions.append("source_account = ANY(%(mailboxes)s)")
+        params["mailboxes"] = list(scope.mailboxes)
+
+    if scope.senders:
+        conditions.append("sender_address = ANY(%(senders)s)")
+        params["senders"] = list(scope.senders)
+
+    return conditions, params
+
+
+def scope_fingerprint(scope: QueryScope) -> str:
+    """Return ``qs_`` + first 16 hex chars of sha256(canonical JSON).
+
+    Canonical form: model dump with sorted keys, aliases, exclude-none.
+    Stable across key order of the input.
+    """
+    data = scope.model_dump(mode="json", by_alias=True, exclude_none=True)
+    canonical = json.dumps(data, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+    return f"qs_{digest}"

--- a/apps/chronicle/server/src/chronicle_server/sources.py
+++ b/apps/chronicle/server/src/chronicle_server/sources.py
@@ -10,11 +10,13 @@ from uuid import UUID
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from chronicle_server.auth import require_user
+from chronicle_server.cursor import decode_cursor, encode_cursor
 from chronicle_server.ids import decode_source_id, encode_source_id, msg_key_to_uuid
 from chronicle_server.sanitize import sanitize_email_html
+from chronicle_server.scope import QueryScope, scope_filters, scope_fingerprint
 
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
@@ -25,6 +27,8 @@ router = APIRouter(tags=["sources"])
 
 _MARKDOWN_PAGE = 50_000
 _THREAD_MSG_CAP = 500
+_LIST_DEFAULT_LIMIT = 50
+_LIST_MAX_LIMIT = 200
 
 
 # --- response models ---
@@ -122,6 +126,41 @@ class ThreadResponse(BaseModel):
     message_count: int
     messages: list[ThreadMessage]
     truncated: bool = False
+
+
+class SourceListRequest(BaseModel):
+    """Envelope-only list for timeline bucket drill-in (keyset pagination)."""
+
+    scope: QueryScope = Field(default_factory=QueryScope)
+    date_from: str
+    date_to: str
+    cursor: str | None = None
+    limit: int = _LIST_DEFAULT_LIMIT
+
+    @field_validator("limit")
+    @classmethod
+    def _clamp_limit(cls, value: int) -> int:
+        if value < 1:
+            raise ValueError("limit must be >= 1")
+        return min(value, _LIST_MAX_LIMIT)
+
+
+class SourceListItem(BaseModel):
+    id: str
+    subject: str | None = None
+    sender_name: str | None = None
+    sender_address: str | None = None
+    date: str | None = None
+    mailbox: str | None = None
+    has_attachment: bool = False
+    attachment_count: int = 0
+    thread_id: str | None = None
+
+
+class SourceListResponse(BaseModel):
+    items: list[SourceListItem]
+    next_cursor: str | None = None
+    scope_fingerprint: str
 
 
 # --- helpers ---
@@ -488,7 +527,154 @@ def get_thread(pool: ConnectionPool, thread_id: str) -> ThreadResponse:
     )
 
 
+def _attachment_count(raw: Any) -> int:
+    """Cheap count from emails.attachments JSONB (array length or 0)."""
+    if raw is None:
+        return 0
+    if isinstance(raw, list):
+        return len(raw)
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    return 0
+
+
+def _parse_list_cursor(token: str, secret_key: str) -> tuple[str | None, UUID]:
+    """Decode keyset cursor ``{d: last_date_iso|null, id: last_uuid}``."""
+    try:
+        payload = decode_cursor(token, secret_key)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid cursor") from exc
+    if "id" not in payload:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+    raw_id = payload["id"]
+    try:
+        last_id = UUID(str(raw_id))
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise HTTPException(status_code=400, detail="invalid cursor") from exc
+    d = payload.get("d")
+    if d is not None and not isinstance(d, str):
+        raise HTTPException(status_code=400, detail="invalid cursor")
+    return d if isinstance(d, str) else None, last_id
+
+
+def list_sources(
+    pool: ConnectionPool,
+    body: SourceListRequest,
+    secret_key: str,
+) -> SourceListResponse:
+    """Envelope-only message list ordered chronologically with keyset pagination.
+
+    Order: ``date ASC NULLS LAST, id ASC``. Cursor payload ``{d, id}`` with
+    NULL dates last:
+    - non-null cursor date: remaining later/same-date rows, then all null dates
+    - null cursor date: further null-date rows only
+    """
+    scope_conds, scope_params = scope_filters(body.scope)
+    conditions: list[str] = [
+        "date >= %(list_from)s",
+        "date < %(list_to)s",
+        *scope_conds,
+    ]
+    params: dict[str, Any] = {
+        "list_from": body.date_from,
+        "list_to": body.date_to,
+        "lim": body.limit + 1,  # fetch one extra to detect next page
+        **scope_params,
+    }
+
+    if body.cursor:
+        cursor_d, cursor_id = _parse_list_cursor(body.cursor, secret_key)
+        params["cursor_id"] = cursor_id
+        if cursor_d is not None:
+            # ASC NULLS LAST: after (d, id) come later dates, same-date higher ids,
+            # then all NULL dates. ORDER BY keeps non-nulls first within the page.
+            params["cursor_d"] = cursor_d
+            conditions.append(
+                "("
+                " (date IS NOT NULL AND (date > %(cursor_d)s"
+                "  OR (date = %(cursor_d)s AND id > %(cursor_id)s)))"
+                " OR date IS NULL"
+                ")"
+            )
+        else:
+            conditions.append("date IS NULL AND id > %(cursor_id)s")
+
+    where_sql = " AND ".join(conditions)
+    sql = f"""
+        SELECT id, thread_id, subject, sender_name, sender_address,
+               date, source_account, has_attachment, attachments
+          FROM emails
+         WHERE {where_sql}
+         ORDER BY date ASC NULLS LAST, id ASC
+         LIMIT %(lim)s
+    """
+
+    with pool.connection() as conn:
+        rows = conn.execute(sql, params).fetchall()
+
+    cols = [
+        "id",
+        "thread_id",
+        "subject",
+        "sender_name",
+        "sender_address",
+        "date",
+        "source_account",
+        "has_attachment",
+        "attachments",
+    ]
+    page = rows[: body.limit]
+    has_more = len(rows) > body.limit
+
+    items: list[SourceListItem] = []
+    for row in page:
+        data = _row_to_dict(row, cols)
+        email_id: UUID = data["id"]
+        thread_raw = data.get("thread_id")
+        thr_sid = encode_source_id("thr", thread_raw) if thread_raw else None
+        items.append(
+            SourceListItem(
+                id=encode_source_id("msg", email_id),
+                subject=data.get("subject"),
+                sender_name=data.get("sender_name"),
+                sender_address=data.get("sender_address"),
+                date=_iso(data.get("date")),
+                mailbox=data.get("source_account"),
+                has_attachment=bool(data.get("has_attachment")),
+                attachment_count=_attachment_count(data.get("attachments")),
+                thread_id=thr_sid,
+            )
+        )
+
+    next_cursor: str | None = None
+    if has_more and page:
+        last = _row_to_dict(page[-1], cols)
+        payload = {
+            "d": _iso(last.get("date")),
+            "id": str(last["id"]),
+        }
+        next_cursor = encode_cursor(payload, secret_key)
+
+    return SourceListResponse(
+        items=items,
+        next_cursor=next_cursor,
+        scope_fingerprint=scope_fingerprint(body.scope),
+    )
+
+
 # --- routes ---
+
+
+@router.post("/sources/list")
+def post_sources_list(
+    body: SourceListRequest,
+    request: Request,
+    _user: str = Depends(require_user),
+) -> SourceListResponse:
+    """Cursor-paginated envelope list for a date window (timeline drill-in)."""
+    pool: ConnectionPool = request.app.state.pool
+    secret_key: str = request.app.state.settings.secret_key
+    return list_sources(pool, body, secret_key)
 
 
 @router.get("/sources/{sid}")

--- a/apps/chronicle/server/tests/test_chronicle.py
+++ b/apps/chronicle/server/tests/test_chronicle.py
@@ -338,3 +338,161 @@ def test_buckets_request_model_defaults() -> None:
     assert req.aggregation == "auto"
     assert req.pixel_width == 920
     assert set(req.lanes) == {"messages", "attachments", "people"}
+
+
+def test_buckets_request_accepts_top_people_lane() -> None:
+    req = BucketsRequest.model_validate(
+        {
+            "viewport": {"from": "2020-01-01", "to": "2021-01-01"},
+            "lanes": ["messages", "top_people"],
+        }
+    )
+    assert "top_people" in req.lanes
+
+
+def _insert_contact(
+    pool: ConnectionPool,
+    *,
+    contact_id: Any,
+    display_name: str | None,
+    addresses: list[tuple[str, bool]],
+) -> None:
+    """Insert a contact and its addresses. addresses: (address, is_user)."""
+    with pool.connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO contacts (id, display_name)
+            VALUES (%(id)s, %(name)s)
+            ON CONFLICT (id) DO UPDATE SET display_name = EXCLUDED.display_name
+            """,
+            {"id": contact_id, "name": display_name},
+        )
+        for address, is_user in addresses:
+            conn.execute(
+                """
+                INSERT INTO contact_addresses (address, contact_id, is_user)
+                VALUES (%(addr)s, %(cid)s, %(is_user)s)
+                ON CONFLICT (address) DO UPDATE
+                  SET contact_id = EXCLUDED.contact_id,
+                      is_user = EXCLUDED.is_user
+                """,
+                {"addr": address, "cid": contact_id, "is_user": is_user},
+            )
+        conn.commit()
+
+
+def _cleanup_top_people_fixtures(pool: ConnectionPool) -> None:
+    with pool.connection() as conn:
+        conn.execute(
+            """
+            DELETE FROM contact_addresses
+            WHERE address LIKE '%%@top-people-test.example'
+               OR address LIKE 'user-only@%%'
+            """
+        )
+        conn.execute(
+            """
+            DELETE FROM contacts
+            WHERE display_name LIKE 'TopPeople%%'
+               OR display_name = 'UserOnly'
+            """
+        )
+        conn.commit()
+    _cleanup_bucket_emails(pool)
+
+
+def test_top_people_lane_shape_and_rules(db_client: TestClient, db_pool: ConnectionPool) -> None:
+    _cleanup_top_people_fixtures(db_pool)
+    acct = "top-people-acct@example.com"
+    # 9 external contacts + 1 user-only; top-8 should exclude user and lowest volume.
+    contact_ids = [uuid4() for _ in range(9)]
+    user_contact = uuid4()
+    try:
+        for i, cid in enumerate(contact_ids):
+            addr = f"person{i}@top-people-test.example"
+            _insert_contact(
+                db_pool,
+                contact_id=cid,
+                display_name=f"TopPeople {i}" if i % 2 == 0 else None,
+                addresses=[(addr, False)],
+            )
+            # Volume = i+1 messages so person8 has most, person0 least.
+            for n in range(i + 1):
+                _insert_email(
+                    db_pool,
+                    date=datetime(2020, 3, 1 + (n % 20), 12, 0, tzinfo=UTC),
+                    source_account=acct,
+                    sender_address=addr,
+                )
+        # User-only contact with high volume must be excluded.
+        user_addr = "user-only@top-people-test.example"
+        _insert_contact(
+            db_pool,
+            contact_id=user_contact,
+            display_name="UserOnly",
+            addresses=[(user_addr, True)],
+        )
+        for _ in range(50):
+            _insert_email(
+                db_pool,
+                date=datetime(2020, 4, 1, 12, 0, tzinfo=UTC),
+                source_account=acct,
+                sender_address=user_addr,
+            )
+
+        _login(db_client)
+        payload = {
+            "scope": {"mailboxes": [acct]},
+            "viewport": {"from": "2020-01-01T00:00:00Z", "to": "2021-01-01T00:00:00Z"},
+            "pixel_width": 920,
+            "aggregation": "month",
+            "lanes": ["top_people"],
+        }
+        r = db_client.post("/api/chronicle/buckets", json=payload)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        tp = body["lanes"]["top_people"]
+        assert isinstance(tp, dict)
+        assert "contacts" in tp
+        contacts = tp["contacts"]
+        assert isinstance(contacts, list)
+        assert len(contacts) <= 8
+        assert len(contacts) == 8  # 9 external, lowest dropped
+
+        ids = {c["contact_id"] for c in contacts}
+        assert str(user_contact) not in ids
+        assert str(contact_ids[0]) not in ids  # lowest volume excluded
+
+        # Ranked by volume desc: person8 .. person1
+        totals = []
+        for c in contacts:
+            assert "contact_id" in c
+            assert "display_name" in c
+            assert isinstance(c["buckets"], list)
+            for pt in c["buckets"]:
+                assert "bucket" in pt
+                assert isinstance(pt["count"], int)
+                assert pt["count"] >= 0
+            totals.append(sum(pt["count"] for pt in c["buckets"]))
+        assert totals == sorted(totals, reverse=True)
+
+        # Null display_name falls back to address
+        odd = next(c for c in contacts if c["contact_id"] == str(contact_ids[7]))
+        assert odd["display_name"] == "person7@top-people-test.example"
+        even = next(c for c in contacts if c["contact_id"] == str(contact_ids[8]))
+        assert even["display_name"] == "TopPeople 8"
+
+        # Scope filter is monotonic (narrower mailbox → fewer or equal totals)
+        other_acct = "top-people-other@example.com"
+        r_empty = db_client.post(
+            "/api/chronicle/buckets",
+            json={**payload, "scope": {"mailboxes": [other_acct]}},
+        )
+        assert r_empty.status_code == 200, r_empty.text
+        empty_contacts = r_empty.json()["lanes"]["top_people"]["contacts"]
+        empty_total = sum(sum(pt["count"] for pt in c["buckets"]) for c in empty_contacts)
+        full_total = sum(totals)
+        assert empty_total <= full_total
+        assert empty_total == 0
+    finally:
+        _cleanup_top_people_fixtures(db_pool)

--- a/apps/chronicle/server/tests/test_chronicle.py
+++ b/apps/chronicle/server/tests/test_chronicle.py
@@ -1,0 +1,340 @@
+# tests/test_chronicle.py
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+import pytest
+
+from chronicle_server.chronicle import (
+    AggregationTooFineError,
+    BucketsRequest,
+    choose_aggregation,
+    resolve_aggregation,
+)
+from tests.conftest import PASSWORD, USERNAME
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from psycopg_pool import ConnectionPool
+
+
+# --- pure unit tests ---
+
+
+def test_choose_aggregation_10y_920px() -> None:
+    duration = timedelta(days=365 * 10 + 2)  # ~10y including leap days
+    unit = choose_aggregation(duration, 920)
+    # target_buckets=115; month≈122 > 115, quarter≈40 ≤ 115
+    assert unit in ("month", "quarter")
+
+
+def test_choose_aggregation_3d_920px() -> None:
+    assert choose_aggregation(timedelta(days=3), 920) == "hour"
+
+
+def test_choose_aggregation_40y_320px() -> None:
+    assert choose_aggregation(timedelta(days=365 * 40), 320) == "year"
+
+
+def test_explicit_unit_over_2000_raises() -> None:
+    duration = timedelta(days=365 * 10)
+    with pytest.raises(AggregationTooFineError) as exc_info:
+        resolve_aggregation("hour", duration, 920)
+    assert exc_info.value.requested == "hour"
+    assert exc_info.value.smallest_valid_unit in (
+        "day",
+        "week",
+        "month",
+        "quarter",
+        "year",
+    )
+    # Day still exceeds 2000 for 10y; week should fit.
+    assert exc_info.value.smallest_valid_unit == "week"
+
+
+def test_resolve_auto_matches_choose() -> None:
+    duration = timedelta(days=3)
+    assert resolve_aggregation("auto", duration, 920) == choose_aggregation(duration, 920)
+
+
+def test_resolve_explicit_valid_unit() -> None:
+    assert resolve_aggregation("month", timedelta(days=365), 920) == "month"
+
+
+# --- auth ---
+
+
+def test_buckets_requires_auth(client: TestClient) -> None:
+    r = client.post(
+        "/api/chronicle/buckets",
+        json={
+            "scope": {},
+            "viewport": {"from": "2020-01-01", "to": "2021-01-01"},
+            "pixel_width": 920,
+            "aggregation": "auto",
+            "lanes": ["messages"],
+        },
+    )
+    assert r.status_code == 401
+
+
+def test_buckets_422_bad_lane(client: TestClient) -> None:
+    login = client.post("/api/auth/login", json={"username": USERNAME, "password": PASSWORD})
+    assert login.status_code == 200
+    r = client.post(
+        "/api/chronicle/buckets",
+        json={
+            "scope": {},
+            "viewport": {"from": "2020-01-01", "to": "2021-01-01"},
+            "pixel_width": 920,
+            "aggregation": "auto",
+            "lanes": ["messages", "not-a-lane"],
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_buckets_422_bad_unit(client: TestClient) -> None:
+    login = client.post("/api/auth/login", json={"username": USERNAME, "password": PASSWORD})
+    assert login.status_code == 200
+    r = client.post(
+        "/api/chronicle/buckets",
+        json={
+            "scope": {},
+            "viewport": {"from": "2020-01-01", "to": "2021-01-01"},
+            "pixel_width": 920,
+            "aggregation": "minute",
+            "lanes": ["messages"],
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_buckets_422_explicit_too_fine(client: TestClient) -> None:
+    login = client.post("/api/auth/login", json={"username": USERNAME, "password": PASSWORD})
+    assert login.status_code == 200
+    r = client.post(
+        "/api/chronicle/buckets",
+        json={
+            "scope": {},
+            "viewport": {"from": "2010-01-01", "to": "2020-01-01"},
+            "pixel_width": 920,
+            "aggregation": "hour",
+            "lanes": ["messages"],
+        },
+    )
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    assert isinstance(detail, dict)
+    assert detail["smallest_valid_unit"] == "week"
+    assert detail["requested"] == "hour"
+
+
+# --- DB-backed ---
+
+
+def _login(client: TestClient) -> None:
+    r = client.post("/api/auth/login", json={"username": USERNAME, "password": PASSWORD})
+    assert r.status_code == 200
+
+
+def _insert_email(
+    pool: ConnectionPool,
+    *,
+    date: datetime,
+    source_account: str = "acct-a@example.com",
+    sender_address: str = "alice@example.com",
+    with_attachment: bool = False,
+) -> None:
+    email_id = uuid4()
+    with pool.connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO emails (
+                id, message_id, thread_id, subject,
+                sender_name, sender_address, sender_domain,
+                recipients, date, body_text, body_html,
+                has_attachment, labels, source_account, created_at
+            ) VALUES (
+                %(id)s, %(mid)s, %(tid)s, 'bucket test',
+                'Alice', %(saddr)s, 'example.com',
+                '{}'::jsonb, %(date)s, 'body', NULL,
+                %(has_att)s, %(labels)s, %(acct)s, now()
+            )
+            """,
+            {
+                "id": email_id,
+                "mid": f"<bucket-{email_id}@example.com>",
+                "tid": f"thread-{email_id}",
+                "saddr": sender_address,
+                "date": date,
+                "has_att": with_attachment,
+                "labels": ["INBOX"],
+                "acct": source_account,
+            },
+        )
+        if with_attachment:
+            row = conn.execute(
+                """
+                INSERT INTO attachments (sha256, filename, content_type, size, storage_path)
+                VALUES (%(sha)s, 'f.txt', 'text/plain', 4, %(path)s)
+                RETURNING id
+                """,
+                {
+                    "sha": hashlib.sha256(str(email_id).encode()).hexdigest(),
+                    "path": f"/tmp/chronicle-bucket/{email_id}",
+                },
+            ).fetchone()
+            assert row is not None
+            conn.execute(
+                """
+                INSERT INTO email_attachments (email_id, attachment_id, filename)
+                VALUES (%(eid)s, %(aid)s, 'f.txt')
+                """,
+                {"eid": email_id, "aid": row[0]},
+            )
+        conn.commit()
+
+
+def _cleanup_bucket_emails(pool: ConnectionPool) -> None:
+    with pool.connection() as conn:
+        conn.execute(
+            """
+            DELETE FROM email_attachments
+            WHERE email_id IN (
+                SELECT id FROM emails WHERE message_id LIKE '<bucket-%%@example.com>'
+            )
+            """
+        )
+        conn.execute(
+            """
+            DELETE FROM attachments
+            WHERE storage_path LIKE '/tmp/chronicle-bucket/%%'
+            """
+        )
+        conn.execute("DELETE FROM emails WHERE message_id LIKE '<bucket-%%@example.com>'")
+        conn.commit()
+
+
+def _assert_buckets_shape(body: dict[str, Any]) -> None:
+    assert body["scope_fingerprint"].startswith("qs_")
+    assert body["aggregation"] in (
+        "hour",
+        "day",
+        "week",
+        "month",
+        "quarter",
+        "year",
+    )
+    assert body["unit"] == body["aggregation"]
+    assert "from" in body["viewport"]
+    assert "to" in body["viewport"]
+    assert isinstance(body["lanes"], dict)
+    for points in body["lanes"].values():
+        assert isinstance(points, list)
+        for pt in points:
+            assert "bucket" in pt
+            assert isinstance(pt["count"], int)
+            assert pt["count"] >= 0
+    assert "unit" in body["density"]
+    assert isinstance(body["density"]["buckets"], list)
+    assert "from" in body["extent"]
+    assert "to" in body["extent"]
+    assert isinstance(body["generated_at"], str)
+    assert len(body["generated_at"]) > 0
+
+
+def test_buckets_endpoint_shape_and_filters(db_client: TestClient, db_pool: ConnectionPool) -> None:
+    _cleanup_bucket_emails(db_pool)
+    acct_a = "bucket-test-a@example.com"
+    acct_b = "bucket-test-b@example.com"
+    try:
+        # Inside viewport
+        _insert_email(
+            db_pool,
+            date=datetime(2020, 6, 15, 12, 0, tzinfo=UTC),
+            source_account=acct_a,
+            sender_address="alice@example.com",
+            with_attachment=True,
+        )
+        _insert_email(
+            db_pool,
+            date=datetime(2020, 7, 1, 8, 0, tzinfo=UTC),
+            source_account=acct_b,
+            sender_address="bob@example.com",
+        )
+        # Outside viewport (should not appear in lanes; density still includes them)
+        _insert_email(
+            db_pool,
+            date=datetime(2018, 1, 1, tzinfo=UTC),
+            source_account=acct_a,
+        )
+        _insert_email(
+            db_pool,
+            date=datetime(2022, 1, 1, tzinfo=UTC),
+            source_account=acct_a,
+        )
+
+        _login(db_client)
+        # Scope to test accounts only so ambient DB rows cannot inflate counts.
+        both_accounts = {"mailboxes": [acct_a, acct_b]}
+        payload = {
+            "scope": both_accounts,
+            "viewport": {"from": "2020-01-01T00:00:00Z", "to": "2021-01-01T00:00:00Z"},
+            "pixel_width": 920,
+            "aggregation": "month",
+            "lanes": ["messages", "attachments", "people"],
+        }
+        r = db_client.post("/api/chronicle/buckets", json=payload)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        _assert_buckets_shape(body)
+
+        msg_total = sum(p["count"] for p in body["lanes"]["messages"])
+        assert msg_total == 2  # only viewport messages
+
+        att_total = sum(p["count"] for p in body["lanes"]["attachments"])
+        assert att_total == 1
+
+        people_total = sum(p["count"] for p in body["lanes"]["people"])
+        assert people_total == 2  # alice + bob
+
+        # Density covers full extent (scope only) — includes outside-viewport messages
+        density_total = sum(p["count"] for p in body["density"]["buckets"])
+        assert density_total == 4
+        assert density_total >= msg_total
+
+        # Extent spans our seeded range under this scope
+        assert body["extent"]["from"] is not None
+        assert body["extent"]["to"] is not None
+        assert body["extent"]["from"].startswith("2018")
+        assert body["extent"]["to"].startswith("2022")
+
+        # Mailbox filter reduces counts monotonically
+        r_filtered = db_client.post(
+            "/api/chronicle/buckets",
+            json={
+                **payload,
+                "scope": {"mailboxes": [acct_a]},
+            },
+        )
+        assert r_filtered.status_code == 200, r_filtered.text
+        filtered = r_filtered.json()
+        filtered_msg = sum(p["count"] for p in filtered["lanes"]["messages"])
+        assert filtered_msg <= msg_total
+        assert filtered_msg == 1
+
+        # Fingerprint changes with scope
+        assert filtered["scope_fingerprint"] != body["scope_fingerprint"]
+    finally:
+        _cleanup_bucket_emails(db_pool)
+
+
+def test_buckets_request_model_defaults() -> None:
+    req = BucketsRequest.model_validate({"viewport": {"from": "2020-01-01", "to": "2021-01-01"}})
+    assert req.aggregation == "auto"
+    assert req.pixel_width == 920
+    assert set(req.lanes) == {"messages", "attachments", "people"}

--- a/apps/chronicle/server/tests/test_scope.py
+++ b/apps/chronicle/server/tests/test_scope.py
@@ -1,0 +1,77 @@
+# tests/test_scope.py
+from __future__ import annotations
+
+from chronicle_server.scope import DateRange, QueryScope, scope_filters, scope_fingerprint
+
+
+def test_scope_filters_empty() -> None:
+    conditions, params = scope_filters(QueryScope())
+    assert conditions == []
+    assert params == {}
+
+
+def test_scope_filters_each_field() -> None:
+    scope = QueryScope(
+        date=DateRange(**{"from": "2020-01-01", "to": "2021-01-01"}),
+        mailboxes=["acct@example.com"],
+        senders=["alice@example.com"],
+    )
+    conditions, params = scope_filters(scope)
+
+    assert conditions == [
+        "date >= %(scope_from)s",
+        "date < %(scope_to)s",
+        "source_account = ANY(%(mailboxes)s)",
+        "sender_address = ANY(%(senders)s)",
+    ]
+    assert params == {
+        "scope_from": "2020-01-01",
+        "scope_to": "2021-01-01",
+        "mailboxes": ["acct@example.com"],
+        "senders": ["alice@example.com"],
+    }
+
+
+def test_scope_filters_partial_date_from_only() -> None:
+    scope = QueryScope(date=DateRange(**{"from": "2015-06-01"}))
+    conditions, params = scope_filters(scope)
+    assert conditions == ["date >= %(scope_from)s"]
+    assert params == {"scope_from": "2015-06-01"}
+
+
+def test_scope_filters_empty_lists_omit_conditions() -> None:
+    scope = QueryScope(mailboxes=[], senders=[])
+    conditions, params = scope_filters(scope)
+    assert conditions == []
+    assert params == {}
+
+
+def test_scope_fingerprint_stable_under_key_reorder() -> None:
+    a = QueryScope.model_validate(
+        {
+            "version": 1,
+            "mailboxes": ["a@x.com", "b@x.com"],
+            "senders": ["s@x.com"],
+            "date": {"from": "2010-01-01", "to": "2020-01-01"},
+        }
+    )
+    b = QueryScope.model_validate(
+        {
+            "date": {"to": "2020-01-01", "from": "2010-01-01"},
+            "senders": ["s@x.com"],
+            "mailboxes": ["a@x.com", "b@x.com"],
+            "version": 1,
+        }
+    )
+    assert scope_fingerprint(a) == scope_fingerprint(b)
+    assert scope_fingerprint(a).startswith("qs_")
+    assert len(scope_fingerprint(a)) == len("qs_") + 16
+
+
+def test_scope_fingerprint_changes_when_filter_changes() -> None:
+    base = QueryScope(mailboxes=["a@x.com"])
+    other = QueryScope(mailboxes=["b@x.com"])
+    assert scope_fingerprint(base) != scope_fingerprint(other)
+
+    with_sender = QueryScope(mailboxes=["a@x.com"], senders=["s@x.com"])
+    assert scope_fingerprint(base) != scope_fingerprint(with_sender)

--- a/apps/chronicle/server/tests/test_sources.py
+++ b/apps/chronicle/server/tests/test_sources.py
@@ -25,6 +25,16 @@ def test_sources_require_auth(client: TestClient) -> None:
     assert client.get("/api/sources/msg_1").status_code == 401
     assert client.get("/api/sources/msg_1/context?start=0&end=1").status_code == 401
     assert client.get("/api/threads/thr_YQ").status_code == 401
+    assert (
+        client.post(
+            "/api/sources/list",
+            json={
+                "date_from": "2010-01-01T00:00:00Z",
+                "date_to": "2020-01-01T00:00:00Z",
+            },
+        ).status_code
+        == 401
+    )
 
 
 def test_malformed_id_404_authenticated(client: TestClient) -> None:
@@ -50,42 +60,63 @@ def _seed_message(
     thread_id: str = "thread-test-sources",
     sender_name: str = "Alice",
     sender_address: str = "alice@example.com",
+    source_account: str = "test@example.com",
+    date: str | None = "now",
     with_attachment: bool = False,
     markdown: str | None = None,
+    attachments_json: str | None = None,
 ) -> dict[str, Any]:
-    """Insert minimal email (+ optional attachment) rows; caller cleans up."""
+    """Insert minimal email (+ optional attachment) rows; caller cleans up.
+
+    ``date``: ``\"now\"`` uses now(); ISO string uses that timestamp; ``None`` inserts NULL.
+    """
     email_id = uuid4()
     message_id = f"<src-test-{email_id}@example.com>"
     att_id: int | None = None
 
+    if date == "now":
+        date_sql = "now()"
+        date_param: str | None = None
+    elif date is None:
+        date_sql = "NULL"
+        date_param = None
+    else:
+        date_sql = "%(date)s::timestamptz"
+        date_param = date
+
     with pool.connection() as conn:
+        params: dict[str, Any] = {
+            "id": email_id,
+            "mid": message_id,
+            "tid": thread_id,
+            "subject": subject,
+            "sname": sender_name,
+            "saddr": sender_address,
+            "recip": '{"to": ["bob@example.com"], "cc": ["carol@example.com"], "bcc": []}',
+            "btext": body_text,
+            "bhtml": body_html,
+            "has_att": with_attachment,
+            "labels": ["INBOX"],
+            "acct": source_account,
+            "att_json": attachments_json,
+        }
+        if date_param is not None:
+            params["date"] = date_param
         conn.execute(
-            """
+            f"""
             INSERT INTO emails (
                 id, message_id, thread_id, subject,
                 sender_name, sender_address, sender_domain,
                 recipients, date, body_text, body_html,
-                has_attachment, labels, source_account, created_at
+                has_attachment, attachments, labels, source_account, created_at
             ) VALUES (
                 %(id)s, %(mid)s, %(tid)s, %(subject)s,
                 %(sname)s, %(saddr)s, 'example.com',
-                %(recip)s::jsonb, now(), %(btext)s, %(bhtml)s,
-                %(has_att)s, %(labels)s, 'test@example.com', now()
+                %(recip)s::jsonb, {date_sql}, %(btext)s, %(bhtml)s,
+                %(has_att)s, %(att_json)s::jsonb, %(labels)s, %(acct)s, now()
             )
             """,
-            {
-                "id": email_id,
-                "mid": message_id,
-                "tid": thread_id,
-                "subject": subject,
-                "sname": sender_name,
-                "saddr": sender_address,
-                "recip": '{"to": ["bob@example.com"], "cc": [], "bcc": []}',
-                "btext": body_text,
-                "bhtml": body_html,
-                "has_att": with_attachment,
-                "labels": ["INBOX"],
-            },
+            params,
         )
         if with_attachment:
             row = conn.execute(
@@ -307,3 +338,258 @@ def test_unknown_thread_404(db_client: TestClient) -> None:
     sid = encode_source_id("thr", f"missing-thread-{uuid4()}")
     r = db_client.get(f"/api/threads/{sid}")
     assert r.status_code == 404
+
+
+# --- POST /api/sources/list ---
+
+
+_LIST_FROM = "2014-01-01T00:00:00+00:00"
+_LIST_TO = "2015-01-01T00:00:00+00:00"
+
+
+def test_sources_list_invalid_cursor_400(db_client: TestClient) -> None:
+    _login(db_client)
+    r = db_client.post(
+        "/api/sources/list",
+        json={
+            "date_from": _LIST_FROM,
+            "date_to": _LIST_TO,
+            "cursor": "not-a-valid-cursor",
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_sources_list_keyset_walks_full_set(db_pool: ConnectionPool, db_client: TestClient) -> None:
+    """Page N+1 first item > page N last; union of pages is the full ordered set."""
+    seeds: list[dict[str, Any]] = []
+    # Deterministic chronological order via fixed timestamps.
+    dates = [
+        "2014-03-01T10:00:00+00:00",
+        "2014-03-01T11:00:00+00:00",  # same day, later
+        "2014-06-15T08:00:00+00:00",
+        "2014-09-01T12:00:00+00:00",
+        "2014-12-31T23:00:00+00:00",
+    ]
+    try:
+        for i, d in enumerate(dates):
+            seeds.append(
+                _seed_message(
+                    db_pool,
+                    subject=f"List-{i}",
+                    date=d,
+                    body_html=None,
+                    sender_address=f"u{i}@example.com",
+                )
+            )
+        _login(db_client)
+
+        all_ids: list[str] = []
+        cursor: str | None = None
+        prev_last: dict[str, Any] | None = None
+        pages = 0
+        while True:
+            body: dict[str, Any] = {
+                "date_from": _LIST_FROM,
+                "date_to": _LIST_TO,
+                "limit": 2,
+            }
+            if cursor is not None:
+                body["cursor"] = cursor
+            r = db_client.post("/api/sources/list", json=body)
+            assert r.status_code == 200, r.text
+            data = r.json()
+            pages += 1
+            items = data["items"]
+            assert "scope_fingerprint" in data
+            assert data["scope_fingerprint"].startswith("qs_")
+            if not items:
+                assert data["next_cursor"] is None
+                break
+            # Envelope-only: no body fields
+            for it in items:
+                assert "body" not in it
+                assert it["id"].startswith("msg_")
+                assert "subject" in it
+            if prev_last is not None:
+                first = items[0]
+                # Chronological keyset: page N+1 first > page N last
+                assert (first["date"], first["id"]) > (
+                    prev_last["date"],
+                    prev_last["id"],
+                )
+            all_ids.extend(it["id"] for it in items)
+            prev_last = items[-1]
+            cursor = data["next_cursor"]
+            if cursor is None:
+                break
+            assert pages < 20  # safety
+
+        expected = [s["msg_sid"] for s in seeds]
+        assert all_ids == expected
+        assert len(set(all_ids)) == len(all_ids)
+        assert pages >= 3  # limit=2 over 5 rows
+    finally:
+        for s in seeds:
+            _cleanup(db_pool, s)
+
+
+def test_sources_list_null_date_ordering(db_pool: ConnectionPool, db_client: TestClient) -> None:
+    """Null dates sort last; keyset continues correctly into the null-date region.
+
+    Uses a wide date window plus a direct SQL check of ORDER BY … NULLS LAST,
+    and walks keyset pages that include only dated rows in-range (nulls are
+    outside the bucket range filter). Verifies cursor with d=null is accepted
+    after the last dated row when more null-only rows would follow.
+    """
+    from chronicle_server.cursor import encode_cursor
+
+    seeds: list[dict[str, Any]] = []
+    try:
+        seeds.append(
+            _seed_message(
+                db_pool,
+                subject="Dated-early",
+                date="2014-02-01T00:00:00+00:00",
+                body_html=None,
+            )
+        )
+        seeds.append(
+            _seed_message(
+                db_pool,
+                subject="Dated-late",
+                date="2014-08-01T00:00:00+00:00",
+                body_html=None,
+            )
+        )
+        seeds.append(
+            _seed_message(
+                db_pool,
+                subject="Null-date-A",
+                date=None,
+                body_html=None,
+            )
+        )
+        seeds.append(
+            _seed_message(
+                db_pool,
+                subject="Null-date-B",
+                date=None,
+                body_html=None,
+            )
+        )
+
+        # Direct SQL: ASC NULLS LAST places nulls after all dated rows.
+        with db_pool.connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT subject, date IS NULL AS is_null
+                  FROM emails
+                 WHERE id = ANY(%(ids)s)
+                 ORDER BY date ASC NULLS LAST, id ASC
+                """,
+                {"ids": [s["email_id"] for s in seeds]},
+            ).fetchall()
+        subjects = [r[0] for r in rows]
+        assert subjects[:2] == ["Dated-early", "Dated-late"]
+        assert set(subjects[2:]) == {"Null-date-A", "Null-date-B"}
+        assert all(r[1] for r in rows[2:])
+
+        _login(db_client)
+        # Bucket range excludes nulls (timeline drill-in).
+        r = db_client.post(
+            "/api/sources/list",
+            json={"date_from": _LIST_FROM, "date_to": _LIST_TO, "limit": 50},
+        )
+        assert r.status_code == 200
+        items = r.json()["items"]
+        assert [it["subject"] for it in items] == ["Dated-early", "Dated-late"]
+        assert all(it["date"] is not None for it in items)
+
+        # Cursor with d=null is valid (null-date keyset branch); no in-range nulls.
+        secret = "db-test-secret"
+        null_cursor = encode_cursor(
+            {"d": None, "id": str(seeds[2]["email_id"])},
+            secret,
+        )
+        r2 = db_client.post(
+            "/api/sources/list",
+            json={
+                "date_from": _LIST_FROM,
+                "date_to": _LIST_TO,
+                "cursor": null_cursor,
+                "limit": 50,
+            },
+        )
+        assert r2.status_code == 200
+        assert r2.json()["items"] == []
+        assert r2.json()["next_cursor"] is None
+    finally:
+        for s in seeds:
+            _cleanup(db_pool, s)
+
+
+def test_sources_list_scope_filter(db_pool: ConnectionPool, db_client: TestClient) -> None:
+    seeds: list[dict[str, Any]] = []
+    try:
+        seeds.append(
+            _seed_message(
+                db_pool,
+                subject="In-mailbox",
+                date="2014-05-01T00:00:00+00:00",
+                source_account="keep@example.com",
+                sender_address="alice@example.com",
+                body_html=None,
+            )
+        )
+        seeds.append(
+            _seed_message(
+                db_pool,
+                subject="Other-mailbox",
+                date="2014-05-02T00:00:00+00:00",
+                source_account="drop@example.com",
+                sender_address="bob@example.com",
+                body_html=None,
+            )
+        )
+        _login(db_client)
+        r = db_client.post(
+            "/api/sources/list",
+            json={
+                "date_from": _LIST_FROM,
+                "date_to": _LIST_TO,
+                "scope": {"mailboxes": ["keep@example.com"]},
+                "limit": 50,
+            },
+        )
+        assert r.status_code == 200
+        items = r.json()["items"]
+        assert len(items) == 1
+        assert items[0]["subject"] == "In-mailbox"
+        assert items[0]["mailbox"] == "keep@example.com"
+    finally:
+        for s in seeds:
+            _cleanup(db_pool, s)
+
+
+def test_sources_list_attachment_count(db_pool: ConnectionPool, db_client: TestClient) -> None:
+    seed = _seed_message(
+        db_pool,
+        date="2014-04-01T00:00:00+00:00",
+        body_html=None,
+        with_attachment=True,
+        attachments_json='[{"filename": "a.pdf"}, {"filename": "b.txt"}]',
+    )
+    try:
+        _login(db_client)
+        r = db_client.post(
+            "/api/sources/list",
+            json={"date_from": _LIST_FROM, "date_to": _LIST_TO, "limit": 10},
+        )
+        assert r.status_code == 200
+        match = next(it for it in r.json()["items"] if it["id"] == seed["msg_sid"])
+        assert match["has_attachment"] is True
+        assert match["attachment_count"] == 2
+        assert match["thread_id"] == seed["thr_sid"]
+    finally:
+        _cleanup(db_pool, seed)

--- a/apps/chronicle/web/src/App.tsx
+++ b/apps/chronicle/web/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router'
 
 import { LoginPage } from './auth/LoginPage'
 import { RequireAuth } from './auth/RequireAuth'
+import { SourcePage } from './reader/SourcePage'
 import { ChroniclePage } from './routes/ChroniclePage'
 import { DataHealthPage } from './routes/DataHealthPage'
 import { StubPage } from './routes/StubPage'
@@ -20,6 +21,7 @@ export function App() {
       >
         <Route index element={<ChroniclePage />} />
         <Route path="chronicle" element={<ChroniclePage />} />
+        <Route path="source/:sid" element={<SourcePage />} />
         <Route path="research" element={<StubPage title="Research" />} />
         <Route path="topics" element={<StubPage title="Topics" />} />
         <Route path="people" element={<StubPage title="People" />} />

--- a/apps/chronicle/web/src/acceptance/chronicle.acceptance.test.tsx
+++ b/apps/chronicle/web/src/acceptance/chronicle.acceptance.test.tsx
@@ -1,0 +1,460 @@
+/**
+ * Chronicle acceptance tests — spec §4.10 criteria 1–8.
+ * Mocked-API integration (no real server). One `it` per criterion.
+ *
+ * Criterion 4 (generated events) is deferred to Phase 3 as `it.todo`.
+ */
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChronicleBuckets } from '../api/types'
+import {
+  mockArchiveSummary,
+  mockSessionOk,
+  renderApp,
+} from '../test/test-utils'
+import { resetUrlSyncForTests } from '../workingset/useUrlSync'
+import { resetWorkingSetStore, useWorkingSetStore } from '../workingset/store'
+import { encodeState } from '../workingset/urlState'
+
+const EXTENT_FROM = '2014-01-01T00:00:00.000Z'
+const EXTENT_TO = '2019-01-01T00:00:00.000Z'
+
+function mockBuckets(overrides: Partial<ChronicleBuckets> = {}): Response {
+  const body: ChronicleBuckets = {
+    scope_fingerprint: 'qs_test',
+    aggregation: 'month',
+    unit: 'month',
+    viewport: { from: EXTENT_FROM, to: EXTENT_TO },
+    lanes: {
+      messages: [
+        { bucket: '2014-01-01T00:00:00.000Z', count: 100 },
+        { bucket: '2015-01-01T00:00:00.000Z', count: 200 },
+        { bucket: '2016-01-01T00:00:00.000Z', count: 150 },
+      ],
+      attachments: [{ bucket: '2014-01-01T00:00:00.000Z', count: 10 }],
+    },
+    density: {
+      unit: 'year',
+      buckets: [
+        { bucket: '2014-01-01T00:00:00.000Z', count: 100 },
+        { bucket: '2015-01-01T00:00:00.000Z', count: 200 },
+      ],
+    },
+    extent: { from: EXTENT_FROM, to: EXTENT_TO },
+    generated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response
+}
+
+function mockSourceList(items: unknown[] = []) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      items,
+      next_cursor: null,
+      scope_fingerprint: 'qs',
+    }),
+  } as Response
+}
+
+function mockMessageSource(sid = 'msg_42') {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      kind: 'msg',
+      envelope: {
+        id: sid,
+        thread_id: 'thr_1',
+        subject: 'Acceptance subject',
+        sender_name: 'Alice',
+        sender_address: 'alice@example.com',
+        recipients: { to: ['bob@example.com'], cc: [], bcc: [] },
+        date: '2015-06-01T12:00:00Z',
+        mailbox: 'me@example.com',
+        labels: [],
+        has_attachment: false,
+        attachments: [],
+      },
+      body: {
+        text: 'body',
+        html: null,
+        remote_resources_blocked: 0,
+        had_active_content: false,
+      },
+    }),
+  } as Response
+}
+
+function installFetch(
+  impl?: (url: string, init?: RequestInit) => Promise<unknown> | unknown,
+) {
+  const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    const u = String(url)
+    if (u.includes('/api/auth/session')) return mockSessionOk()
+    if (u.includes('/api/archive/summary')) return mockArchiveSummary()
+    if (impl) {
+      const r = await impl(u, init)
+      if (r !== undefined) return r
+    }
+    if (u.includes('/api/chronicle/buckets')) return mockBuckets()
+    if (u.includes('/api/sources/list')) return mockSourceList()
+    if (u.includes('/api/sources/')) return mockMessageSource()
+    throw new Error(`unexpected fetch: ${u}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+describe('Chronicle acceptance (§4.10)', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/')
+    resetWorkingSetStore()
+    resetUrlSyncForTests()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.history.replaceState(null, '', '/')
+    resetWorkingSetStore()
+    resetUrlSyncForTests()
+  })
+
+  it('lands on chronicle with full archive', async () => {
+    installFetch()
+    renderApp(['/'])
+
+    expect(await screen.findByTestId('workstation-shell')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Chronicle' })).toBeInTheDocument()
+
+    // Viewport bootstraps to extent from the first buckets response.
+    await waitFor(() => {
+      const vp = useWorkingSetStore.getState().viewport
+      expect(vp).not.toBeNull()
+      expect(vp!.fromMs).toBe(Date.parse(EXTENT_FROM))
+      expect(vp!.toMs).toBe(Date.parse(EXTENT_TO))
+    })
+    expect(await screen.findByTestId('visible-period')).toHaveTextContent(/Jan 2014/)
+  })
+
+  it('zoom preserves working set and selection', async () => {
+    const fetchMock = installFetch()
+    // Deep-link a scope + selection so hydrate restores them before fetches.
+    const qs = encodeState({
+      scope: { mailboxes: ['me@example.com'] },
+      viewport: {
+        fromMs: Date.parse(EXTENT_FROM),
+        toMs: Date.parse(EXTENT_TO),
+      },
+      aggregation: 'auto',
+      view: 'canvas',
+      selection: {
+        kind: 'bucket',
+        lane: 'messages',
+        bucketIso: '2015-01-01T00:00:00.000Z',
+      },
+      lanes: null,
+    }).toString()
+    window.history.replaceState(null, '', `/?${qs}`)
+
+    renderApp(['/'])
+    expect(await screen.findByTestId('timeline-toolbar')).toBeInTheDocument()
+
+    // Scope chip + selection present
+    expect(screen.getByTestId('scope-chip-mailbox')).toBeInTheDocument()
+    expect(useWorkingSetStore.getState().selection).toEqual({
+      kind: 'bucket',
+      lane: 'messages',
+      bucketIso: '2015-01-01T00:00:00.000Z',
+    })
+
+    const beforeVp = useWorkingSetStore.getState().viewport!
+    fireEvent.click(screen.getByRole('button', { name: /zoom in/i }))
+
+    await waitFor(() => {
+      const after = useWorkingSetStore.getState().viewport!
+      expect(after.toMs - after.fromMs).toBeLessThan(beforeVp.toMs - beforeVp.fromMs)
+    })
+
+    // Chips and selection unchanged
+    expect(screen.getByTestId('scope-chip-mailbox')).toBeInTheDocument()
+    expect(useWorkingSetStore.getState().selection).toEqual({
+      kind: 'bucket',
+      lane: 'messages',
+      bucketIso: '2015-01-01T00:00:00.000Z',
+    })
+    expect(useWorkingSetStore.getState().scope.mailboxes).toEqual(['me@example.com'])
+
+    // Buckets re-issued with the same scope
+    const scoped = fetchMock.mock.calls.filter((c) => {
+      if (!String(c[0]).includes('/api/chronicle/buckets')) return false
+      const body = JSON.parse(String((c[1] as RequestInit).body)) as {
+        scope: { mailboxes?: string[] }
+      }
+      return body.scope?.mailboxes?.[0] === 'me@example.com'
+    })
+    expect(scoped.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('date range change updates lanes and count consistently', async () => {
+    const fetchMock = installFetch(async (url, init) => {
+      if (url.includes('/api/chronicle/buckets')) {
+        const body = JSON.parse(String((init as RequestInit).body)) as {
+          scope: { date?: { from?: string; to?: string } }
+        }
+        // Reflect scope date in message totals so scope-bar count updates.
+        const scoped = !!body.scope?.date?.from
+        return mockBuckets({
+          lanes: {
+            messages: scoped
+              ? [
+                  { bucket: '2015-01-01T00:00:00.000Z', count: 42 },
+                  { bucket: '2015-06-01T00:00:00.000Z', count: 8 },
+                ]
+              : [
+                  { bucket: '2014-01-01T00:00:00.000Z', count: 100 },
+                  { bucket: '2015-01-01T00:00:00.000Z', count: 200 },
+                ],
+            attachments: [],
+          },
+        })
+      }
+      return undefined
+    })
+
+    renderApp(['/'])
+    expect(await screen.findByTestId('timeline-toolbar')).toBeInTheDocument()
+
+    // Open date editor and apply a range
+    fireEvent.click(screen.getByRole('button', { name: /add date filter/i }))
+    const editor = await screen.findByTestId('date-range-editor')
+    const from = within(editor).getByLabelText(/date from/i)
+    const to = within(editor).getByLabelText(/date to/i)
+    fireEvent.change(from, { target: { value: '2015-01-01' } })
+    fireEvent.change(to, { target: { value: '2015-12-31' } })
+    fireEvent.click(within(editor).getByRole('button', { name: /^apply$/i }))
+
+    await waitFor(() => {
+      expect(useWorkingSetStore.getState().scope.date).toEqual({
+        from: '2015-01-01',
+        to: '2015-12-31',
+      })
+    })
+
+    // Buckets request carries the scope date
+    await waitFor(() => {
+      const hit = fetchMock.mock.calls.some((c) => {
+        if (!String(c[0]).includes('/api/chronicle/buckets')) return false
+        const body = JSON.parse(String((c[1] as RequestInit).body)) as {
+          scope: { date?: { from?: string; to?: string } }
+        }
+        return (
+          body.scope?.date?.from === '2015-01-01' &&
+          body.scope?.date?.to === '2015-12-31'
+        )
+      })
+      expect(hit).toBe(true)
+    })
+
+    // Scope-bar count updates from the response (42+8=50)
+    await waitFor(() => {
+      expect(useWorkingSetStore.getState().resultCount).toBe(50)
+    })
+    expect(await screen.findByTestId('scope-result-count')).toHaveTextContent(
+      /50 messages in scope/,
+    )
+  })
+
+  // Phase 3: generated events expose origin/evidence/derivation — not in Phase 1.
+  it.todo('generated events expose origin/evidence/derivation')
+
+  it('open source and return restores viewport and selection', async () => {
+    // Re-assert the 1.4 return contract through focus mode:
+    // focus → select message → URL with ff/ft+sel → popstate → still in focus.
+    installFetch()
+
+    const focus = {
+      fromMs: Date.UTC(2015, 0, 1),
+      toMs: Date.UTC(2016, 0, 1),
+    }
+    const viewport = {
+      fromMs: Date.parse(EXTENT_FROM),
+      toMs: Date.parse(EXTENT_TO),
+    }
+    const selection = { kind: 'message' as const, sid: 'msg_42' }
+
+    const chronicleState = {
+      scope: { mailboxes: ['me@example.com'] },
+      viewport,
+      aggregation: 'auto' as const,
+      view: 'canvas' as const,
+      selection,
+      lanes: null as string[] | null,
+      focus,
+    }
+    const qs = encodeState(chronicleState).toString()
+    const chronicleUrl = qs ? `/?${qs}` : '/'
+    window.history.replaceState(null, '', chronicleUrl)
+    useWorkingSetStore.getState().hydrate(chronicleState)
+
+    renderApp(['/'])
+
+    // In focus mode with selection preserved
+    expect(await screen.findByTestId('focus-mode')).toBeInTheDocument()
+    expect(useWorkingSetStore.getState().focus).toEqual(focus)
+    expect(useWorkingSetStore.getState().selection).toEqual(selection)
+
+    // Simulate open full source: push reader path; then return via popstate
+    // with the chronicle URL (params preserve focus + selection).
+    window.history.pushState(null, '', '/source/msg_42')
+
+    // Corrupt store as if remounted mid-navigation
+    useWorkingSetStore.setState({
+      focus: null,
+      selection: null,
+      viewport: { fromMs: 0, toMs: 1 },
+      historyIntent: 'silent',
+    })
+
+    // Restore chronicle URL and fire popstate (return contract)
+    window.history.replaceState(null, '', chronicleUrl)
+    window.dispatchEvent(new PopStateEvent('popstate'))
+
+    await waitFor(() => {
+      const s = useWorkingSetStore.getState()
+      expect(s.focus).toEqual(focus)
+      expect(s.selection).toEqual(selection)
+      expect(s.viewport?.fromMs).toBe(viewport.fromMs)
+      expect(s.viewport?.toMs).toBe(viewport.toMs)
+    })
+
+    // Leave a clean URL for subsequent tests (avoid ff/ft leak)
+    window.history.replaceState(null, '', '/')
+  })
+
+  it('brushed period opens in focus with same scope', async () => {
+    installFetch()
+    renderApp(['/'])
+    expect(await screen.findByTestId('timeline-toolbar')).toBeInTheDocument()
+
+    // Set scope chips + brush via store (scope object must survive focus round-trip)
+    useWorkingSetStore.getState().setScopeDate({ from: '2014-01-01', to: '2018-01-01' })
+    useWorkingSetStore.getState().addMailbox('me@example.com')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scope-chip-mailbox')).toBeInTheDocument()
+      expect(screen.getByTestId('scope-chip-date')).toBeInTheDocument()
+    })
+
+    // Programmatically set a brush then click Focus period
+    // (canvas brush drag is hard to synthesize reliably in jsdom)
+    const brush = {
+      fromMs: Date.UTC(2015, 0, 1),
+      toMs: Date.UTC(2015, 6, 1),
+    }
+    useWorkingSetStore.getState().setBrush(brush)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('focus-period-btn')).not.toBeDisabled()
+    })
+    fireEvent.click(screen.getByTestId('focus-period-btn'))
+
+    expect(await screen.findByTestId('focus-mode')).toBeInTheDocument()
+    expect(screen.getByTestId('focus-period-label')).toHaveTextContent(/Jan 2015/)
+    // Scope chips intact (Research Desk/Topic Atlas transfer is Phase 2/4)
+    expect(screen.getByTestId('scope-chip-mailbox')).toBeInTheDocument()
+    expect(screen.getByTestId('scope-chip-date')).toBeInTheDocument()
+    expect(useWorkingSetStore.getState().scope.mailboxes).toEqual(['me@example.com'])
+    expect(useWorkingSetStore.getState().brush).toBeNull()
+  })
+
+  it('dense periods aggregate with open-as-list', async () => {
+    installFetch(async (url) => {
+      if (url.includes('/api/chronicle/buckets')) {
+        return mockBuckets({
+          aggregation: 'year',
+          unit: 'year',
+          lanes: {
+            messages: [
+              { bucket: '2014-01-01T00:00:00.000Z', count: 50000 },
+              { bucket: '2015-01-01T00:00:00.000Z', count: 80000 },
+            ],
+            attachments: [
+              { bucket: '2014-01-01T00:00:00.000Z', count: 500 },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/sources/list')) {
+        return mockSourceList([
+          {
+            id: 'msg_dense',
+            subject: 'Dense period source',
+            sender_name: 'A',
+            sender_address: 'a@b.com',
+            date: '2014-06-01T00:00:00Z',
+            mailbox: 'me@example.com',
+            has_attachment: false,
+            attachment_count: 0,
+            thread_id: null,
+          },
+        ])
+      }
+      return undefined
+    })
+
+    renderApp(['/'])
+    expect(await screen.findByTestId('timeline-canvas')).toBeInTheDocument()
+    // Unit from response is year (aggregated)
+    expect(await screen.findByTestId('visible-period')).toHaveTextContent(/year buckets/)
+
+    // Bucket selection → inspector list ("Open as list")
+    useWorkingSetStore.getState().setSelection({
+      kind: 'bucket',
+      lane: 'messages',
+      bucketIso: '2014-01-01T00:00:00.000Z',
+    })
+    useWorkingSetStore.getState().setTimelineUnit('year')
+
+    expect(await screen.findByTestId('inspector-bucket')).toBeInTheDocument()
+    expect(screen.getByText(/Open as list/i)).toBeInTheDocument()
+    expect(await screen.findByTestId('source-list')).toBeInTheDocument()
+    expect(screen.getByText('Dense period source')).toBeInTheDocument()
+  })
+
+  it('usable with AI disabled', async () => {
+    // No model-dependent code paths exist yet in Phase 1. Assert the app
+    // renders fully with only the implemented endpoints mocked — guards
+    // against future accidental hard-dependencies on AI services
+    // (no /api/ask, no embedding generation, no event generation).
+    const fetchMock = installFetch()
+
+    renderApp(['/'])
+
+    expect(await screen.findByTestId('workstation-shell')).toBeInTheDocument()
+    expect(await screen.findByTestId('timeline-toolbar')).toBeInTheDocument()
+    expect(screen.getByTestId('evidence-inspector')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Chronicle' })).toBeInTheDocument()
+
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]))
+    const allowed = [
+      '/api/auth/session',
+      '/api/archive/summary',
+      '/api/chronicle/buckets',
+      '/api/sources/',
+    ]
+    for (const u of urls) {
+      const ok = allowed.some((a) => u.includes(a))
+      expect(ok, `unexpected endpoint (AI?): ${u}`).toBe(true)
+    }
+    expect(urls.some((u) => u.includes('/api/ask'))).toBe(false)
+    expect(urls.some((u) => u.includes('/api/events'))).toBe(false)
+  })
+})

--- a/apps/chronicle/web/src/api/types.ts
+++ b/apps/chronicle/web/src/api/types.ts
@@ -103,3 +103,58 @@ export interface ArchiveHealth {
   imports: ImportHistoryRow[]
   generated_at: string
 }
+
+/** POST /api/chronicle/buckets */
+
+export interface QueryScopeDate {
+  from?: string | null
+  to?: string | null
+}
+
+export interface QueryScope {
+  version?: number
+  date?: QueryScopeDate | null
+  mailboxes?: string[]
+  senders?: string[]
+}
+
+export interface ChronicleTimeRange {
+  from: string
+  to: string
+}
+
+export interface BucketPoint {
+  bucket: string
+  count: number
+}
+
+export interface DensitySeries {
+  unit: string
+  buckets: BucketPoint[]
+}
+
+export interface ChronicleExtent {
+  from: string | null
+  to: string | null
+}
+
+/** Request body for POST /api/chronicle/buckets */
+export interface ChronicleRequest {
+  scope?: QueryScope
+  viewport: ChronicleTimeRange
+  pixel_width?: number
+  aggregation?: string
+  lanes?: string[]
+}
+
+/** Response body for POST /api/chronicle/buckets */
+export interface ChronicleBuckets {
+  scope_fingerprint: string
+  aggregation: string
+  unit: string
+  viewport: ChronicleTimeRange
+  lanes: Record<string, BucketPoint[]>
+  density: DensitySeries
+  extent: ChronicleExtent
+  generated_at: string
+}

--- a/apps/chronicle/web/src/api/types.ts
+++ b/apps/chronicle/web/src/api/types.ts
@@ -158,3 +158,118 @@ export interface ChronicleBuckets {
   extent: ChronicleExtent
   generated_at: string
 }
+
+/** POST /api/sources/list */
+
+export interface SourceListRequest {
+  scope?: QueryScope
+  date_from: string
+  date_to: string
+  cursor?: string | null
+  limit?: number
+}
+
+export interface SourceListItem {
+  id: string
+  subject: string | null
+  sender_name: string | null
+  sender_address: string | null
+  date: string | null
+  mailbox: string | null
+  has_attachment: boolean
+  attachment_count: number
+  thread_id: string | null
+}
+
+export interface SourceListResponse {
+  items: SourceListItem[]
+  next_cursor: string | null
+  scope_fingerprint: string
+}
+
+/** GET /api/sources/:sid (message) */
+
+export interface AttachmentMeta {
+  id: string
+  filename: string
+  content_type: string | null
+  size: number | null
+}
+
+export interface MessageEnvelope {
+  id: string
+  thread_id: string | null
+  subject: string | null
+  sender_name: string | null
+  sender_address: string | null
+  recipients: unknown
+  date: string | null
+  mailbox: string | null
+  labels: string[]
+  has_attachment: boolean
+  attachments: AttachmentMeta[]
+}
+
+export interface BodyDescriptor {
+  text: string | null
+  html: string | null
+  remote_resources_blocked: number
+  had_active_content: boolean
+}
+
+export interface MessageSource {
+  kind: 'msg'
+  envelope: MessageEnvelope
+  body: BodyDescriptor
+}
+
+export interface AttachmentSource {
+  kind: 'att'
+  id: string
+  filename: string
+  content_type: string | null
+  size: number | null
+  source_message_id: string | null
+  source_envelope: MessageEnvelope | null
+  extraction_status: string | null
+  extraction_reason: string | null
+  markdown: string | null
+  truncated: boolean
+  text_offset: number
+}
+
+export type SourceResponse = MessageSource | AttachmentSource
+
+/** GET /api/threads/:thr */
+
+export interface ThreadParticipant {
+  name: string | null
+  address: string | null
+}
+
+export interface ThreadDateRange {
+  from: string | null
+  to: string | null
+}
+
+export interface ThreadMessage {
+  id: string
+  subject: string | null
+  sender_name: string | null
+  sender_address: string | null
+  recipients: unknown
+  date: string | null
+  mailbox: string | null
+  labels: string[]
+  has_attachment: boolean
+}
+
+export interface ThreadResponse {
+  thread_id: string
+  subject: string | null
+  date_range: ThreadDateRange
+  participants: ThreadParticipant[]
+  message_count: number
+  messages: ThreadMessage[]
+  truncated: boolean
+}

--- a/apps/chronicle/web/src/api/types.ts
+++ b/apps/chronicle/web/src/api/types.ts
@@ -128,6 +128,34 @@ export interface BucketPoint {
   count: number
 }
 
+/** top_people lane: activity bucket series for one contact. */
+export interface TopPeopleContact {
+  contact_id: string
+  display_name: string
+  buckets: BucketPoint[]
+}
+
+/** top_people lane payload (activity spans only). */
+export interface TopPeopleLane {
+  contacts: TopPeopleContact[]
+}
+
+/** A bars-style lane is BucketPoint[]; top_people is nested contact series. */
+export type LaneData = BucketPoint[] | TopPeopleLane
+
+export function isTopPeopleLane(data: LaneData | undefined): data is TopPeopleLane {
+  return (
+    data != null &&
+    typeof data === 'object' &&
+    !Array.isArray(data) &&
+    Array.isArray((data as TopPeopleLane).contacts)
+  )
+}
+
+export function isBucketSeries(data: LaneData | undefined): data is BucketPoint[] {
+  return Array.isArray(data)
+}
+
 export interface DensitySeries {
   unit: string
   buckets: BucketPoint[]
@@ -153,7 +181,7 @@ export interface ChronicleBuckets {
   aggregation: string
   unit: string
   viewport: ChronicleTimeRange
-  lanes: Record<string, BucketPoint[]>
+  lanes: Record<string, LaneData>
   density: DensitySeries
   extent: ChronicleExtent
   generated_at: string

--- a/apps/chronicle/web/src/chronicle/ChroniclePage.timeline.test.tsx
+++ b/apps/chronicle/web/src/chronicle/ChroniclePage.timeline.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChronicleBuckets } from '../api/types'
+import {
+  mockArchiveSummary,
+  mockSessionOk,
+  renderApp,
+} from '../test/test-utils'
+
+function mockBuckets(overrides: Partial<ChronicleBuckets> = {}): Response {
+  const body: ChronicleBuckets = {
+    scope_fingerprint: 'qs_test',
+    aggregation: 'month',
+    unit: 'month',
+    viewport: { from: '2014-01-01T00:00:00.000Z', to: '2019-01-01T00:00:00.000Z' },
+    lanes: {
+      messages: [
+        { bucket: '2014-01-01T00:00:00.000Z', count: 100 },
+        { bucket: '2015-01-01T00:00:00.000Z', count: 200 },
+      ],
+      attachments: [{ bucket: '2014-01-01T00:00:00.000Z', count: 10 }],
+    },
+    density: {
+      unit: 'year',
+      buckets: [
+        { bucket: '2014-01-01T00:00:00.000Z', count: 100 },
+        { bucket: '2015-01-01T00:00:00.000Z', count: 200 },
+      ],
+    },
+    extent: {
+      from: '2014-01-01T00:00:00.000Z',
+      to: '2019-01-01T00:00:00.000Z',
+    },
+    generated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response
+}
+
+function installFetch(
+  impl: (url: string, init?: RequestInit) => Promise<unknown> | unknown,
+) {
+  const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    if (String(url).includes('/api/auth/session')) return mockSessionOk()
+    if (String(url).includes('/api/archive/summary')) return mockArchiveSummary()
+    return impl(String(url), init)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+describe('ChroniclePage timeline', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('bootstrap sets viewport to extent', async () => {
+    const fetchMock = installFetch(async (url) => {
+      if (url.includes('/api/chronicle/buckets')) return mockBuckets()
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+
+    renderApp(['/'])
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some((c) => String(c[0]).includes('/api/chronicle/buckets'))).toBe(
+        true,
+      )
+    })
+
+    // Visible period reflects extent (Jan 2014 – Jan 2019)
+    expect(await screen.findByTestId('visible-period')).toHaveTextContent(/Jan 2014/)
+    expect(screen.getByTestId('visible-period')).toHaveTextContent(/Jan 2019|Dec 2018/)
+
+    // Bootstrap request used the sentinel full-range viewport
+    const bucketCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes('/api/chronicle/buckets'),
+    )
+    expect(bucketCalls.length).toBeGreaterThanOrEqual(1)
+    const firstBody = JSON.parse(String((bucketCalls[0]![1] as RequestInit).body)) as {
+      viewport: { from: string; to: string }
+    }
+    expect(firstBody.viewport.from.startsWith('1970-01-01')).toBe(true)
+    expect(firstBody.viewport.to.startsWith('2100-01-01')).toBe(true)
+  })
+
+  it('error → Retry refetches', async () => {
+    let fail = true
+    const fetchMock = installFetch(async (url) => {
+      if (url.includes('/api/chronicle/buckets')) {
+        if (fail) {
+          return {
+            ok: false,
+            status: 500,
+            json: async () => ({ detail: 'boom' }),
+          }
+        }
+        return mockBuckets()
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+
+    renderApp(['/'])
+
+    const alert = await screen.findByTestId('timeline-error')
+    expect(alert).toHaveTextContent(/Failed to load timeline/)
+
+    const retries = screen.getAllByRole('button', { name: /^retry$/i })
+    const timelineRetry = retries.find((b) => alert.contains(b)) ?? retries[0]!
+    fail = false
+    fireEvent.click(timelineRetry)
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('timeline-error')).not.toBeInTheDocument()
+    })
+    expect(
+      fetchMock.mock.calls.filter((c) => String(c[0]).includes('/api/chronicle/buckets')).length,
+    ).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/apps/chronicle/web/src/chronicle/ChroniclePage.timeline.test.tsx
+++ b/apps/chronicle/web/src/chronicle/ChroniclePage.timeline.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChronicleBuckets } from '../api/types'
 import {
@@ -7,6 +7,7 @@ import {
   mockSessionOk,
   renderApp,
 } from '../test/test-utils'
+import { resetWorkingSetStore } from '../workingset/store'
 
 function mockBuckets(overrides: Partial<ChronicleBuckets> = {}): Response {
   const body: ChronicleBuckets = {
@@ -55,8 +56,15 @@ function installFetch(
 }
 
 describe('ChroniclePage timeline', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/')
+    resetWorkingSetStore()
+  })
+
   afterEach(() => {
     vi.unstubAllGlobals()
+    window.history.replaceState(null, '', '/')
+    resetWorkingSetStore()
   })
 
   it('bootstrap sets viewport to extent', async () => {

--- a/apps/chronicle/web/src/chronicle/DensityNavigator.tsx
+++ b/apps/chronicle/web/src/chronicle/DensityNavigator.tsx
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useRef, useState, type PointerEvent } from 'react'
+
+import type { BucketPoint } from '../api/types'
+import { timeForX, type Viewport, xForTime } from './timeScale'
+
+const COLORS = {
+  steel: '#344050',
+  action: '#5aa7ff',
+  muted: '#91a0b5',
+  bg: '#151b23',
+  bar: '#344050',
+} as const
+
+const HEIGHT = 48
+const MIN_WINDOW_PX = 8
+
+export interface DensityNavigatorProps {
+  extent: Viewport
+  viewport: Viewport
+  densityBuckets: BucketPoint[]
+  onViewportChange: (vp: Viewport) => void
+}
+
+type DragMode =
+  | { kind: 'move'; originX: number; originVp: Viewport }
+  | { kind: 'resize-left'; originX: number; originVp: Viewport }
+  | { kind: 'resize-right'; originX: number; originVp: Viewport }
+  | null
+
+/**
+ * Full-width 48px density strip over the FULL extent with a viewport window.
+ *
+ * aria-hidden: keyboard equivalence is via toolbar / table (Phase 5 full a11y).
+ * Density data comes from the same buckets response; keep previous while loading.
+ */
+export function DensityNavigator({
+  extent,
+  viewport,
+  densityBuckets,
+  onViewportChange,
+}: DensityNavigatorProps) {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [width, setWidth] = useState(0)
+  const dragRef = useRef<DragMode>(null)
+
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    if (typeof ResizeObserver === 'undefined') {
+      setWidth(el.clientWidth || 920)
+      return
+    }
+    const ro = new ResizeObserver((entries) => {
+      const w = Math.floor(entries[0]?.contentRect.width ?? 0)
+      setWidth(w)
+    })
+    ro.observe(el)
+    setWidth(el.clientWidth)
+    return () => ro.disconnect()
+  }, [])
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas || width <= 0) return
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = Math.floor(width * dpr)
+    canvas.height = Math.floor(HEIGHT * dpr)
+    canvas.style.width = `${width}px`
+    canvas.style.height = `${HEIGHT}px`
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.fillStyle = COLORS.bg
+    ctx.fillRect(0, 0, width, HEIGHT)
+
+    let max = 1
+    for (const b of densityBuckets) if (b.count > max) max = b.count
+
+    const extentSpan = Math.max(1, extent.toMs - extent.fromMs)
+    // Approximate bar width from density spacing
+    let barW = 2
+    if (densityBuckets.length >= 2) {
+      const t0 = Date.parse(densityBuckets[0]!.bucket)
+      const t1 = Date.parse(densityBuckets[1]!.bucket)
+      if (Number.isFinite(t0) && Number.isFinite(t1) && t1 > t0) {
+        barW = Math.max(1, ((t1 - t0) / extentSpan) * width - 1)
+      }
+    } else if (densityBuckets.length === 1) {
+      barW = Math.max(2, width / 40)
+    }
+
+    ctx.fillStyle = COLORS.bar
+    for (const b of densityBuckets) {
+      const t = Date.parse(b.bucket)
+      if (!Number.isFinite(t)) continue
+      const x = xForTime(t, extent, width)
+      const h = (b.count / max) * (HEIGHT - 8)
+      ctx.globalAlpha = 0.7
+      ctx.fillRect(x, HEIGHT - 4 - h, barW, h)
+    }
+    ctx.globalAlpha = 1
+
+    // Viewport window
+    const x0 = xForTime(viewport.fromMs, extent, width)
+    const x1 = xForTime(viewport.toMs, extent, width)
+    const wx = Math.min(x0, x1)
+    const ww = Math.max(MIN_WINDOW_PX, Math.abs(x1 - x0))
+    ctx.fillStyle = COLORS.action
+    ctx.globalAlpha = 0.12
+    ctx.fillRect(wx, 0, ww, HEIGHT)
+    ctx.globalAlpha = 1
+    ctx.strokeStyle = COLORS.action
+    ctx.lineWidth = 1
+    ctx.strokeRect(wx + 0.5, 0.5, ww - 1, HEIGHT - 1)
+
+    // Edge handles
+    ctx.fillStyle = COLORS.action
+    ctx.fillRect(wx, 0, 3, HEIGHT)
+    ctx.fillRect(wx + ww - 3, 0, 3, HEIGHT)
+  }, [densityBuckets, extent, viewport, width])
+
+  useEffect(() => {
+    const id = requestAnimationFrame(draw)
+    return () => cancelAnimationFrame(id)
+  }, [draw])
+
+  const applyDrag = (clientX: number) => {
+    const mode = dragRef.current
+    const el = wrapRef.current
+    if (!mode || !el || width <= 0) return
+    const rect = el.getBoundingClientRect()
+    const x = clientX - rect.left
+    const dx = x - mode.originX
+    const span = mode.originVp.toMs - mode.originVp.fromMs
+
+    if (mode.kind === 'move') {
+      const dMs = (dx / width) * (extent.toMs - extent.fromMs)
+      onViewportChange({
+        fromMs: mode.originVp.fromMs + dMs,
+        toMs: mode.originVp.toMs + dMs,
+      })
+      return
+    }
+
+    const minSpan = (MIN_WINDOW_PX / width) * (extent.toMs - extent.fromMs)
+    if (mode.kind === 'resize-left') {
+      const dMs = (dx / width) * (extent.toMs - extent.fromMs)
+      let fromMs = mode.originVp.fromMs + dMs
+      const toMs = mode.originVp.toMs
+      if (toMs - fromMs < minSpan) fromMs = toMs - minSpan
+      onViewportChange({ fromMs, toMs })
+    } else if (mode.kind === 'resize-right') {
+      const dMs = (dx / width) * (extent.toMs - extent.fromMs)
+      const fromMs = mode.originVp.fromMs
+      let toMs = mode.originVp.toMs + dMs
+      if (toMs - fromMs < minSpan) toMs = fromMs + minSpan
+      onViewportChange({ fromMs, toMs })
+    }
+    void span
+  }
+
+  const onPointerDown = (e: PointerEvent) => {
+    if (width <= 0) return
+    const el = wrapRef.current
+    if (!el) return
+    el.setPointerCapture(e.pointerId)
+    const rect = el.getBoundingClientRect()
+    const x = e.clientX - rect.left
+    const x0 = xForTime(viewport.fromMs, extent, width)
+    const x1 = xForTime(viewport.toMs, extent, width)
+    const left = Math.min(x0, x1)
+    const right = Math.max(x0, x1)
+    const edge = 6
+
+    if (x >= left - edge && x <= left + edge) {
+      dragRef.current = {
+        kind: 'resize-left',
+        originX: x,
+        originVp: { ...viewport },
+      }
+    } else if (x >= right - edge && x <= right + edge) {
+      dragRef.current = {
+        kind: 'resize-right',
+        originX: x,
+        originVp: { ...viewport },
+      }
+    } else if (x >= left && x <= right) {
+      dragRef.current = {
+        kind: 'move',
+        originX: x,
+        originVp: { ...viewport },
+      }
+    } else {
+      // Click outside window = center viewport there
+      const t = timeForX(x, extent, width)
+      const half = (viewport.toMs - viewport.fromMs) / 2
+      onViewportChange({ fromMs: t - half, toMs: t + half })
+      dragRef.current = null
+    }
+  }
+
+  const onPointerMove = (e: PointerEvent) => {
+    if (!dragRef.current) return
+    applyDrag(e.clientX)
+  }
+
+  const onPointerUp = () => {
+    dragRef.current = null
+  }
+
+  return (
+    <div
+      ref={wrapRef}
+      className="w-full touch-none overflow-hidden rounded-md border border-steel"
+      style={{ height: HEIGHT }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      data-testid="density-navigator"
+      // Density navigator is pointer-first; keyboard users use toolbar / table.
+      // Full a11y pass (role=slider) is Phase 5.
+      aria-hidden="true"
+    >
+      <canvas ref={canvasRef} />
+    </div>
+  )
+}

--- a/apps/chronicle/web/src/chronicle/LaneConfigPanel.test.tsx
+++ b/apps/chronicle/web/src/chronicle/LaneConfigPanel.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LaneConfigPanel } from './LaneConfigPanel'
+import { LANES_STORAGE_KEY } from '../workingset/urlState'
+
+function installMemoryLocalStorage(): void {
+  const map = new Map<string, string>()
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      get length() {
+        return map.size
+      },
+      clear: () => map.clear(),
+      getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+      key: (i: number) => [...map.keys()][i] ?? null,
+      removeItem: (k: string) => {
+        map.delete(k)
+      },
+      setItem: (k: string, v: string) => {
+        map.set(k, String(v))
+      },
+    },
+    configurable: true,
+    writable: true,
+  })
+}
+
+describe('LaneConfigPanel', () => {
+  beforeEach(() => {
+    installMemoryLocalStorage()
+  })
+
+  it('toggles and reorders via keyboard-accessible controls', () => {
+    const onToggle = vi.fn()
+    const onMove = vi.fn()
+    render(
+      <LaneConfigPanel
+        lanes={['messages', 'attachments', 'top_people']}
+        onToggle={onToggle}
+        onMove={onMove}
+      />,
+    )
+
+    expect(screen.getByTestId('lane-config-panel')).toBeInTheDocument()
+    expect(screen.getByLabelText('Show Messages')).toBeChecked()
+    expect(screen.getByLabelText('Show People (distinct)')).not.toBeChecked()
+
+    fireEvent.click(screen.getByLabelText('Show People (distinct)'))
+    expect(onToggle).toHaveBeenCalledWith('people')
+
+    fireEvent.click(screen.getByLabelText('Move Messages down'))
+    expect(onMove).toHaveBeenCalledWith('messages', 'down')
+
+    fireEvent.click(screen.getByLabelText('Move Top people up'))
+    expect(onMove).toHaveBeenCalledWith('top_people', 'up')
+  })
+
+  it('saves current lanes as default lens', () => {
+    render(
+      <LaneConfigPanel
+        lanes={['people', 'messages']}
+        onToggle={() => {}}
+        onMove={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('save-default-lanes'))
+    expect(localStorage.getItem(LANES_STORAGE_KEY)).toBe('people,messages')
+  })
+})

--- a/apps/chronicle/web/src/chronicle/LaneConfigPanel.tsx
+++ b/apps/chronicle/web/src/chronicle/LaneConfigPanel.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react'
+
+import {
+  LANE_CATALOG,
+  type LaneSpec,
+} from './laneModel'
+import {
+  saveLanesAsDefault,
+} from '../workingset/urlState'
+import type { MoveLaneDir } from '../workingset/store'
+
+export interface LaneConfigPanelProps {
+  /** Ordered visible lane keys. */
+  lanes: string[]
+  onToggle: (key: string) => void
+  onMove: (key: string, dir: MoveLaneDir) => void
+  /** Optional: collapse state controlled externally; default internal. */
+  defaultCollapsed?: boolean
+}
+
+/**
+ * Configuration rail: hide/show and reorder lanes; save lens to localStorage.
+ * Placed left of the timeline canvas in ChroniclePage (220px, collapsible).
+ */
+export function LaneConfigPanel({
+  lanes,
+  onToggle,
+  onMove,
+  defaultCollapsed = false,
+}: LaneConfigPanelProps) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed)
+
+  if (collapsed) {
+    return (
+      <div
+        className="flex shrink-0 flex-col items-center border border-steel bg-graphite-900"
+        data-testid="lane-config-panel"
+        data-collapsed="true"
+      >
+        <button
+          type="button"
+          className="px-2 py-3 text-text-muted hover:text-text-primary"
+          aria-expanded={false}
+          aria-controls="lane-config-body"
+          onClick={() => setCollapsed(false)}
+        >
+          Lanes
+        </button>
+      </div>
+    )
+  }
+
+  // Visible lanes in store order, then hidden catalog entries.
+  const visibleSet = new Set(lanes)
+  const visibleSpecs: LaneSpec[] = []
+  for (const key of lanes) {
+    const spec = LANE_CATALOG.find((s) => s.key === key)
+    if (spec) visibleSpecs.push(spec)
+  }
+  const hiddenSpecs = LANE_CATALOG.filter((s) => !visibleSet.has(s.key))
+  const rows = [...visibleSpecs, ...hiddenSpecs]
+
+  return (
+    <aside
+      className="flex w-[220px] shrink-0 flex-col gap-2 rounded-lg border border-steel bg-graphite-900 p-3"
+      data-testid="lane-config-panel"
+      data-collapsed="false"
+      aria-label="Lane configuration"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-medium text-text-primary">Lanes</h2>
+        <button
+          type="button"
+          className="text-xs text-text-muted hover:text-text-primary"
+          aria-expanded={true}
+          aria-controls="lane-config-body"
+          onClick={() => setCollapsed(true)}
+        >
+          Collapse
+        </button>
+      </div>
+
+      <ul id="lane-config-body" className="flex flex-col gap-1.5" role="list">
+        {rows.map((spec) => {
+          const visible = visibleSet.has(spec.key)
+          const orderIdx = lanes.indexOf(spec.key)
+          const canUp = visible && orderIdx > 0
+          const canDown = visible && orderIdx >= 0 && orderIdx < lanes.length - 1
+          return (
+            <li
+              key={spec.key}
+              className="flex items-center gap-1 rounded border border-steel/60 px-1.5 py-1"
+              data-lane-key={spec.key}
+            >
+              <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-sm text-text-primary">
+                <input
+                  type="checkbox"
+                  checked={visible}
+                  onChange={() => onToggle(spec.key)}
+                  aria-label={`Show ${spec.label}`}
+                />
+                <span className="truncate">{spec.label}</span>
+              </label>
+              <div className="flex shrink-0 flex-col gap-0.5">
+                <button
+                  type="button"
+                  className="rounded px-1.5 py-0.5 text-xs text-text-muted enabled:hover:bg-graphite-800 enabled:hover:text-text-primary disabled:opacity-30"
+                  disabled={!canUp}
+                  aria-label={`Move ${spec.label} up`}
+                  onClick={() => onMove(spec.key, 'up')}
+                >
+                  Up
+                </button>
+                <button
+                  type="button"
+                  className="rounded px-1.5 py-0.5 text-xs text-text-muted enabled:hover:bg-graphite-800 enabled:hover:text-text-primary disabled:opacity-30"
+                  disabled={!canDown}
+                  aria-label={`Move ${spec.label} down`}
+                  onClick={() => onMove(spec.key, 'down')}
+                >
+                  Down
+                </button>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+
+      <button
+        type="button"
+        className="mt-1 rounded-md border border-steel bg-graphite-800 px-2 py-1.5 text-xs text-text-primary hover:border-action"
+        onClick={() => saveLanesAsDefault(lanes)}
+        data-testid="save-default-lanes"
+      >
+        Save as default lanes
+      </button>
+    </aside>
+  )
+}

--- a/apps/chronicle/web/src/chronicle/TimelineCanvas.focus.test.ts
+++ b/apps/chronicle/web/src/chronicle/TimelineCanvas.focus.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for double-click focus entry vs Alt+double-click zoom
+ * (canvas handler policy — resolveDoubleClickAction).
+ */
+import { describe, expect, it } from 'vitest'
+
+import { resolveDoubleClickAction } from './TimelineCanvas'
+import type { Viewport } from './timeScale'
+
+const vp: Viewport = {
+  fromMs: Date.UTC(2014, 0, 1),
+  toMs: Date.UTC(2019, 0, 1),
+}
+
+describe('double-click focus vs Alt+zoom', () => {
+  it('Alt+double-click retains zoom (does not enter focus)', () => {
+    const bucket: Viewport = {
+      fromMs: Date.UTC(2015, 0, 1),
+      toMs: Date.UTC(2015, 1, 1),
+    }
+    const result = resolveDoubleClickAction({
+      altKey: true,
+      bucketHit: bucket,
+      viewport: vp,
+      plotX: 100,
+      plotW: 800,
+    })
+    expect(result.kind).toBe('zoom')
+    if (result.kind === 'zoom') {
+      const span = result.viewport.toMs - result.viewport.fromMs
+      const origSpan = vp.toMs - vp.fromMs
+      expect(span).toBeCloseTo(origSpan * 0.25, -2)
+    }
+  })
+
+  it('plain double-click with bucket hit enters focus', () => {
+    const bucket: Viewport = {
+      fromMs: Date.UTC(2015, 0, 1),
+      toMs: Date.UTC(2015, 1, 1),
+    }
+    const result = resolveDoubleClickAction({
+      altKey: false,
+      bucketHit: bucket,
+      viewport: vp,
+      plotX: 100,
+      plotW: 800,
+    })
+    expect(result).toEqual({ kind: 'focus', period: bucket })
+  })
+
+  it('plain double-click without hit falls back to zoom', () => {
+    const result = resolveDoubleClickAction({
+      altKey: false,
+      bucketHit: null,
+      viewport: vp,
+      plotX: 100,
+      plotW: 800,
+    })
+    expect(result.kind).toBe('zoom')
+  })
+})

--- a/apps/chronicle/web/src/chronicle/TimelineCanvas.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineCanvas.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type KeyboardEvent,
@@ -8,7 +9,23 @@ import {
   type PointerEvent,
 } from 'react'
 
-import type { BucketPoint } from '../api/types'
+import type { BucketPoint, LaneData } from '../api/types'
+import { isTopPeopleLane } from '../api/types'
+import {
+  AXIS_H,
+  BAR_LANE_COLORS,
+  LANE_GAP,
+  LANE_H,
+  LANE_LABEL_W,
+  MULTIROW_HEADER_H,
+  MULTIROW_ROW_H,
+  PEOPLE_CYAN,
+  barsPoints,
+  canvasHeightForLanes,
+  laneAtY as laneAtYFromLayout,
+  layoutLanes,
+  type LaneSpec,
+} from './laneModel'
 import {
   bucketWidthPx,
   formatPeriodRange,
@@ -33,17 +50,14 @@ const COLORS = {
   graphite900: '#151b23',
 } as const
 
-const AXIS_H = 28
-const LANE_H = 72
-const LANE_LABEL_W = 52
-const LANE_GAP = 4
-
 export interface TimelineCanvasProps {
   viewport: Viewport
   extent: Viewport | null
   unit: string
-  messages: BucketPoint[]
-  attachments: BucketPoint[]
+  /** Ordered lane specs (store order). */
+  lanes: LaneSpec[]
+  /** Lane key → server payload (bars series or top_people contacts). */
+  laneData: Record<string, LaneData>
   isFetching: boolean
   brush: Viewport | null
   /** Currently selected bucket (for highlight outline). */
@@ -51,7 +65,7 @@ export interface TimelineCanvasProps {
   onViewportChange: (vp: Viewport) => void
   onBrushChange: (brush: Viewport | null) => void
   onWidthChange: (width: number) => void
-  /** Fired when a bar is clicked (lane + bucket ISO). */
+  /** Fired when a bar/mark is clicked (lane + bucket ISO). */
   onSelectBucket?: (bucketIso: string, laneName: string) => void
 }
 
@@ -101,7 +115,7 @@ export function bucketAtX(
   return hit
 }
 
-/** Which lane (0 = messages, 1 = attachments) contains localY, or null. */
+/** @deprecated Prefer layout-aware hit-test; kept for tests with default two bars. */
 export function laneAtY(localY: number): 'messages' | 'attachments' | null {
   if (localY <= AXIS_H) return null
   const messagesTop = AXIS_H + LANE_GAP
@@ -123,15 +137,27 @@ function maxCount(points: BucketPoint[]): number {
   return m
 }
 
+function truncateLabel(text: string, maxCh: number): string {
+  if (text.length <= maxCh) return text
+  return text.slice(0, Math.max(0, maxCh - 1)) + '…'
+}
+
 function buildAriaLabel(
   viewport: Viewport,
-  messages: BucketPoint[],
-  attachments: BucketPoint[],
+  lanes: LaneSpec[],
+  laneData: Record<string, LaneData>,
 ): string {
   const range = formatPeriodRange(viewport)
-  const msg = sumCounts(messages).toLocaleString()
-  const att = sumCounts(attachments).toLocaleString()
-  return `Timeline, ${range}, ${msg} messages, ${att} attachments`
+  const parts = lanes.map((spec) => {
+    if (spec.kind === 'bars') {
+      const n = sumCounts(barsPoints(laneData, spec.key)).toLocaleString()
+      return `${n} ${spec.label.toLowerCase()}`
+    }
+    const tp = laneData[spec.key]
+    const n = isTopPeopleLane(tp) ? tp.contacts.length : 0
+    return `${n} contacts`
+  })
+  return `Timeline, ${range}, ${parts.join(', ')}`
 }
 
 /**
@@ -142,8 +168,8 @@ export function TimelineCanvas({
   viewport,
   extent,
   unit,
-  messages,
-  attachments,
+  lanes,
+  laneData,
   isFetching,
   brush,
   selectedBucket = null,
@@ -163,19 +189,28 @@ export function TimelineCanvas({
     return () => el.removeEventListener('wheel', handler)
   }, [])
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const [cssSize, setCssSize] = useState({ w: 0, h: AXIS_H + 2 * (LANE_H + LANE_GAP) })
+  const contentH = useMemo(
+    () => canvasHeightForLanes(lanes, laneData),
+    [lanes, laneData],
+  )
+  const layout = useMemo(() => layoutLanes(lanes, laneData), [lanes, laneData])
+  const [cssSize, setCssSize] = useState({ w: 0, h: contentH })
   const brushDrag = useRef<{ startX: number; curX: number } | null>(null)
   const rafRef = useRef<number>(0)
   const shimmerRef = useRef(0)
+
+  // Keep height in sync with lane config / top_people row count.
+  useEffect(() => {
+    setCssSize((prev) => (prev.h === contentH ? prev : { ...prev, h: contentH }))
+  }, [contentH])
 
   // ResizeObserver × devicePixelRatio (fallback for jsdom / older environments)
   useEffect(() => {
     const el = wrapRef.current
     if (!el) return
-    const h = AXIS_H + 2 * (LANE_H + LANE_GAP)
     const apply = (w: number) => {
       const width = Math.max(0, Math.floor(w))
-      setCssSize({ w: width, h })
+      setCssSize({ w: width, h: contentH })
       onWidthChange(width)
     }
     if (typeof ResizeObserver === 'undefined') {
@@ -190,7 +225,7 @@ export function TimelineCanvas({
     ro.observe(el)
     apply(el.clientWidth)
     return () => ro.disconnect()
-  }, [onWidthChange])
+  }, [onWidthChange, contentH])
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current
@@ -234,47 +269,89 @@ export function TimelineCanvas({
       }
     }
 
-    const lanes: { name: string; points: BucketPoint[]; color: string }[] = [
-      { name: 'messages', points: messages, color: COLORS.action },
-      { name: 'attachments', points: attachments, color: COLORS.attachment },
-    ]
-
-    lanes.forEach((lane, i) => {
-      const top = AXIS_H + LANE_GAP + i * (LANE_H + LANE_GAP)
-      const max = maxCount(lane.points) || 1
+    for (const block of layout) {
+      const { spec, top, height } = block
       ctx.fillStyle = COLORS.graphite900
-      ctx.fillRect(0, top, w, LANE_H)
+      ctx.fillRect(0, top, w, height)
 
-      // Count scale label
-      ctx.fillStyle = COLORS.muted
-      ctx.font = '10px Inter, system-ui, sans-serif'
-      ctx.textBaseline = 'top'
-      ctx.fillText(`0–${maxCount(lane.points).toLocaleString()}`, 4, top + 4)
-      ctx.fillText(lane.name, 4, top + 18)
+      if (spec.kind === 'bars') {
+        const points = barsPoints(laneData, spec.key)
+        const max = maxCount(points) || 1
+        const color = BAR_LANE_COLORS[spec.key] ?? COLORS.action
 
-      const barMaxH = LANE_H - 12
-      for (const pt of lane.points) {
-        const t = Date.parse(pt.bucket)
-        if (!Number.isFinite(t)) continue
-        const x = LANE_LABEL_W + xForTime(t, viewport, plotW)
-        const barH = (pt.count / max) * barMaxH
-        const barY = top + LANE_H - 4 - barH
-        ctx.fillStyle = lane.color
-        ctx.globalAlpha = 0.85
-        ctx.fillRect(x, barY, bw, barH)
-        ctx.globalAlpha = 1
-        // Selected bucket: 1px action-blue outline
-        if (
-          selectedBucket &&
-          selectedBucket.lane === lane.name &&
-          selectedBucket.bucketIso === pt.bucket
-        ) {
-          ctx.strokeStyle = COLORS.action
-          ctx.lineWidth = 1
-          ctx.strokeRect(x + 0.5, barY + 0.5, Math.max(0, bw - 1), Math.max(0, barH - 1))
+        ctx.fillStyle = COLORS.muted
+        ctx.font = '10px Inter, system-ui, sans-serif'
+        ctx.textBaseline = 'top'
+        ctx.fillText(`0–${maxCount(points).toLocaleString()}`, 4, top + 4)
+        ctx.fillText(spec.label, 4, top + 18)
+
+        const barMaxH = LANE_H - 12
+        for (const pt of points) {
+          const t = Date.parse(pt.bucket)
+          if (!Number.isFinite(t)) continue
+          const x = LANE_LABEL_W + xForTime(t, viewport, plotW)
+          const barH = (pt.count / max) * barMaxH
+          const barY = top + LANE_H - 4 - barH
+          ctx.fillStyle = color
+          ctx.globalAlpha = 0.85
+          ctx.fillRect(x, barY, bw, barH)
+          ctx.globalAlpha = 1
+          if (
+            selectedBucket &&
+            selectedBucket.lane === spec.key &&
+            selectedBucket.bucketIso === pt.bucket
+          ) {
+            ctx.strokeStyle = COLORS.action
+            ctx.lineWidth = 1
+            ctx.strokeRect(x + 0.5, barY + 0.5, Math.max(0, bw - 1), Math.max(0, barH - 1))
+          }
         }
+      } else {
+        // multirow: top_people activity spans
+        const data = laneData[spec.key]
+        const contacts = isTopPeopleLane(data) ? data.contacts : []
+        ctx.fillStyle = COLORS.muted
+        ctx.font = '10px Inter, system-ui, sans-serif'
+        ctx.textBaseline = 'middle'
+        ctx.fillText(spec.label, 4, top + MULTIROW_HEADER_H / 2)
+
+        contacts.forEach((contact, i) => {
+          const rowTop = top + MULTIROW_HEADER_H + i * MULTIROW_ROW_H
+          const rowMax = maxCount(contact.buckets) || 1
+          ctx.fillStyle = COLORS.muted
+          ctx.font = '10px Inter, system-ui, sans-serif'
+          ctx.textBaseline = 'middle'
+          ctx.fillText(
+            truncateLabel(contact.display_name, 16),
+            4,
+            rowTop + MULTIROW_ROW_H / 2,
+          )
+
+          for (const pt of contact.buckets) {
+            if (pt.count <= 0) continue
+            const t = Date.parse(pt.bucket)
+            if (!Number.isFinite(t)) continue
+            const x = LANE_LABEL_W + xForTime(t, viewport, plotW)
+            const opacity = Math.min(1, Math.max(0.15, pt.count / rowMax))
+            ctx.fillStyle = PEOPLE_CYAN
+            ctx.globalAlpha = opacity
+            const markH = MULTIROW_ROW_H - 4
+            ctx.fillRect(x, rowTop + 2, bw, markH)
+            ctx.globalAlpha = 1
+            const hitLane = `top_people:${contact.contact_id}`
+            if (
+              selectedBucket &&
+              selectedBucket.lane === hitLane &&
+              selectedBucket.bucketIso === pt.bucket
+            ) {
+              ctx.strokeStyle = COLORS.action
+              ctx.lineWidth = 1
+              ctx.strokeRect(x + 0.5, rowTop + 2.5, Math.max(0, bw - 1), markH - 1)
+            }
+          }
+        })
       }
-    })
+    }
 
     // Brush overlay
     const activeBrush = brushDrag.current
@@ -305,7 +382,16 @@ export function TimelineCanvas({
     }
 
     // Empty viewport message
-    const total = sumCounts(messages) + sumCounts(attachments)
+    let total = 0
+    for (const spec of lanes) {
+      if (spec.kind === 'bars') total += sumCounts(barsPoints(laneData, spec.key))
+      else {
+        const tp = laneData[spec.key]
+        if (isTopPeopleLane(tp)) {
+          for (const c of tp.contacts) total += sumCounts(c.buckets)
+        }
+      }
+    }
     if (total === 0 && !isFetching) {
       ctx.fillStyle = COLORS.muted
       ctx.font = '13px Inter, system-ui, sans-serif'
@@ -349,13 +435,14 @@ export function TimelineCanvas({
       ctx.fillRect(0, 0, w, 2)
     }
   }, [
-    attachments,
     brush,
     cssSize.h,
     cssSize.w,
     extent,
     isFetching,
-    messages,
+    laneData,
+    lanes,
+    layout,
     selectedBucket,
     unit,
     viewport,
@@ -462,7 +549,7 @@ export function TimelineCanvas({
       return
     }
 
-    // Bar click hit-test
+    // Bar / multirow mark click hit-test
     const pending = clickRef.current
     clickRef.current = null
     if (!pending || !onSelectBucket) return
@@ -472,15 +559,26 @@ export function TimelineCanvas({
     const localY = e.clientY - rect.top
     // Ignore if pointer moved more than a few px (drag-like)
     if (Math.hypot(localX - pending.x, localY - pending.y) > 6) return
-    const lane = laneAtY(localY)
-    if (!lane) return
+    const hitKey = laneAtYFromLayout(localY, layout)
+    if (!hitKey) return
     const pw = plotWidth()
     const plotX = localX - LANE_LABEL_W
     if (plotX < 0) return
     const unitTyped = parseUnit(unit)
-    const points = lane === 'messages' ? messages : attachments
+
+    let points: BucketPoint[] = []
+    if (hitKey.startsWith('top_people:')) {
+      const contactId = hitKey.slice('top_people:'.length)
+      const tp = laneData.top_people
+      if (isTopPeopleLane(tp)) {
+        const contact = tp.contacts.find((c) => c.contact_id === contactId)
+        points = contact?.buckets ?? []
+      }
+    } else {
+      points = barsPoints(laneData, hitKey)
+    }
     const bucketIso = bucketAtX(plotX, viewport, pw, unitTyped, points)
-    if (bucketIso) onSelectBucket(bucketIso, lane)
+    if (bucketIso) onSelectBucket(bucketIso, hitKey)
   }
 
   const onDoubleClick = (e: MouseEvent) => {
@@ -510,11 +608,13 @@ export function TimelineCanvas({
       onKeyDown={onKeyDown}
       tabIndex={0}
       data-testid="timeline-canvas-wrap"
+      data-lane-count={lanes.length}
+      data-canvas-h={cssSize.h}
     >
       <canvas
         ref={canvasRef}
         role="img"
-        aria-label={buildAriaLabel(viewport, messages, attachments)}
+        aria-label={buildAriaLabel(viewport, lanes, laneData)}
         data-testid="timeline-canvas"
       />
     </div>

--- a/apps/chronicle/web/src/chronicle/TimelineCanvas.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineCanvas.tsx
@@ -1,0 +1,417 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+  type PointerEvent,
+} from 'react'
+
+import type { BucketPoint } from '../api/types'
+import {
+  bucketWidthPx,
+  formatPeriodRange,
+  parseUnit,
+  timeForX,
+  ticksFor,
+  type Unit,
+  type Viewport,
+  wheelZoomFactor,
+  xForTime,
+  zoomViewport,
+} from './timeScale'
+
+const COLORS = {
+  steel: '#344050',
+  action: '#5aa7ff',
+  attachment: '#55c2a3',
+  muted: '#91a0b5',
+  primary: '#e6edf3',
+  bg: '#0d1117',
+  graphite900: '#151b23',
+} as const
+
+const AXIS_H = 28
+const LANE_H = 72
+const LANE_LABEL_W = 52
+const LANE_GAP = 4
+
+export interface TimelineCanvasProps {
+  viewport: Viewport
+  extent: Viewport | null
+  unit: string
+  messages: BucketPoint[]
+  attachments: BucketPoint[]
+  isFetching: boolean
+  brush: Viewport | null
+  onViewportChange: (vp: Viewport) => void
+  onBrushChange: (brush: Viewport | null) => void
+  onWidthChange: (width: number) => void
+}
+
+function sumCounts(points: BucketPoint[]): number {
+  return points.reduce((s, p) => s + p.count, 0)
+}
+
+function maxCount(points: BucketPoint[]): number {
+  let m = 0
+  for (const p of points) if (p.count > m) m = p.count
+  return m
+}
+
+function buildAriaLabel(
+  viewport: Viewport,
+  messages: BucketPoint[],
+  attachments: BucketPoint[],
+): string {
+  const range = formatPeriodRange(viewport)
+  const msg = sumCounts(messages).toLocaleString()
+  const att = sumCounts(attachments).toLocaleString()
+  return `Timeline, ${range}, ${msg} messages, ${att} attachments`
+}
+
+/**
+ * Canvas-2D multi-lane timeline renderer. All time↔pixel math lives in
+ * timeScale.ts; this component is a thin interactive surface.
+ */
+export function TimelineCanvas({
+  viewport,
+  extent,
+  unit,
+  messages,
+  attachments,
+  isFetching,
+  brush,
+  onViewportChange,
+  onBrushChange,
+  onWidthChange,
+}: TimelineCanvasProps) {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const wheelHandlerRef = useRef<(e: globalThis.WheelEvent) => void>(() => {})
+
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    const handler = (e: globalThis.WheelEvent) => wheelHandlerRef.current(e)
+    el.addEventListener('wheel', handler, { passive: false })
+    return () => el.removeEventListener('wheel', handler)
+  }, [])
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [cssSize, setCssSize] = useState({ w: 0, h: AXIS_H + 2 * (LANE_H + LANE_GAP) })
+  const brushDrag = useRef<{ startX: number; curX: number } | null>(null)
+  const rafRef = useRef<number>(0)
+  const shimmerRef = useRef(0)
+
+  // ResizeObserver × devicePixelRatio (fallback for jsdom / older environments)
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    const h = AXIS_H + 2 * (LANE_H + LANE_GAP)
+    const apply = (w: number) => {
+      const width = Math.max(0, Math.floor(w))
+      setCssSize({ w: width, h })
+      onWidthChange(width)
+    }
+    if (typeof ResizeObserver === 'undefined') {
+      apply(el.clientWidth || 920)
+      return
+    }
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      apply(entry.contentRect.width)
+    })
+    ro.observe(el)
+    apply(el.clientWidth)
+    return () => ro.disconnect()
+  }, [onWidthChange])
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas || cssSize.w <= 0) return
+    const dpr = window.devicePixelRatio || 1
+    const w = cssSize.w
+    const h = cssSize.h
+    if (canvas.width !== Math.floor(w * dpr) || canvas.height !== Math.floor(h * dpr)) {
+      canvas.width = Math.floor(w * dpr)
+      canvas.height = Math.floor(h * dpr)
+      canvas.style.width = `${w}px`
+      canvas.style.height = `${h}px`
+    }
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, w, h)
+    ctx.fillStyle = COLORS.bg
+    ctx.fillRect(0, 0, w, h)
+
+    const plotW = Math.max(1, w - LANE_LABEL_W)
+    const unitTyped: Unit = parseUnit(unit)
+    const bw = Math.max(1, bucketWidthPx(unitTyped, viewport, plotW) - 1)
+
+    // Axis
+    ctx.fillStyle = COLORS.graphite900
+    ctx.fillRect(0, 0, w, AXIS_H)
+    const ticks = ticksFor(viewport, plotW)
+    ctx.strokeStyle = COLORS.steel
+    ctx.fillStyle = COLORS.muted
+    ctx.font = '11px Inter, system-ui, sans-serif'
+    ctx.textBaseline = 'middle'
+    for (const tick of ticks) {
+      const x = LANE_LABEL_W + xForTime(tick.timeMs, viewport, plotW)
+      ctx.beginPath()
+      ctx.moveTo(x, AXIS_H - (tick.major ? 10 : 6))
+      ctx.lineTo(x, AXIS_H)
+      ctx.stroke()
+      if (tick.major) {
+        ctx.fillText(tick.label, x + 2, AXIS_H / 2)
+      }
+    }
+
+    const lanes: { name: string; points: BucketPoint[]; color: string }[] = [
+      { name: 'messages', points: messages, color: COLORS.action },
+      { name: 'attachments', points: attachments, color: COLORS.attachment },
+    ]
+
+    lanes.forEach((lane, i) => {
+      const top = AXIS_H + LANE_GAP + i * (LANE_H + LANE_GAP)
+      const max = maxCount(lane.points) || 1
+      ctx.fillStyle = COLORS.graphite900
+      ctx.fillRect(0, top, w, LANE_H)
+
+      // Count scale label
+      ctx.fillStyle = COLORS.muted
+      ctx.font = '10px Inter, system-ui, sans-serif'
+      ctx.textBaseline = 'top'
+      ctx.fillText(`0–${maxCount(lane.points).toLocaleString()}`, 4, top + 4)
+      ctx.fillText(lane.name, 4, top + 18)
+
+      const barMaxH = LANE_H - 12
+      for (const pt of lane.points) {
+        const t = Date.parse(pt.bucket)
+        if (!Number.isFinite(t)) continue
+        const x = LANE_LABEL_W + xForTime(t, viewport, plotW)
+        const barH = (pt.count / max) * barMaxH
+        ctx.fillStyle = lane.color
+        ctx.globalAlpha = 0.85
+        ctx.fillRect(x, top + LANE_H - 4 - barH, bw, barH)
+        ctx.globalAlpha = 1
+      }
+    })
+
+    // Brush overlay
+    const activeBrush = brushDrag.current
+      ? {
+          fromMs: timeForX(
+            Math.min(brushDrag.current.startX, brushDrag.current.curX) - LANE_LABEL_W,
+            viewport,
+            plotW,
+          ),
+          toMs: timeForX(
+            Math.max(brushDrag.current.startX, brushDrag.current.curX) - LANE_LABEL_W,
+            viewport,
+            plotW,
+          ),
+        }
+      : brush
+
+    if (activeBrush && activeBrush.toMs > activeBrush.fromMs) {
+      const x0 = LANE_LABEL_W + xForTime(activeBrush.fromMs, viewport, plotW)
+      const x1 = LANE_LABEL_W + xForTime(activeBrush.toMs, viewport, plotW)
+      ctx.fillStyle = COLORS.action
+      ctx.globalAlpha = 0.15
+      ctx.fillRect(x0, 0, x1 - x0, h)
+      ctx.globalAlpha = 1
+      ctx.strokeStyle = COLORS.action
+      ctx.lineWidth = 1
+      ctx.strokeRect(x0 + 0.5, 0.5, x1 - x0 - 1, h - 1)
+    }
+
+    // Empty viewport message
+    const total = sumCounts(messages) + sumCounts(attachments)
+    if (total === 0 && !isFetching) {
+      ctx.fillStyle = COLORS.muted
+      ctx.font = '13px Inter, system-ui, sans-serif'
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'middle'
+      ctx.fillText('No activity in range', w / 2, h / 2)
+      if (extent) {
+        if (viewport.toMs < extent.fromMs) {
+          ctx.fillText(
+            `activity after ${formatPeriodRange({ fromMs: extent.fromMs, toMs: extent.fromMs })} →`,
+            w / 2,
+            h / 2 + 18,
+          )
+        } else if (viewport.fromMs > extent.toMs) {
+          ctx.fillText(
+            `← activity before ${new Date(extent.toMs).getUTCFullYear()}`,
+            w / 2,
+            h / 2 + 18,
+          )
+        } else if (viewport.toMs <= extent.fromMs || viewport.fromMs >= extent.toMs) {
+          ctx.fillText(
+            `← activity before ${new Date(extent.toMs).getUTCFullYear()}`,
+            w / 2,
+            h / 2 + 18,
+          )
+        }
+      }
+      ctx.textAlign = 'start'
+    }
+
+    // Loading shimmer (2px indeterminate line at top)
+    if (isFetching) {
+      const phase = (shimmerRef.current % 1000) / 1000
+      const sw = w * 0.3
+      const sx = (w + sw) * phase - sw
+      const grad = ctx.createLinearGradient(sx, 0, sx + sw, 0)
+      grad.addColorStop(0, 'transparent')
+      grad.addColorStop(0.5, COLORS.action)
+      grad.addColorStop(1, 'transparent')
+      ctx.fillStyle = grad
+      ctx.fillRect(0, 0, w, 2)
+    }
+  }, [
+    attachments,
+    brush,
+    cssSize.h,
+    cssSize.w,
+    extent,
+    isFetching,
+    messages,
+    unit,
+    viewport,
+  ])
+
+  // rAF redraw on data/viewport change (no continuous loop unless shimmering)
+  useEffect(() => {
+    let alive = true
+    const frame = () => {
+      if (!alive) return
+      draw()
+      if (isFetching) {
+        shimmerRef.current = performance.now()
+        rafRef.current = requestAnimationFrame(frame)
+      }
+    }
+    rafRef.current = requestAnimationFrame(frame)
+    return () => {
+      alive = false
+      cancelAnimationFrame(rafRef.current)
+    }
+  }, [draw, isFetching])
+
+  const plotWidth = () => Math.max(1, cssSize.w - LANE_LABEL_W)
+
+  // React attaches JSX onWheel passively (preventDefault is ignored), so the
+  // wheel listener is bound natively with { passive: false } in an effect
+  // below, reading the latest handler through a ref.
+  const onWheel = (e: globalThis.WheelEvent) => {
+    e.preventDefault()
+    const rect = wrapRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const localX = e.clientX - rect.left
+    const plotX = Math.max(0, localX - LANE_LABEL_W)
+
+    if (e.ctrlKey || e.metaKey) {
+      const factor = wheelZoomFactor(e.deltaY)
+      onViewportChange(zoomViewport(viewport, factor, plotX, plotWidth()))
+    } else {
+      const delta = e.deltaY + e.deltaX
+      const span = viewport.toMs - viewport.fromMs
+      const deltaMs = (delta / plotWidth()) * span
+      onViewportChange({
+        fromMs: viewport.fromMs + deltaMs,
+        toMs: viewport.toMs + deltaMs,
+      })
+    }
+  }
+
+  wheelHandlerRef.current = onWheel
+
+  const onPointerDown = (e: PointerEvent) => {
+    const rect = wrapRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const localY = e.clientY - rect.top
+    const localX = e.clientX - rect.left
+    // Drag on the axis region = brush
+    if (localY <= AXIS_H) {
+      ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
+      brushDrag.current = { startX: localX, curX: localX }
+    }
+  }
+
+  const onPointerMove = (e: PointerEvent) => {
+    if (!brushDrag.current) return
+    const rect = wrapRef.current?.getBoundingClientRect()
+    if (!rect) return
+    brushDrag.current = {
+      ...brushDrag.current,
+      curX: e.clientX - rect.left,
+    }
+    // Trigger redraw
+    cancelAnimationFrame(rafRef.current)
+    rafRef.current = requestAnimationFrame(draw)
+  }
+
+  const onPointerUp = (e: PointerEvent) => {
+    if (!brushDrag.current) return
+    const rect = wrapRef.current?.getBoundingClientRect()
+    if (!rect) {
+      brushDrag.current = null
+      return
+    }
+    const { startX, curX } = brushDrag.current
+    brushDrag.current = null
+    const pw = plotWidth()
+    const x0 = Math.min(startX, curX) - LANE_LABEL_W
+    const x1 = Math.max(startX, curX) - LANE_LABEL_W
+    if (Math.abs(x1 - x0) < 4) {
+      onBrushChange(null)
+      return
+    }
+    onBrushChange({
+      fromMs: timeForX(Math.max(0, x0), viewport, pw),
+      toMs: timeForX(Math.min(pw, x1), viewport, pw),
+    })
+    void e
+  }
+
+  const onDoubleClick = (e: MouseEvent) => {
+    const rect = wrapRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const plotX = Math.max(0, e.clientX - rect.left - LANE_LABEL_W)
+    // Zoom ×0.25 span anchored at pointer
+    onViewportChange(zoomViewport(viewport, 0.25, plotX, plotWidth()))
+  }
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onBrushChange(null)
+      brushDrag.current = null
+    }
+  }
+
+  return (
+    <div
+      ref={wrapRef}
+      className="relative w-full touch-none overflow-hidden rounded-lg border border-steel"
+      style={{ height: cssSize.h }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onDoubleClick={onDoubleClick}
+      onKeyDown={onKeyDown}
+      tabIndex={0}
+      data-testid="timeline-canvas-wrap"
+    >
+      <canvas
+        ref={canvasRef}
+        role="img"
+        aria-label={buildAriaLabel(viewport, messages, attachments)}
+        data-testid="timeline-canvas"
+      />
+    </div>
+  )
+}

--- a/apps/chronicle/web/src/chronicle/TimelineCanvas.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineCanvas.tsx
@@ -15,6 +15,7 @@ import {
   parseUnit,
   timeForX,
   ticksFor,
+  UNIT_MS,
   type Unit,
   type Viewport,
   wheelZoomFactor,
@@ -45,9 +46,71 @@ export interface TimelineCanvasProps {
   attachments: BucketPoint[]
   isFetching: boolean
   brush: Viewport | null
+  /** Currently selected bucket (for highlight outline). */
+  selectedBucket?: { bucketIso: string; lane: string } | null
   onViewportChange: (vp: Viewport) => void
   onBrushChange: (brush: Viewport | null) => void
   onWidthChange: (width: number) => void
+  /** Fired when a bar is clicked (lane + bucket ISO). */
+  onSelectBucket?: (bucketIso: string, laneName: string) => void
+}
+
+/**
+ * Pure hit-test: which bucket bar contains plot-local x?
+ * Bars are positioned at xForTime(bucketStart) with width bucketWidthPx−1.
+ * Exported for unit tests.
+ */
+export function bucketAtX(
+  plotX: number,
+  viewport: Viewport,
+  plotW: number,
+  unit: Unit,
+  points: BucketPoint[],
+): string | null {
+  if (plotW <= 0 || points.length === 0) return null
+  const bw = Math.max(1, bucketWidthPx(unit, viewport, plotW) - 1)
+  // Prefer the bucket whose start is nearest and whose bar covers plotX.
+  let hit: string | null = null
+  let bestDist = Infinity
+  for (const pt of points) {
+    const t = Date.parse(pt.bucket)
+    if (!Number.isFinite(t)) continue
+    const x = xForTime(t, viewport, plotW)
+    if (plotX >= x && plotX < x + bw) {
+      const mid = x + bw / 2
+      const dist = Math.abs(plotX - mid)
+      if (dist < bestDist) {
+        bestDist = dist
+        hit = pt.bucket
+      }
+    }
+  }
+  // Fallback: snap to nearest bucket start by time if inside its span (unit width).
+  if (!hit) {
+    const t = timeForX(plotX, viewport, plotW)
+    const unitMs = UNIT_MS[unit]
+    for (const pt of points) {
+      const start = Date.parse(pt.bucket)
+      if (!Number.isFinite(start)) continue
+      if (t >= start && t < start + unitMs) {
+        hit = pt.bucket
+        break
+      }
+    }
+  }
+  return hit
+}
+
+/** Which lane (0 = messages, 1 = attachments) contains localY, or null. */
+export function laneAtY(localY: number): 'messages' | 'attachments' | null {
+  if (localY <= AXIS_H) return null
+  const messagesTop = AXIS_H + LANE_GAP
+  const attachmentsTop = messagesTop + LANE_H + LANE_GAP
+  if (localY >= messagesTop && localY < messagesTop + LANE_H) return 'messages'
+  if (localY >= attachmentsTop && localY < attachmentsTop + LANE_H) {
+    return 'attachments'
+  }
+  return null
 }
 
 function sumCounts(points: BucketPoint[]): number {
@@ -83,9 +146,11 @@ export function TimelineCanvas({
   attachments,
   isFetching,
   brush,
+  selectedBucket = null,
   onViewportChange,
   onBrushChange,
   onWidthChange,
+  onSelectBucket,
 }: TimelineCanvasProps) {
   const wrapRef = useRef<HTMLDivElement>(null)
   const wheelHandlerRef = useRef<(e: globalThis.WheelEvent) => void>(() => {})
@@ -193,10 +258,21 @@ export function TimelineCanvas({
         if (!Number.isFinite(t)) continue
         const x = LANE_LABEL_W + xForTime(t, viewport, plotW)
         const barH = (pt.count / max) * barMaxH
+        const barY = top + LANE_H - 4 - barH
         ctx.fillStyle = lane.color
         ctx.globalAlpha = 0.85
-        ctx.fillRect(x, top + LANE_H - 4 - barH, bw, barH)
+        ctx.fillRect(x, barY, bw, barH)
         ctx.globalAlpha = 1
+        // Selected bucket: 1px action-blue outline
+        if (
+          selectedBucket &&
+          selectedBucket.lane === lane.name &&
+          selectedBucket.bucketIso === pt.bucket
+        ) {
+          ctx.strokeStyle = COLORS.action
+          ctx.lineWidth = 1
+          ctx.strokeRect(x + 0.5, barY + 0.5, Math.max(0, bw - 1), Math.max(0, barH - 1))
+        }
       }
     })
 
@@ -280,6 +356,7 @@ export function TimelineCanvas({
     extent,
     isFetching,
     messages,
+    selectedBucket,
     unit,
     viewport,
   ])
@@ -330,6 +407,8 @@ export function TimelineCanvas({
 
   wheelHandlerRef.current = onWheel
 
+  const clickRef = useRef<{ x: number; y: number; t: number } | null>(null)
+
   const onPointerDown = (e: PointerEvent) => {
     const rect = wrapRef.current?.getBoundingClientRect()
     if (!rect) return
@@ -339,7 +418,11 @@ export function TimelineCanvas({
     if (localY <= AXIS_H) {
       ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
       brushDrag.current = { startX: localX, curX: localX }
+      clickRef.current = null
+      return
     }
+    // Record potential bar click (lane region)
+    clickRef.current = { x: localX, y: localY, t: performance.now() }
   }
 
   const onPointerMove = (e: PointerEvent) => {
@@ -356,26 +439,48 @@ export function TimelineCanvas({
   }
 
   const onPointerUp = (e: PointerEvent) => {
-    if (!brushDrag.current) return
-    const rect = wrapRef.current?.getBoundingClientRect()
-    if (!rect) {
+    if (brushDrag.current) {
+      const rect = wrapRef.current?.getBoundingClientRect()
+      if (!rect) {
+        brushDrag.current = null
+        return
+      }
+      const { startX, curX } = brushDrag.current
       brushDrag.current = null
+      const pw = plotWidth()
+      const x0 = Math.min(startX, curX) - LANE_LABEL_W
+      const x1 = Math.max(startX, curX) - LANE_LABEL_W
+      if (Math.abs(x1 - x0) < 4) {
+        onBrushChange(null)
+        return
+      }
+      onBrushChange({
+        fromMs: timeForX(Math.max(0, x0), viewport, pw),
+        toMs: timeForX(Math.min(pw, x1), viewport, pw),
+      })
+      void e
       return
     }
-    const { startX, curX } = brushDrag.current
-    brushDrag.current = null
+
+    // Bar click hit-test
+    const pending = clickRef.current
+    clickRef.current = null
+    if (!pending || !onSelectBucket) return
+    const rect = wrapRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const localX = e.clientX - rect.left
+    const localY = e.clientY - rect.top
+    // Ignore if pointer moved more than a few px (drag-like)
+    if (Math.hypot(localX - pending.x, localY - pending.y) > 6) return
+    const lane = laneAtY(localY)
+    if (!lane) return
     const pw = plotWidth()
-    const x0 = Math.min(startX, curX) - LANE_LABEL_W
-    const x1 = Math.max(startX, curX) - LANE_LABEL_W
-    if (Math.abs(x1 - x0) < 4) {
-      onBrushChange(null)
-      return
-    }
-    onBrushChange({
-      fromMs: timeForX(Math.max(0, x0), viewport, pw),
-      toMs: timeForX(Math.min(pw, x1), viewport, pw),
-    })
-    void e
+    const plotX = localX - LANE_LABEL_W
+    if (plotX < 0) return
+    const unitTyped = parseUnit(unit)
+    const points = lane === 'messages' ? messages : attachments
+    const bucketIso = bucketAtX(plotX, viewport, pw, unitTyped, points)
+    if (bucketIso) onSelectBucket(bucketIso, lane)
   }
 
   const onDoubleClick = (e: MouseEvent) => {

--- a/apps/chronicle/web/src/chronicle/TimelineCanvas.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineCanvas.tsx
@@ -67,6 +67,40 @@ export interface TimelineCanvasProps {
   onWidthChange: (width: number) => void
   /** Fired when a bar/mark is clicked (lane + bucket ISO). */
   onSelectBucket?: (bucketIso: string, laneName: string) => void
+  /**
+   * Double-click a mark/bucket enters focus on that bucket's span.
+   * Alt+double-click keeps zoom ×0.25 (documented in toolbar hint).
+   */
+  onFocusBucket?: (period: Viewport) => void
+}
+
+/**
+ * Pure double-click policy for the canvas surface.
+ * - altKey → zoom ×0.25 (retain prior zoom-on-double-click)
+ * - bucket hit without alt → enter focus on that span
+ * - no hit → zoom ×0.25 fallback
+ * Exported for unit tests.
+ */
+export function resolveDoubleClickAction(args: {
+  altKey: boolean
+  bucketHit: Viewport | null
+  viewport: Viewport
+  plotX: number
+  plotW: number
+}): { kind: 'zoom'; viewport: Viewport } | { kind: 'focus'; period: Viewport } {
+  if (args.altKey) {
+    return {
+      kind: 'zoom',
+      viewport: zoomViewport(args.viewport, 0.25, args.plotX, args.plotW),
+    }
+  }
+  if (args.bucketHit) {
+    return { kind: 'focus', period: args.bucketHit }
+  }
+  return {
+    kind: 'zoom',
+    viewport: zoomViewport(args.viewport, 0.25, args.plotX, args.plotW),
+  }
 }
 
 /**
@@ -177,6 +211,7 @@ export function TimelineCanvas({
   onBrushChange,
   onWidthChange,
   onSelectBucket,
+  onFocusBucket,
 }: TimelineCanvasProps) {
   const wrapRef = useRef<HTMLDivElement>(null)
   const wheelHandlerRef = useRef<(e: globalThis.WheelEvent) => void>(() => {})
@@ -584,9 +619,50 @@ export function TimelineCanvas({
   const onDoubleClick = (e: MouseEvent) => {
     const rect = wrapRef.current?.getBoundingClientRect()
     if (!rect) return
-    const plotX = Math.max(0, e.clientX - rect.left - LANE_LABEL_W)
-    // Zoom ×0.25 span anchored at pointer
-    onViewportChange(zoomViewport(viewport, 0.25, plotX, plotWidth()))
+    const localX = e.clientX - rect.left
+    const localY = e.clientY - rect.top
+    const plotX = Math.max(0, localX - LANE_LABEL_W)
+    const pw = plotWidth()
+
+    // Resolve bucket hit for non-alt double-click → focus.
+    let bucketHit: Viewport | null = null
+    if (!e.altKey && onFocusBucket) {
+      const hitKey = laneAtYFromLayout(localY, layout)
+      if (hitKey) {
+        const unitTyped = parseUnit(unit)
+        let points: BucketPoint[] = []
+        if (hitKey.startsWith('top_people:')) {
+          const contactId = hitKey.slice('top_people:'.length)
+          const tp = laneData.top_people
+          if (isTopPeopleLane(tp)) {
+            const contact = tp.contacts.find((c) => c.contact_id === contactId)
+            points = contact?.buckets ?? []
+          }
+        } else {
+          points = barsPoints(laneData, hitKey)
+        }
+        const bucketIso = bucketAtX(plotX, viewport, pw, unitTyped, points)
+        if (bucketIso) {
+          const fromMs = Date.parse(bucketIso)
+          if (Number.isFinite(fromMs)) {
+            bucketHit = { fromMs, toMs: fromMs + UNIT_MS[unitTyped] }
+          }
+        }
+      }
+    }
+
+    const action = resolveDoubleClickAction({
+      altKey: e.altKey,
+      bucketHit,
+      viewport,
+      plotX,
+      plotW: pw,
+    })
+    if (action.kind === 'focus' && onFocusBucket) {
+      onFocusBucket(action.period)
+    } else if (action.kind === 'zoom') {
+      onViewportChange(action.viewport)
+    }
   }
 
   const onKeyDown = (e: KeyboardEvent) => {

--- a/apps/chronicle/web/src/chronicle/TimelineTable.test.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineTable.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { TimelineTable } from './TimelineTable'
+
+describe('TimelineTable', () => {
+  it('renders bucket rows from mock data with caption/th scope', () => {
+    const viewport = {
+      fromMs: Date.UTC(2014, 0, 1),
+      toMs: Date.UTC(2016, 0, 1),
+    }
+    render(
+      <TimelineTable
+        viewport={viewport}
+        unit="month"
+        messages={[
+          { bucket: '2014-01-01T00:00:00.000Z', count: 12 },
+          { bucket: '2014-02-01T00:00:00.000Z', count: 8 },
+        ]}
+        attachments={[
+          { bucket: '2014-01-01T00:00:00.000Z', count: 3 },
+          { bucket: '2014-03-01T00:00:00.000Z', count: 1 },
+        ]}
+      />,
+    )
+
+    const table = screen.getByTestId('timeline-table')
+    expect(table.querySelector('caption')).toBeTruthy()
+    expect(table.querySelector('caption')?.textContent).toMatch(/month/)
+
+    const colHeaders = table.querySelectorAll('thead th[scope="col"]')
+    expect(colHeaders.length).toBe(3)
+
+    const rowHeaders = table.querySelectorAll('tbody th[scope="row"]')
+    expect(rowHeaders.length).toBe(3) // jan, feb, mar merged
+
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('8')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+})

--- a/apps/chronicle/web/src/chronicle/TimelineTable.test.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineTable.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
+import { specsForKeys } from './laneModel'
 import { TimelineTable } from './TimelineTable'
 
 describe('TimelineTable', () => {
@@ -13,14 +14,17 @@ describe('TimelineTable', () => {
       <TimelineTable
         viewport={viewport}
         unit="month"
-        messages={[
-          { bucket: '2014-01-01T00:00:00.000Z', count: 12 },
-          { bucket: '2014-02-01T00:00:00.000Z', count: 8 },
-        ]}
-        attachments={[
-          { bucket: '2014-01-01T00:00:00.000Z', count: 3 },
-          { bucket: '2014-03-01T00:00:00.000Z', count: 1 },
-        ]}
+        lanes={specsForKeys(['messages', 'attachments'])}
+        laneData={{
+          messages: [
+            { bucket: '2014-01-01T00:00:00.000Z', count: 12 },
+            { bucket: '2014-02-01T00:00:00.000Z', count: 8 },
+          ],
+          attachments: [
+            { bucket: '2014-01-01T00:00:00.000Z', count: 3 },
+            { bucket: '2014-03-01T00:00:00.000Z', count: 1 },
+          ],
+        }}
       />,
     )
 
@@ -38,5 +42,44 @@ describe('TimelineTable', () => {
     expect(screen.getByText('8')).toBeInTheDocument()
     expect(screen.getByText('3')).toBeInTheDocument()
     expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('includes per-contact columns for top_people', () => {
+    const viewport = {
+      fromMs: Date.UTC(2014, 0, 1),
+      toMs: Date.UTC(2016, 0, 1),
+    }
+    render(
+      <TimelineTable
+        viewport={viewport}
+        unit="month"
+        lanes={specsForKeys(['messages', 'top_people'])}
+        laneData={{
+          messages: [{ bucket: '2014-01-01T00:00:00.000Z', count: 5 }],
+          top_people: {
+            contacts: [
+              {
+                contact_id: 'c1',
+                display_name: 'Alice',
+                buckets: [{ bucket: '2014-01-01T00:00:00.000Z', count: 2 }],
+              },
+              {
+                contact_id: 'c2',
+                display_name: 'Bob',
+                buckets: [{ bucket: '2014-01-01T00:00:00.000Z', count: 4 }],
+              },
+            ],
+          },
+        }}
+      />,
+    )
+
+    const table = screen.getByTestId('timeline-table')
+    expect(table.querySelector('[data-contact-col="c1"]')?.textContent).toBe('Alice')
+    expect(table.querySelector('[data-contact-col="c2"]')?.textContent).toBe('Bob')
+    expect(table.querySelector('[data-contact-cell="c1"]')?.textContent).toBe('2')
+    expect(table.querySelector('[data-contact-cell="c2"]')?.textContent).toBe('4')
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.getByText('Bob')).toBeInTheDocument()
   })
 })

--- a/apps/chronicle/web/src/chronicle/TimelineTable.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineTable.tsx
@@ -1,0 +1,93 @@
+import type { BucketPoint } from '../api/types'
+import { formatPeriodLabel, formatPeriodRange, type Viewport } from './timeScale'
+
+export interface TimelineTableProps {
+  viewport: Viewport
+  unit: string
+  messages: BucketPoint[]
+  attachments: BucketPoint[]
+}
+
+/** Merge message/attachment buckets by timestamp for table rows. */
+export function mergeBucketRows(
+  messages: BucketPoint[],
+  attachments: BucketPoint[],
+): { bucket: string; messages: number; attachments: number }[] {
+  const map = new Map<string, { messages: number; attachments: number }>()
+  for (const b of messages) {
+    const row = map.get(b.bucket) ?? { messages: 0, attachments: 0 }
+    row.messages = b.count
+    map.set(b.bucket, row)
+  }
+  for (const b of attachments) {
+    const row = map.get(b.bucket) ?? { messages: 0, attachments: 0 }
+    row.attachments = b.count
+    map.set(b.bucket, row)
+  }
+  return [...map.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([bucket, counts]) => ({ bucket, ...counts }))
+}
+
+function bucketLabel(iso: string): string {
+  const ms = Date.parse(iso)
+  if (!Number.isFinite(ms)) return iso
+  return formatPeriodLabel(ms)
+}
+
+/**
+ * Accessible table alternative for the timeline canvas (A11Y-002).
+ * One row per bucket in the current viewport: label, messages, attachments.
+ */
+export function TimelineTable({
+  viewport,
+  unit,
+  messages,
+  attachments,
+}: TimelineTableProps) {
+  const rows = mergeBucketRows(messages, attachments)
+  const caption = `Timeline buckets (${unit}), ${formatPeriodRange(viewport)}`
+
+  return (
+    <div className="max-h-96 overflow-auto rounded-lg border border-steel bg-graphite-900">
+      <table className="w-full border-collapse text-left" data-testid="timeline-table">
+        <caption className="sr-only">{caption}</caption>
+        <thead>
+          <tr className="border-b border-steel text-text-muted">
+            <th scope="col" className="px-3 py-2 font-sans font-medium">
+              Bucket
+            </th>
+            <th scope="col" className="px-3 py-2 font-sans font-medium">
+              Messages
+            </th>
+            <th scope="col" className="px-3 py-2 font-sans font-medium">
+              Attachments
+            </th>
+          </tr>
+        </thead>
+        <tbody className="tabular-nums font-mono text-text-primary">
+          {rows.length === 0 ? (
+            <tr>
+              <td colSpan={3} className="px-3 py-4 text-center font-sans text-text-muted">
+                No activity in range
+              </td>
+            </tr>
+          ) : (
+            rows.map((row) => (
+              <tr key={row.bucket} className="border-b border-steel">
+                <th
+                  scope="row"
+                  className="px-3 py-1.5 text-left font-sans font-normal text-text-muted"
+                >
+                  {bucketLabel(row.bucket)}
+                </th>
+                <td className="px-3 py-1.5">{row.messages.toLocaleString()}</td>
+                <td className="px-3 py-1.5">{row.attachments.toLocaleString()}</td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/apps/chronicle/web/src/chronicle/TimelineTable.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineTable.tsx
@@ -1,15 +1,170 @@
-import type { BucketPoint } from '../api/types'
+import type { BucketPoint, LaneData, TopPeopleContact } from '../api/types'
+import { isBucketSeries, isTopPeopleLane } from '../api/types'
+import type { LaneSpec } from './laneModel'
 import { formatPeriodLabel, formatPeriodRange, type Viewport } from './timeScale'
 
 export interface TimelineTableProps {
   viewport: Viewport
   unit: string
-  messages: BucketPoint[]
-  attachments: BucketPoint[]
+  /** Ordered visible lane specs (store order). */
+  lanes: LaneSpec[]
+  laneData: Record<string, LaneData>
 }
 
-/** Merge message/attachment buckets by timestamp for table rows. */
+type MergedRow = {
+  bucket: string
+  /** bars lane key → count */
+  bars: Record<string, number>
+  /** contact_id → count for top_people */
+  contacts: Record<string, number>
+}
+
+/** Collect contact columns from top_people (stable order from server). */
+export function topPeopleContacts(
+  laneData: Record<string, LaneData>,
+): TopPeopleContact[] {
+  const tp = laneData.top_people
+  return isTopPeopleLane(tp) ? tp.contacts : []
+}
+
+/** Merge all bar lanes + top_people per-contact counts by bucket timestamp. */
 export function mergeBucketRows(
+  lanes: LaneSpec[],
+  laneData: Record<string, LaneData>,
+): MergedRow[] {
+  const map = new Map<string, MergedRow>()
+
+  const ensure = (bucket: string): MergedRow => {
+    let row = map.get(bucket)
+    if (!row) {
+      row = { bucket, bars: {}, contacts: {} }
+      map.set(bucket, row)
+    }
+    return row
+  }
+
+  for (const spec of lanes) {
+    if (spec.kind === 'bars') {
+      const points = laneData[spec.key]
+      if (!isBucketSeries(points)) continue
+      for (const p of points) {
+        ensure(p.bucket).bars[spec.key] = p.count
+      }
+    } else if (spec.key === 'top_people') {
+      const contacts = topPeopleContacts(laneData)
+      for (const c of contacts) {
+        for (const p of c.buckets) {
+          ensure(p.bucket).contacts[c.contact_id] = p.count
+        }
+      }
+    }
+  }
+
+  return [...map.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([, row]) => row)
+}
+
+function bucketLabel(iso: string): string {
+  const ms = Date.parse(iso)
+  if (!Number.isFinite(ms)) return iso
+  return formatPeriodLabel(ms)
+}
+
+/**
+ * Accessible table alternative for the timeline canvas (A11Y-002).
+ * One row per bucket; columns follow configured lanes. For top_people,
+ * one column per contact (contact × bucket counts).
+ */
+export function TimelineTable({
+  viewport,
+  unit,
+  lanes,
+  laneData,
+}: TimelineTableProps) {
+  const rows = mergeBucketRows(lanes, laneData)
+  const contacts =
+    lanes.some((s) => s.key === 'top_people') ? topPeopleContacts(laneData) : []
+  const barLanes = lanes.filter((s) => s.kind === 'bars')
+  const colCount = 1 + barLanes.length + contacts.length
+  const caption = `Timeline buckets (${unit}), ${formatPeriodRange(viewport)}`
+
+  return (
+    <div className="max-h-96 overflow-auto rounded-lg border border-steel bg-graphite-900">
+      <table className="w-full border-collapse text-left" data-testid="timeline-table">
+        <caption className="sr-only">{caption}</caption>
+        <thead>
+          <tr className="border-b border-steel text-text-muted">
+            <th scope="col" className="px-3 py-2 font-sans font-medium">
+              Bucket
+            </th>
+            {barLanes.map((spec) => (
+              <th
+                key={spec.key}
+                scope="col"
+                className="px-3 py-2 font-sans font-medium"
+                data-lane-col={spec.key}
+              >
+                {spec.label}
+              </th>
+            ))}
+            {contacts.map((c) => (
+              <th
+                key={c.contact_id}
+                scope="col"
+                className="px-3 py-2 font-sans font-medium"
+                data-contact-col={c.contact_id}
+                title={c.display_name}
+              >
+                {c.display_name}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="tabular-nums font-mono text-text-primary">
+          {rows.length === 0 ? (
+            <tr>
+              <td
+                colSpan={Math.max(1, colCount)}
+                className="px-3 py-4 text-center font-sans text-text-muted"
+              >
+                No activity in range
+              </td>
+            </tr>
+          ) : (
+            rows.map((row) => (
+              <tr key={row.bucket} className="border-b border-steel">
+                <th
+                  scope="row"
+                  className="px-3 py-1.5 text-left font-sans font-normal text-text-muted"
+                >
+                  {bucketLabel(row.bucket)}
+                </th>
+                {barLanes.map((spec) => (
+                  <td key={spec.key} className="px-3 py-1.5" data-lane-cell={spec.key}>
+                    {(row.bars[spec.key] ?? 0).toLocaleString()}
+                  </td>
+                ))}
+                {contacts.map((c) => (
+                  <td
+                    key={c.contact_id}
+                    className="px-3 py-1.5"
+                    data-contact-cell={c.contact_id}
+                  >
+                    {(row.contacts[c.contact_id] ?? 0).toLocaleString()}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+/** Back-compat helper used by older tests that pass messages/attachments arrays. */
+export function mergeMessagesAttachments(
   messages: BucketPoint[],
   attachments: BucketPoint[],
 ): { bucket: string; messages: number; attachments: number }[] {
@@ -27,67 +182,4 @@ export function mergeBucketRows(
   return [...map.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([bucket, counts]) => ({ bucket, ...counts }))
-}
-
-function bucketLabel(iso: string): string {
-  const ms = Date.parse(iso)
-  if (!Number.isFinite(ms)) return iso
-  return formatPeriodLabel(ms)
-}
-
-/**
- * Accessible table alternative for the timeline canvas (A11Y-002).
- * One row per bucket in the current viewport: label, messages, attachments.
- */
-export function TimelineTable({
-  viewport,
-  unit,
-  messages,
-  attachments,
-}: TimelineTableProps) {
-  const rows = mergeBucketRows(messages, attachments)
-  const caption = `Timeline buckets (${unit}), ${formatPeriodRange(viewport)}`
-
-  return (
-    <div className="max-h-96 overflow-auto rounded-lg border border-steel bg-graphite-900">
-      <table className="w-full border-collapse text-left" data-testid="timeline-table">
-        <caption className="sr-only">{caption}</caption>
-        <thead>
-          <tr className="border-b border-steel text-text-muted">
-            <th scope="col" className="px-3 py-2 font-sans font-medium">
-              Bucket
-            </th>
-            <th scope="col" className="px-3 py-2 font-sans font-medium">
-              Messages
-            </th>
-            <th scope="col" className="px-3 py-2 font-sans font-medium">
-              Attachments
-            </th>
-          </tr>
-        </thead>
-        <tbody className="tabular-nums font-mono text-text-primary">
-          {rows.length === 0 ? (
-            <tr>
-              <td colSpan={3} className="px-3 py-4 text-center font-sans text-text-muted">
-                No activity in range
-              </td>
-            </tr>
-          ) : (
-            rows.map((row) => (
-              <tr key={row.bucket} className="border-b border-steel">
-                <th
-                  scope="row"
-                  className="px-3 py-1.5 text-left font-sans font-normal text-text-muted"
-                >
-                  {bucketLabel(row.bucket)}
-                </th>
-                <td className="px-3 py-1.5">{row.messages.toLocaleString()}</td>
-                <td className="px-3 py-1.5">{row.attachments.toLocaleString()}</td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </table>
-    </div>
-  )
 }

--- a/apps/chronicle/web/src/chronicle/TimelineToolbar.test.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineToolbar.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TimelineToolbar } from './TimelineToolbar'
+
+const viewport = {
+  fromMs: Date.UTC(2014, 0, 1),
+  toMs: Date.UTC(2019, 0, 1),
+}
+
+describe('TimelineToolbar', () => {
+  it('buttons dispatch the right viewport transitions', () => {
+    const onZoomIn = vi.fn()
+    const onZoomOut = vi.fn()
+    const onFitAll = vi.fn()
+    const onZoomToSelection = vi.fn()
+    const onClearSelection = vi.fn()
+    const onToggleViewMode = vi.fn()
+
+    render(
+      <TimelineToolbar
+        viewport={viewport}
+        unit="month"
+        brush={{ fromMs: viewport.fromMs, toMs: viewport.fromMs + 1e10 }}
+        viewMode="canvas"
+        onZoomIn={onZoomIn}
+        onZoomOut={onZoomOut}
+        onFitAll={onFitAll}
+        onZoomToSelection={onZoomToSelection}
+        onClearSelection={onClearSelection}
+        onToggleViewMode={onToggleViewMode}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /zoom in/i }))
+    fireEvent.click(screen.getByRole('button', { name: /zoom out/i }))
+    fireEvent.click(screen.getByRole('button', { name: /fit all/i }))
+    fireEvent.click(screen.getByRole('button', { name: /zoom to selection/i }))
+    fireEvent.click(screen.getByRole('button', { name: /clear selection/i }))
+    fireEvent.click(screen.getByRole('button', { name: /view as table/i }))
+
+    expect(onZoomIn).toHaveBeenCalledTimes(1)
+    expect(onZoomOut).toHaveBeenCalledTimes(1)
+    expect(onFitAll).toHaveBeenCalledTimes(1)
+    expect(onZoomToSelection).toHaveBeenCalledTimes(1)
+    expect(onClearSelection).toHaveBeenCalledTimes(1)
+    expect(onToggleViewMode).toHaveBeenCalledTimes(1)
+  })
+
+  it('zoom-to-selection disabled without brush', () => {
+    render(
+      <TimelineToolbar
+        viewport={viewport}
+        unit="month"
+        brush={null}
+        viewMode="canvas"
+        onZoomIn={() => {}}
+        onZoomOut={() => {}}
+        onFitAll={() => {}}
+        onZoomToSelection={() => {}}
+        onClearSelection={() => {}}
+        onToggleViewMode={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: /zoom to selection/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /clear selection/i })).toBeDisabled()
+  })
+})

--- a/apps/chronicle/web/src/chronicle/TimelineToolbar.test.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineToolbar.test.tsx
@@ -16,6 +16,7 @@ describe('TimelineToolbar', () => {
     const onZoomToSelection = vi.fn()
     const onClearSelection = vi.fn()
     const onToggleViewMode = vi.fn()
+    const onFocusPeriod = vi.fn()
 
     render(
       <TimelineToolbar
@@ -29,6 +30,7 @@ describe('TimelineToolbar', () => {
         onZoomToSelection={onZoomToSelection}
         onClearSelection={onClearSelection}
         onToggleViewMode={onToggleViewMode}
+        onFocusPeriod={onFocusPeriod}
       />,
     )
 
@@ -37,6 +39,7 @@ describe('TimelineToolbar', () => {
     fireEvent.click(screen.getByRole('button', { name: /fit all/i }))
     fireEvent.click(screen.getByRole('button', { name: /zoom to selection/i }))
     fireEvent.click(screen.getByRole('button', { name: /clear selection/i }))
+    fireEvent.click(screen.getByRole('button', { name: /focus period/i }))
     fireEvent.click(screen.getByRole('button', { name: /view as table/i }))
 
     expect(onZoomIn).toHaveBeenCalledTimes(1)
@@ -44,10 +47,52 @@ describe('TimelineToolbar', () => {
     expect(onFitAll).toHaveBeenCalledTimes(1)
     expect(onZoomToSelection).toHaveBeenCalledTimes(1)
     expect(onClearSelection).toHaveBeenCalledTimes(1)
+    expect(onFocusPeriod).toHaveBeenCalledTimes(1)
     expect(onToggleViewMode).toHaveBeenCalledTimes(1)
   })
 
-  it('zoom-to-selection disabled without brush', () => {
+  it('zoom-to-selection and focus-period disabled without brush', () => {
+    render(
+      <TimelineToolbar
+        viewport={viewport}
+        unit="month"
+        brush={null}
+        viewMode="canvas"
+        onZoomIn={() => {}}
+        onZoomOut={() => {}}
+        onFitAll={() => {}}
+        onZoomToSelection={() => {}}
+        onClearSelection={() => {}}
+        onToggleViewMode={() => {}}
+        onFocusPeriod={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: /zoom to selection/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /clear selection/i })).toBeDisabled()
+    expect(screen.getByTestId('focus-period-btn')).toBeDisabled()
+  })
+
+  it('focus-period enabled when brush exists', () => {
+    render(
+      <TimelineToolbar
+        viewport={viewport}
+        unit="month"
+        brush={{ fromMs: 1, toMs: 2 }}
+        viewMode="canvas"
+        onZoomIn={() => {}}
+        onZoomOut={() => {}}
+        onFitAll={() => {}}
+        onZoomToSelection={() => {}}
+        onClearSelection={() => {}}
+        onToggleViewMode={() => {}}
+        onFocusPeriod={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('focus-period-btn')).not.toBeDisabled()
+  })
+
+  it('documents Alt+double-click zoom in toolbar hint', () => {
     render(
       <TimelineToolbar
         viewport={viewport}
@@ -62,8 +107,8 @@ describe('TimelineToolbar', () => {
         onToggleViewMode={() => {}}
       />,
     )
-
-    expect(screen.getByRole('button', { name: /zoom to selection/i })).toBeDisabled()
-    expect(screen.getByRole('button', { name: /clear selection/i })).toBeDisabled()
+    expect(screen.getByTestId('toolbar-focus-hint')).toHaveTextContent(
+      /Alt\+double-click/i,
+    )
   })
 })

--- a/apps/chronicle/web/src/chronicle/TimelineToolbar.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineToolbar.tsx
@@ -1,0 +1,75 @@
+import type { Viewport } from './timeScale'
+import { formatPeriodRange } from './timeScale'
+
+export interface TimelineToolbarProps {
+  viewport: Viewport
+  unit: string
+  brush: Viewport | null
+  viewMode: 'canvas' | 'table'
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onFitAll: () => void
+  onZoomToSelection: () => void
+  onClearSelection: () => void
+  onToggleViewMode: () => void
+}
+
+const btnClass =
+  'rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-primary enabled:hover:bg-graphite-900 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-action'
+
+export function TimelineToolbar({
+  viewport,
+  unit,
+  brush,
+  viewMode,
+  onZoomIn,
+  onZoomOut,
+  onFitAll,
+  onZoomToSelection,
+  onClearSelection,
+  onToggleViewMode,
+}: TimelineToolbarProps) {
+  const period = formatPeriodRange(viewport)
+  const unitLabel = unit ? `${unit} buckets` : 'buckets'
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2 text-text-primary"
+      data-testid="timeline-toolbar"
+    >
+      <span className="tabular-nums text-text-muted" data-testid="visible-period">
+        {period} · {unitLabel}
+      </span>
+      <div className="flex flex-wrap items-center gap-1">
+        <button type="button" className={btnClass} onClick={onZoomIn} title="Zoom in (])">
+          Zoom in <span className="text-text-muted">[&#93;</span>
+        </button>
+        <button type="button" className={btnClass} onClick={onZoomOut} title="Zoom out ([)">
+          Zoom out <span className="text-text-muted">&#91;</span>
+        </button>
+        <button type="button" className={btnClass} onClick={onFitAll}>
+          Fit all
+        </button>
+        <button
+          type="button"
+          className={btnClass}
+          onClick={onZoomToSelection}
+          disabled={brush == null}
+        >
+          Zoom to selection
+        </button>
+        <button
+          type="button"
+          className={btnClass}
+          onClick={onClearSelection}
+          disabled={brush == null}
+        >
+          Clear selection
+        </button>
+        <button type="button" className={btnClass} onClick={onToggleViewMode}>
+          {viewMode === 'canvas' ? 'View as table' : 'View as canvas'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/chronicle/web/src/chronicle/TimelineToolbar.tsx
+++ b/apps/chronicle/web/src/chronicle/TimelineToolbar.tsx
@@ -12,6 +12,8 @@ export interface TimelineToolbarProps {
   onZoomToSelection: () => void
   onClearSelection: () => void
   onToggleViewMode: () => void
+  /** Enter focus mode on the brushed range (enabled when brush exists). */
+  onFocusPeriod?: () => void
 }
 
 const btnClass =
@@ -28,6 +30,7 @@ export function TimelineToolbar({
   onZoomToSelection,
   onClearSelection,
   onToggleViewMode,
+  onFocusPeriod,
 }: TimelineToolbarProps) {
   const period = formatPeriodRange(viewport)
   const unitLabel = unit ? `${unit} buckets` : 'buckets'
@@ -66,10 +69,26 @@ export function TimelineToolbar({
         >
           Clear selection
         </button>
+        <button
+          type="button"
+          className={btnClass}
+          onClick={onFocusPeriod}
+          disabled={brush == null || !onFocusPeriod}
+          title="Focus period (Enter when a brush exists)"
+          data-testid="focus-period-btn"
+        >
+          Focus period
+        </button>
         <button type="button" className={btnClass} onClick={onToggleViewMode}>
           {viewMode === 'canvas' ? 'View as table' : 'View as canvas'}
         </button>
       </div>
+      <span
+        className="w-full text-[11px] text-text-muted"
+        data-testid="toolbar-focus-hint"
+      >
+        Double-click a mark to enter focus · Alt+double-click zooms ×4
+      </span>
     </div>
   )
 }

--- a/apps/chronicle/web/src/chronicle/bucketAtX.test.ts
+++ b/apps/chronicle/web/src/chronicle/bucketAtX.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import type { BucketPoint } from '../api/types'
+import { bucketAtX, laneAtY } from './TimelineCanvas'
+import type { Viewport } from './timeScale'
+
+const vp: Viewport = {
+  fromMs: Date.UTC(2014, 0, 1),
+  toMs: Date.UTC(2015, 0, 1),
+}
+
+const points: BucketPoint[] = [
+  { bucket: '2014-01-01T00:00:00.000Z', count: 10 },
+  { bucket: '2014-04-01T00:00:00.000Z', count: 20 },
+  { bucket: '2014-07-01T00:00:00.000Z', count: 30 },
+]
+
+describe('bucketAtX', () => {
+  it('picks the bucket whose bar covers plot x', () => {
+    const plotW = 1000
+    // July bucket starts at mid-year-ish
+    const julyStart = Date.parse('2014-07-01T00:00:00.000Z')
+    const span = vp.toMs - vp.fromMs
+    const x = ((julyStart - vp.fromMs) / span) * plotW + 2
+    const hit = bucketAtX(x, vp, plotW, 'month', points)
+    expect(hit).toBe('2014-07-01T00:00:00.000Z')
+  })
+
+  it('returns null outside bars / empty', () => {
+    expect(bucketAtX(0, vp, 1000, 'month', [])).toBeNull()
+    // Far left of first bucket with tiny width may still hit via time fallback
+    const miss = bucketAtX(-10, vp, 1000, 'month', points)
+    expect(miss).toBeNull()
+  })
+
+  it('distinguishes adjacent month buckets', () => {
+    const monthPoints: BucketPoint[] = [
+      { bucket: '2014-01-01T00:00:00.000Z', count: 1 },
+      { bucket: '2014-02-01T00:00:00.000Z', count: 1 },
+    ]
+    const plotW = 1200
+    const jan = Date.parse('2014-01-01T00:00:00.000Z')
+    const feb = Date.parse('2014-02-01T00:00:00.000Z')
+    const span = vp.toMs - vp.fromMs
+    const xJan = ((jan - vp.fromMs) / span) * plotW + 1
+    const xFeb = ((feb - vp.fromMs) / span) * plotW + 1
+    expect(bucketAtX(xJan, vp, plotW, 'month', monthPoints)).toBe(
+      '2014-01-01T00:00:00.000Z',
+    )
+    expect(bucketAtX(xFeb, vp, plotW, 'month', monthPoints)).toBe(
+      '2014-02-01T00:00:00.000Z',
+    )
+  })
+})
+
+describe('laneAtY', () => {
+  it('maps y into messages / attachments / null', () => {
+    expect(laneAtY(10)).toBeNull() // axis
+    expect(laneAtY(40)).toBe('messages')
+    expect(laneAtY(120)).toBe('attachments')
+  })
+})

--- a/apps/chronicle/web/src/chronicle/laneModel.test.ts
+++ b/apps/chronicle/web/src/chronicle/laneModel.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  canvasHeightForLanes,
+  AXIS_H,
+  LANE_GAP,
+  LANE_H,
+  MULTIROW_HEADER_H,
+  MULTIROW_ROW_H,
+  layoutLanes,
+  laneAtY,
+  specsForKeys,
+} from './laneModel'
+
+describe('laneModel', () => {
+  it('canvas height responds to lane config and multirow rows', () => {
+    const barsOnly = specsForKeys(['messages', 'attachments'])
+    const h2 = canvasHeightForLanes(barsOnly)
+    expect(h2).toBe(AXIS_H + 2 * (LANE_GAP + LANE_H))
+
+    const withPeople = specsForKeys(['messages', 'attachments', 'people'])
+    expect(canvasHeightForLanes(withPeople)).toBe(AXIS_H + 3 * (LANE_GAP + LANE_H))
+
+    const multi = specsForKeys(['top_people'])
+    const hMulti = canvasHeightForLanes(multi, {
+      top_people: {
+        contacts: [
+          { contact_id: 'a', display_name: 'A', buckets: [] },
+          { contact_id: 'b', display_name: 'B', buckets: [] },
+          { contact_id: 'c', display_name: 'C', buckets: [] },
+        ],
+      },
+    })
+    expect(hMulti).toBe(
+      AXIS_H + LANE_GAP + MULTIROW_HEADER_H + 3 * MULTIROW_ROW_H,
+    )
+  })
+
+  it('layout hit-test maps multirow rows to top_people:contact_id', () => {
+    const specs = specsForKeys(['messages', 'top_people'])
+    const layout = layoutLanes(specs, {
+      messages: [],
+      top_people: {
+        contacts: [
+          { contact_id: 'c1', display_name: 'A', buckets: [] },
+          { contact_id: 'c2', display_name: 'B', buckets: [] },
+        ],
+      },
+    })
+    expect(laneAtY(10, layout)).toBeNull()
+    expect(laneAtY(AXIS_H + LANE_GAP + 10, layout)).toBe('messages')
+    const multiTop = layout[1]!.top + MULTIROW_HEADER_H + 1
+    expect(laneAtY(multiTop, layout)).toBe('top_people:c1')
+    expect(laneAtY(multiTop + MULTIROW_ROW_H, layout)).toBe('top_people:c2')
+  })
+})

--- a/apps/chronicle/web/src/chronicle/laneModel.ts
+++ b/apps/chronicle/web/src/chronicle/laneModel.ts
@@ -1,0 +1,163 @@
+import type { BucketPoint, LaneData, TopPeopleLane } from '../api/types'
+import { isBucketSeries, isTopPeopleLane } from '../api/types'
+import type { LaneKey } from '../workingset/urlState'
+
+export type LaneKind = 'bars' | 'multirow'
+
+export interface LaneSpec {
+  key: LaneKey
+  label: string
+  kind: LaneKind
+}
+
+/** Catalog of available lanes for config panel + canvas. */
+export const LANE_CATALOG: readonly LaneSpec[] = [
+  { key: 'messages', label: 'Messages', kind: 'bars' },
+  { key: 'attachments', label: 'Attachments', kind: 'bars' },
+  { key: 'people', label: 'People (distinct)', kind: 'bars' },
+  { key: 'top_people', label: 'Top people', kind: 'multirow' },
+] as const
+
+const CATALOG_BY_KEY = new Map(LANE_CATALOG.map((s) => [s.key, s]))
+
+export const BAR_LANE_COLORS: Record<string, string> = {
+  messages: '#5aa7ff', // action blue
+  attachments: '#55c2a3', // green
+  people: '#56d4dd', // people cyan
+}
+
+export const PEOPLE_CYAN = '#56d4dd'
+
+export const AXIS_H = 28
+export const LANE_H = 72
+export const LANE_LABEL_W = 72
+export const LANE_GAP = 4
+export const MULTIROW_HEADER_H = 16
+export const MULTIROW_ROW_H = 18
+
+/** Build ordered LaneSpec[] from store lane keys (unknown keys dropped). */
+export function specsForKeys(keys: readonly string[]): LaneSpec[] {
+  const out: LaneSpec[] = []
+  for (const key of keys) {
+    const spec = CATALOG_BY_KEY.get(key as LaneKey)
+    if (spec) out.push(spec)
+  }
+  return out
+}
+
+export function multirowHeight(contactCount: number): number {
+  return MULTIROW_HEADER_H + MULTIROW_ROW_H * Math.max(0, contactCount)
+}
+
+export function laneContentHeight(
+  spec: LaneSpec,
+  laneData: Record<string, LaneData> | undefined,
+): number {
+  if (spec.kind === 'bars') return LANE_H
+  const data = laneData?.[spec.key]
+  const n = isTopPeopleLane(data) ? data.contacts.length : 0
+  return multirowHeight(n)
+}
+
+/** Total canvas CSS height for the given lane set and data. */
+export function canvasHeightForLanes(
+  specs: readonly LaneSpec[],
+  laneData?: Record<string, LaneData>,
+): number {
+  let h = AXIS_H
+  for (const spec of specs) {
+    h += LANE_GAP + laneContentHeight(spec, laneData)
+  }
+  return h
+}
+
+export interface LaneLayoutRow {
+  /** Hit-test id: lane key, or `top_people:<contact_id>` for multirow rows. */
+  hitKey: string
+  /** Y of the top of this hit region (local canvas coords). */
+  top: number
+  /** Height of the hit region. */
+  height: number
+  /** Lane key for data lookup. */
+  laneKey: string
+  kind: LaneKind
+  /** Contact id when multirow row. */
+  contactId?: string
+}
+
+export interface LaneLayoutBlock {
+  spec: LaneSpec
+  top: number
+  height: number
+  rows: LaneLayoutRow[]
+}
+
+/** Compute vertical layout for hit-testing and drawing. */
+export function layoutLanes(
+  specs: readonly LaneSpec[],
+  laneData?: Record<string, LaneData>,
+): LaneLayoutBlock[] {
+  const blocks: LaneLayoutBlock[] = []
+  let y = AXIS_H
+  for (const spec of specs) {
+    y += LANE_GAP
+    const height = laneContentHeight(spec, laneData)
+    const rows: LaneLayoutRow[] = []
+    if (spec.kind === 'bars') {
+      rows.push({
+        hitKey: spec.key,
+        top: y,
+        height,
+        laneKey: spec.key,
+        kind: 'bars',
+      })
+    } else {
+      const data = laneData?.[spec.key]
+      const contacts = isTopPeopleLane(data) ? data.contacts : []
+      contacts.forEach((c, i) => {
+        rows.push({
+          hitKey: `top_people:${c.contact_id}`,
+          top: y + MULTIROW_HEADER_H + i * MULTIROW_ROW_H,
+          height: MULTIROW_ROW_H,
+          laneKey: spec.key,
+          kind: 'multirow',
+          contactId: c.contact_id,
+        })
+      })
+    }
+    blocks.push({ spec, top: y, height, rows })
+    y += height
+  }
+  return blocks
+}
+
+/** Which hit key contains localY, or null (axis / gap). */
+export function laneAtY(
+  localY: number,
+  layout: readonly LaneLayoutBlock[],
+): string | null {
+  if (localY <= AXIS_H) return null
+  for (const block of layout) {
+    for (const row of block.rows) {
+      if (localY >= row.top && localY < row.top + row.height) {
+        return row.hitKey
+      }
+    }
+  }
+  return null
+}
+
+export function barsPoints(
+  laneData: Record<string, LaneData> | undefined,
+  key: string,
+): BucketPoint[] {
+  const data = laneData?.[key]
+  return isBucketSeries(data) ? data : []
+}
+
+export function topPeopleData(
+  laneData: Record<string, LaneData> | undefined,
+): TopPeopleLane | undefined {
+  const data = laneData?.top_people
+  return isTopPeopleLane(data) ? data : undefined
+}

--- a/apps/chronicle/web/src/chronicle/timeScale.test.ts
+++ b/apps/chronicle/web/src/chronicle/timeScale.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  clampViewport,
+  panViewport,
+  timeForX,
+  ticksFor,
+  type Viewport,
+  wheelZoomFactor,
+  xForTime,
+  zoomViewport,
+} from './timeScale'
+
+const vp: Viewport = {
+  fromMs: Date.UTC(2014, 0, 1),
+  toMs: Date.UTC(2019, 0, 1),
+}
+const width = 1000
+
+describe('timeScale', () => {
+  it('xForTime / timeForX roundtrip', () => {
+    const samples = [0, 100, 500, 999, width]
+    for (const x of samples) {
+      const t = timeForX(x, vp, width)
+      const x2 = xForTime(t, vp, width)
+      expect(x2).toBeCloseTo(x, 6)
+    }
+    const times = [vp.fromMs, (vp.fromMs + vp.toMs) / 2, vp.toMs]
+    for (const t of times) {
+      const x = xForTime(t, vp, width)
+      expect(timeForX(x, vp, width)).toBeCloseTo(t, 3)
+    }
+  })
+
+  it('pan by +100px shifts times by exactly the per-px duration', () => {
+    const span = vp.toMs - vp.fromMs
+    const perPx = span / width
+    const panned = panViewport(vp, 100, width)
+    expect(panned.fromMs - vp.fromMs).toBeCloseTo(100 * perPx, 6)
+    expect(panned.toMs - vp.toMs).toBeCloseTo(100 * perPx, 6)
+    expect(panned.toMs - panned.fromMs).toBeCloseTo(span, 6)
+  })
+
+  it('zoom anchor invariant (property-style over anchors/factors)', () => {
+    const anchors = [0, 50, 200, 500, 750, 999]
+    const factors = [0.5, 0.75, 1.25, 2, wheelZoomFactor(100), wheelZoomFactor(-200)]
+    for (const anchorPx of anchors) {
+      for (const factor of factors) {
+        const before = timeForX(anchorPx, vp, width)
+        const zoomed = zoomViewport(vp, factor, anchorPx, width)
+        const after = timeForX(anchorPx, zoomed, width)
+        expect(after).toBeCloseTo(before, 4)
+      }
+    }
+  })
+
+  it('clamp respects minSpan and extent bounds', () => {
+    const extent: Viewport = {
+      fromMs: Date.UTC(2010, 0, 1),
+      toMs: Date.UTC(2020, 0, 1),
+    }
+    const minSpanMs = 60 * 60 * 1000 // 1 hour
+    const extentSpan = extent.toMs - extent.fromMs
+    const maxSpan = extentSpan * 1.2
+
+    // Too narrow → expanded to minSpan
+    const tooNarrow = clampViewport(
+      { fromMs: extent.fromMs, toMs: extent.fromMs + 1000 },
+      extent,
+      minSpanMs,
+    )
+    expect(tooNarrow.toMs - tooNarrow.fromMs).toBeGreaterThanOrEqual(minSpanMs)
+
+    // Too wide → capped at extent * 1.2
+    const tooWide = clampViewport(
+      { fromMs: extent.fromMs - extentSpan, toMs: extent.toMs + extentSpan },
+      extent,
+      minSpanMs,
+    )
+    expect(tooWide.toMs - tooWide.fromMs).toBeLessThanOrEqual(maxSpan + 1)
+
+    // Far outside → pulled into bounds
+    const outside = clampViewport(
+      {
+        fromMs: Date.UTC(1990, 0, 1),
+        toMs: Date.UTC(1991, 0, 1),
+      },
+      extent,
+      minSpanMs,
+    )
+    expect(outside.toMs).toBeGreaterThan(extent.fromMs - (maxSpan - extentSpan))
+    expect(outside.fromMs).toBeLessThan(extent.toMs + (maxSpan - extentSpan))
+  })
+
+  it('ticksFor produces 80–120px spacing and correct label formats at year/month/day spans', () => {
+    const cases: { vp: Viewport; width: number; labelRe: RegExp }[] = [
+      {
+        // multi-year → year labels
+        vp: { fromMs: Date.UTC(2000, 0, 1), toMs: Date.UTC(2020, 0, 1) },
+        width: 1000,
+        labelRe: /^\d{4}$/,
+      },
+      {
+        // ~2 years → month or quarter labels
+        vp: { fromMs: Date.UTC(2015, 0, 1), toMs: Date.UTC(2017, 0, 1) },
+        width: 1000,
+        labelRe: /^(Q[1-4] \d{4}|[A-Z][a-z]{2} \d{4})$/,
+      },
+      {
+        // ~2 months → day labels
+        vp: { fromMs: Date.UTC(2015, 0, 1), toMs: Date.UTC(2015, 2, 1) },
+        width: 1000,
+        labelRe: /^\d{1,2} [A-Z][a-z]{2}/,
+      },
+    ]
+
+    for (const { vp: v, width: w, labelRe } of cases) {
+      const ticks = ticksFor(v, w)
+      expect(ticks.length).toBeGreaterThan(1)
+      for (let i = 1; i < ticks.length; i++) {
+        const dx =
+          xForTime(ticks[i]!.timeMs, v, w) - xForTime(ticks[i - 1]!.timeMs, v, w)
+        // Spec target 80–120; allow calendar-alignment slack
+        expect(dx).toBeGreaterThanOrEqual(70)
+        expect(dx).toBeLessThanOrEqual(160)
+      }
+      expect(ticks.some((t) => labelRe.test(t.label))).toBe(true)
+    }
+  })
+
+  it('wheelZoomFactor clamps to [0.5, 2]', () => {
+    expect(wheelZoomFactor(0)).toBeCloseTo(1, 6)
+    expect(wheelZoomFactor(10_000)).toBe(0.5)
+    expect(wheelZoomFactor(-10_000)).toBe(2)
+  })
+})

--- a/apps/chronicle/web/src/chronicle/timeScale.ts
+++ b/apps/chronicle/web/src/chronicle/timeScale.ts
@@ -1,0 +1,343 @@
+/** Pure time↔pixel math for the Chronicle timeline. No DOM / React. */
+
+export interface Viewport {
+  fromMs: number
+  toMs: number
+}
+
+export type Unit = 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year'
+
+/** Minimum zoom span: 1 hour. */
+export const MIN_SPAN_MS = 60 * 60 * 1000
+
+/** Approximate unit widths (ms) for bar sizing and tick steps. */
+export const UNIT_MS: Record<Unit, number> = {
+  hour: 60 * 60 * 1000,
+  day: 24 * 60 * 60 * 1000,
+  week: 7 * 24 * 60 * 60 * 1000,
+  month: 30 * 24 * 60 * 60 * 1000,
+  quarter: 91 * 24 * 60 * 60 * 1000,
+  year: 365 * 24 * 60 * 60 * 1000,
+}
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const
+
+export function xForTime(t: number, vp: Viewport, width: number): number {
+  const span = vp.toMs - vp.fromMs
+  if (span <= 0 || width <= 0) return 0
+  return ((t - vp.fromMs) / span) * width
+}
+
+export function timeForX(x: number, vp: Viewport, width: number): number {
+  const span = vp.toMs - vp.fromMs
+  if (width <= 0) return vp.fromMs
+  return vp.fromMs + (x / width) * span
+}
+
+/** Shift viewport later by `deltaPx` pixels (positive → later times). */
+export function panViewport(vp: Viewport, deltaPx: number, width: number): Viewport {
+  if (width <= 0) return { ...vp }
+  const span = vp.toMs - vp.fromMs
+  const deltaMs = (deltaPx / width) * span
+  return { fromMs: vp.fromMs + deltaMs, toMs: vp.toMs + deltaMs }
+}
+
+/**
+ * Zoom viewport by `factor` (span multiplier), keeping the time at `anchorPx` fixed.
+ * factor < 1 zooms in; factor > 1 zooms out.
+ * Invariant: timeForX(anchorPx) is identical before and after.
+ */
+export function zoomViewport(
+  vp: Viewport,
+  factor: number,
+  anchorPx: number,
+  width: number,
+): Viewport {
+  if (width <= 0 || !Number.isFinite(factor) || factor <= 0) return { ...vp }
+  const anchorTime = timeForX(anchorPx, vp, width)
+  const span = vp.toMs - vp.fromMs
+  const newSpan = span * factor
+  const fromMs = anchorTime - (anchorPx / width) * newSpan
+  return { fromMs, toMs: fromMs + newSpan }
+}
+
+/**
+ * Map wheel deltaY to a zoom factor: exp(-deltaY * 0.002), clamped to [0.5, 2].
+ */
+export function wheelZoomFactor(deltaY: number): number {
+  const raw = Math.exp(-deltaY * 0.002)
+  return Math.min(2, Math.max(0.5, raw))
+}
+
+/**
+ * Clamp span to [minSpanMs, extentSpan * 1.2] and keep the window within
+ * the extent expanded by the max-span slack.
+ */
+export function clampViewport(
+  vp: Viewport,
+  extent: Viewport,
+  minSpanMs: number,
+): Viewport {
+  const extentSpan = Math.max(extent.toMs - extent.fromMs, minSpanMs)
+  const maxSpan = extentSpan * 1.2
+
+  let span = vp.toMs - vp.fromMs
+  if (!Number.isFinite(span) || span <= 0) {
+    span = extentSpan
+  }
+  span = Math.min(Math.max(span, minSpanMs), maxSpan)
+
+  const mid = (vp.fromMs + vp.toMs) / 2
+  let fromMs = mid - span / 2
+  let toMs = mid + span / 2
+
+  const slack = (maxSpan - extentSpan) / 2
+  const boundFrom = extent.fromMs - slack
+  const boundTo = extent.toMs + slack
+
+  if (fromMs < boundFrom) {
+    fromMs = boundFrom
+    toMs = fromMs + span
+  }
+  if (toMs > boundTo) {
+    toMs = boundTo
+    fromMs = toMs - span
+  }
+  if (fromMs < boundFrom) {
+    fromMs = boundFrom
+    toMs = Math.min(fromMs + span, boundTo)
+  }
+
+  return { fromMs, toMs }
+}
+
+export function bucketWidthPx(unit: Unit, vp: Viewport, width: number): number {
+  const span = vp.toMs - vp.fromMs
+  if (span <= 0 || width <= 0) return 0
+  return (UNIT_MS[unit] / span) * width
+}
+
+export interface Tick {
+  timeMs: number
+  label: string
+  major: boolean
+}
+
+type LabelKind = 'year' | 'quarter' | 'month' | 'day' | 'hour'
+
+function labelFor(timeMs: number, kind: LabelKind): string {
+  const d = new Date(timeMs)
+  const y = d.getUTCFullYear()
+  const mon = MONTHS[d.getUTCMonth()]
+  const day = d.getUTCDate()
+  const h = d.getUTCHours()
+  switch (kind) {
+    case 'year':
+      return String(y)
+    case 'quarter':
+      return `Q${Math.floor(d.getUTCMonth() / 3) + 1} ${y}`
+    case 'month':
+      return `${mon} ${y}`
+    case 'day':
+      return `${day} ${mon}`
+    case 'hour':
+      return `${day} ${mon} ${String(h).padStart(2, '0')}:00`
+  }
+}
+
+/** Nice step sizes in ms, coarsest last. */
+const NICE_STEPS_MS: { ms: number; kind: LabelKind; majorEvery: number }[] = [
+  { ms: UNIT_MS.hour, kind: 'hour', majorEvery: 6 },
+  { ms: 3 * UNIT_MS.hour, kind: 'hour', majorEvery: 4 },
+  { ms: 6 * UNIT_MS.hour, kind: 'hour', majorEvery: 4 },
+  { ms: 12 * UNIT_MS.hour, kind: 'hour', majorEvery: 2 },
+  { ms: UNIT_MS.day, kind: 'day', majorEvery: 7 },
+  { ms: 2 * UNIT_MS.day, kind: 'day', majorEvery: 7 },
+  { ms: UNIT_MS.week, kind: 'day', majorEvery: 4 },
+  { ms: UNIT_MS.month, kind: 'month', majorEvery: 3 },
+  { ms: 3 * UNIT_MS.month, kind: 'quarter', majorEvery: 4 },
+  { ms: UNIT_MS.year, kind: 'year', majorEvery: 5 },
+  { ms: 2 * UNIT_MS.year, kind: 'year', majorEvery: 5 },
+  { ms: 5 * UNIT_MS.year, kind: 'year', majorEvery: 2 },
+  { ms: 10 * UNIT_MS.year, kind: 'year', majorEvery: 1 },
+]
+
+/**
+ * Tick density ≈ every 80–120 px. Labels: year / "Q1 2015" / "Jan 2015" /
+ * "12 Jan" / "12 Jan 14:00" by span.
+ */
+export function ticksFor(vp: Viewport, width: number): Tick[] {
+  if (width <= 0) return []
+  const span = vp.toMs - vp.fromMs
+  if (span <= 0) return []
+
+  // Target ~100 px between ticks (within 80–120).
+  const targetStepMs = (100 / width) * span
+
+  // Pick the smallest nice step that is ≥ target (avoids overcrowding).
+  let chosen = NICE_STEPS_MS[NICE_STEPS_MS.length - 1]!
+  for (const step of NICE_STEPS_MS) {
+    if (step.ms >= targetStepMs * 0.85) {
+      chosen = step
+      break
+    }
+  }
+
+  let ticks: Tick[]
+  if (chosen.kind === 'year' || chosen.ms >= UNIT_MS.year) {
+    const years = Math.max(1, Math.round(chosen.ms / UNIT_MS.year))
+    ticks = calendarTicks(vp, 'year', years)
+  } else if (chosen.kind === 'quarter' || chosen.ms === 3 * UNIT_MS.month) {
+    ticks = calendarTicks(vp, 'quarter', 1)
+  } else if (chosen.kind === 'month' || chosen.ms === UNIT_MS.month) {
+    ticks = calendarTicks(vp, 'month', 1)
+  } else {
+    const stepMs = chosen.ms
+    const start = Math.ceil(vp.fromMs / stepMs) * stepMs
+    ticks = []
+    let i = 0
+    for (let t = start; t <= vp.toMs + 1; t += stepMs) {
+      if (t < vp.fromMs - 1) {
+        i++
+        continue
+      }
+      if (t > vp.toMs + stepMs * 0.01) break
+      ticks.push({
+        timeMs: t,
+        label: labelFor(t, chosen.kind),
+        major: i % chosen.majorEvery === 0,
+      })
+      i++
+      if (ticks.length > 200) break
+    }
+  }
+
+  return thinTicks(ticks, vp, width)
+}
+
+/** Drop ticks until median spacing is at least ~80px. */
+function thinTicks(ticks: Tick[], vp: Viewport, width: number): Tick[] {
+  if (ticks.length < 2 || width <= 0) return ticks
+  const spacing =
+    xForTime(ticks[1]!.timeMs, vp, width) - xForTime(ticks[0]!.timeMs, vp, width)
+  if (spacing >= 80) return ticks
+  const keepEvery = Math.max(1, Math.ceil(90 / Math.max(spacing, 1)))
+  const thinned: Tick[] = []
+  ticks.forEach((tick, i) => {
+    if (i % keepEvery === 0) {
+      thinned.push({ ...tick, major: true })
+    }
+  })
+  return thinned.length >= 2 ? thinned : ticks
+}
+
+function calendarTicks(
+  vp: Viewport,
+  kind: 'year' | 'quarter' | 'month',
+  stepUnits: number,
+): Tick[] {
+  const ticks: Tick[] = []
+  const d = new Date(vp.fromMs)
+  d.setUTCMilliseconds(0)
+  d.setUTCSeconds(0)
+  d.setUTCMinutes(0)
+  d.setUTCHours(0)
+
+  if (kind === 'year') {
+    d.setUTCMonth(0, 1)
+    if (d.getTime() < vp.fromMs) {
+      d.setUTCFullYear(d.getUTCFullYear() + 1)
+    }
+    const y0 = d.getUTCFullYear()
+    const aligned = Math.ceil(y0 / stepUnits) * stepUnits
+    d.setUTCFullYear(aligned)
+    let idx = 0
+    while (d.getTime() <= vp.toMs + 1 && ticks.length < 200) {
+      const t = d.getTime()
+      if (t >= vp.fromMs - 1) {
+        ticks.push({
+          timeMs: t,
+          label: labelFor(t, 'year'),
+          major: idx % 5 === 0 || stepUnits >= 5,
+        })
+        idx++
+      }
+      d.setUTCFullYear(d.getUTCFullYear() + stepUnits)
+    }
+  } else if (kind === 'quarter') {
+    const m = d.getUTCMonth()
+    d.setUTCMonth(m - (m % 3), 1)
+    if (d.getTime() < vp.fromMs) {
+      d.setUTCMonth(d.getUTCMonth() + 3)
+    }
+    let idx = 0
+    while (d.getTime() <= vp.toMs + 1 && ticks.length < 200) {
+      const t = d.getTime()
+      if (t >= vp.fromMs - 1) {
+        ticks.push({
+          timeMs: t,
+          label: labelFor(t, 'quarter'),
+          major: idx % 4 === 0,
+        })
+        idx++
+      }
+      d.setUTCMonth(d.getUTCMonth() + 3)
+    }
+  } else {
+    d.setUTCDate(1)
+    if (d.getTime() < vp.fromMs) {
+      d.setUTCMonth(d.getUTCMonth() + 1)
+    }
+    while (d.getTime() <= vp.toMs + 1 && ticks.length < 200) {
+      const t = d.getTime()
+      if (t >= vp.fromMs - 1) {
+        ticks.push({
+          timeMs: t,
+          label: labelFor(t, 'month'),
+          major: d.getUTCMonth() % 3 === 0,
+        })
+      }
+      d.setUTCMonth(d.getUTCMonth() + 1)
+    }
+  }
+  return ticks
+}
+
+/** Format a UTC ms timestamp for toolbar / aria (e.g. "Jan 2014"). */
+export function formatPeriodLabel(ms: number): string {
+  const d = new Date(ms)
+  return `${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`
+}
+
+export function formatPeriodRange(vp: Viewport): string {
+  return `${formatPeriodLabel(vp.fromMs)} – ${formatPeriodLabel(vp.toMs)}`
+}
+
+export function viewportToIso(vp: Viewport): { from: string; to: string } {
+  return {
+    from: new Date(vp.fromMs).toISOString(),
+    to: new Date(vp.toMs).toISOString(),
+  }
+}
+
+export function isoToMs(iso: string): number {
+  return Date.parse(iso)
+}
+
+export function parseUnit(unit: string): Unit {
+  if (unit in UNIT_MS) return unit as Unit
+  return 'month'
+}

--- a/apps/chronicle/web/src/chronicle/useChronicleBuckets.test.ts
+++ b/apps/chronicle/web/src/chronicle/useChronicleBuckets.test.ts
@@ -1,0 +1,219 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChronicleBuckets } from '../api/types'
+import {
+  quantizePixelWidth,
+  useChronicleBuckets,
+} from './useChronicleBuckets'
+
+function mockBuckets(overrides: Partial<ChronicleBuckets> = {}): ChronicleBuckets {
+  return {
+    scope_fingerprint: 'qs_test',
+    aggregation: 'month',
+    unit: 'month',
+    viewport: { from: '2014-01-01T00:00:00.000Z', to: '2019-01-01T00:00:00.000Z' },
+    lanes: {
+      messages: [{ bucket: '2014-01-01T00:00:00.000Z', count: 10 }],
+      attachments: [{ bucket: '2014-01-01T00:00:00.000Z', count: 2 }],
+    },
+    density: {
+      unit: 'year',
+      buckets: [{ bucket: '2014-01-01T00:00:00.000Z', count: 10 }],
+    },
+    extent: { from: '2010-01-01T00:00:00.000Z', to: '2020-01-01T00:00:00.000Z' },
+    generated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children)
+  }
+}
+
+describe('quantizePixelWidth', () => {
+  it('quantizes to 32px steps', () => {
+    expect(quantizePixelWidth(920)).toBe(928) // round(920/32)*32
+    expect(quantizePixelWidth(32)).toBe(32)
+    expect(quantizePixelWidth(31)).toBe(32)
+    expect(quantizePixelWidth(64)).toBe(64)
+    expect(quantizePixelWidth(80)).toBe(96) // round(2.5)*32
+  })
+})
+
+describe('useChronicleBuckets', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('fetch called with quantized pixel width', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockBuckets(),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const viewport = {
+      fromMs: Date.UTC(2014, 0, 1),
+      toMs: Date.UTC(2019, 0, 1),
+    }
+
+    renderHook(
+      () => useChronicleBuckets({ viewport, pixelWidth: 920 }),
+      { wrapper: createWrapper() },
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled()
+    })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(String(init.body)) as { pixel_width: number }
+    expect(body.pixel_width).toBe(quantizePixelWidth(920))
+  })
+
+  it('changing viewport aborts the prior request', async () => {
+    const signals: AbortSignal[] = []
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      if (init?.signal) signals.push(init.signal)
+      return new Promise((resolve) => {
+        // Never resolve quickly — stay in-flight so the next key aborts us.
+        const signal = init?.signal
+        const done = () =>
+          resolve({
+            ok: true,
+            status: 200,
+            json: async () => mockBuckets(),
+          })
+        if (signal?.aborted) {
+          const err = new Error('Aborted')
+          err.name = 'AbortError'
+          throw err
+        }
+        signal?.addEventListener('abort', () => {
+          const err = new Error('Aborted')
+          err.name = 'AbortError'
+          // reject by throwing in microtask is awkward; leave hanging
+        })
+        // Resolve after long delay if not aborted
+        setTimeout(done, 5000)
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { rerender } = renderHook(
+      ({ fromMs }: { fromMs: number }) =>
+        useChronicleBuckets({
+          viewport: { fromMs, toMs: fromMs + 365 * 24 * 3600 * 1000 },
+          pixelWidth: 920,
+        }),
+      {
+        wrapper: createWrapper(),
+        initialProps: { fromMs: Date.UTC(2014, 0, 1) },
+      },
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    rerender({ fromMs: Date.UTC(2015, 0, 1) })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    expect(signals.length).toBeGreaterThanOrEqual(1)
+    expect(signals[0]!.aborted).toBe(true)
+  })
+
+  it('keepPreviousData exposes stale data while refetching', async () => {
+    let resolveFirst: ((v: unknown) => void) | undefined
+    let call = 0
+    const fetchMock = vi.fn().mockImplementation(() => {
+      call++
+      if (call === 1) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () =>
+            mockBuckets({
+              lanes: {
+                messages: [{ bucket: '2014-01-01T00:00:00.000Z', count: 99 }],
+                attachments: [],
+              },
+            }),
+        })
+      }
+      return new Promise((resolve) => {
+        resolveFirst = resolve
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result, rerender } = renderHook(
+      ({ fromMs }: { fromMs: number }) =>
+        useChronicleBuckets({
+          viewport: { fromMs, toMs: fromMs + 5 * 365 * 24 * 3600 * 1000 },
+          pixelWidth: 920,
+        }),
+      {
+        wrapper: createWrapper(),
+        initialProps: { fromMs: Date.UTC(2014, 0, 1) },
+      },
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+    await waitFor(() => {
+      expect(result.current.data?.lanes.messages?.[0]?.count).toBe(99)
+    })
+
+    rerender({ fromMs: Date.UTC(2016, 0, 1) })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+
+    // While second request is in flight, previous data remains available
+    expect(result.current.isFetching).toBe(true)
+    expect(result.current.data?.lanes.messages?.[0]?.count).toBe(99)
+    expect(result.current.isPlaceholderData).toBe(true)
+
+    await act(async () => {
+      resolveFirst?.({
+        ok: true,
+        status: 200,
+        json: async () =>
+          mockBuckets({
+            lanes: {
+              messages: [{ bucket: '2016-01-01T00:00:00.000Z', count: 1 }],
+              attachments: [],
+            },
+          }),
+      })
+    })
+  })
+})

--- a/apps/chronicle/web/src/chronicle/useChronicleBuckets.test.ts
+++ b/apps/chronicle/web/src/chronicle/useChronicleBuckets.test.ts
@@ -3,11 +3,21 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { createElement, type ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ChronicleBuckets } from '../api/types'
+import type { BucketPoint, ChronicleBuckets } from '../api/types'
+import { isBucketSeries } from '../api/types'
 import {
   quantizePixelWidth,
   useChronicleBuckets,
 } from './useChronicleBuckets'
+
+function messagesCount(
+  data: ChronicleBuckets | undefined,
+  index: number,
+): number | undefined {
+  const m = data?.lanes.messages
+  if (!isBucketSeries(m)) return undefined
+  return (m as BucketPoint[])[index]?.count
+}
 
 function mockBuckets(overrides: Partial<ChronicleBuckets> = {}): ChronicleBuckets {
   return {
@@ -185,7 +195,7 @@ describe('useChronicleBuckets', () => {
       await vi.advanceTimersByTimeAsync(200)
     })
     await waitFor(() => {
-      expect(result.current.data?.lanes.messages?.[0]?.count).toBe(99)
+      expect(messagesCount(result.current.data, 0)).toBe(99)
     })
 
     rerender({ fromMs: Date.UTC(2016, 0, 1) })
@@ -199,7 +209,7 @@ describe('useChronicleBuckets', () => {
 
     // While second request is in flight, previous data remains available
     expect(result.current.isFetching).toBe(true)
-    expect(result.current.data?.lanes.messages?.[0]?.count).toBe(99)
+    expect(messagesCount(result.current.data, 0)).toBe(99)
     expect(result.current.isPlaceholderData).toBe(true)
 
     await act(async () => {

--- a/apps/chronicle/web/src/chronicle/useChronicleBuckets.ts
+++ b/apps/chronicle/web/src/chronicle/useChronicleBuckets.ts
@@ -5,7 +5,8 @@ import { apiPost } from '../api/client'
 import type { ChronicleBuckets, ChronicleRequest, QueryScope } from '../api/types'
 import { type Viewport, viewportToIso } from './timeScale'
 
-export const CHRONICLE_LANES = ['messages', 'attachments'] as const
+/** Default lanes requested when the caller does not pass `lanes`. */
+export const CHRONICLE_LANES = ['messages', 'attachments', 'top_people'] as const
 
 /** Quantize pixel width to 32px steps to avoid resize churn. */
 export function quantizePixelWidth(pixelWidth: number): number {

--- a/apps/chronicle/web/src/chronicle/useChronicleBuckets.ts
+++ b/apps/chronicle/web/src/chronicle/useChronicleBuckets.ts
@@ -1,0 +1,115 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from 'react'
+
+import { apiPost } from '../api/client'
+import type { ChronicleBuckets, ChronicleRequest, QueryScope } from '../api/types'
+import { type Viewport, viewportToIso } from './timeScale'
+
+export const CHRONICLE_LANES = ['messages', 'attachments'] as const
+
+/** Quantize pixel width to 32px steps to avoid resize churn. */
+export function quantizePixelWidth(pixelWidth: number): number {
+  if (!Number.isFinite(pixelWidth) || pixelWidth <= 0) return 32
+  return Math.max(32, Math.round(pixelWidth / 32) * 32)
+}
+
+export function chronicleBucketsQueryKey(parts: {
+  scopeFingerprint: string
+  viewportFromIso: string
+  viewportToIso: string
+  pixelWidth: number
+  lanes: readonly string[]
+}) {
+  return [
+    'chronicle',
+    'buckets',
+    parts.scopeFingerprint,
+    parts.viewportFromIso,
+    parts.viewportToIso,
+    parts.pixelWidth,
+    [...parts.lanes].join(','),
+  ] as const
+}
+
+/**
+ * Fingerprint-relevant scope key for the query. Full QueryScope serialization
+ * lands in task 1.3; for now empty scope is the only client value.
+ */
+export function scopeKey(scope: QueryScope | undefined): string {
+  if (!scope) return 'qs_empty'
+  return JSON.stringify({
+    version: scope.version ?? 1,
+    date: scope.date ?? null,
+    mailboxes: scope.mailboxes ?? [],
+    senders: scope.senders ?? [],
+  })
+}
+
+export interface UseChronicleBucketsArgs {
+  viewport: Viewport
+  pixelWidth: number
+  scope?: QueryScope
+  lanes?: readonly string[]
+  /** When false, the query is disabled (e.g. zero width). */
+  enabled?: boolean
+}
+
+/**
+ * TanStack Query hook for POST /api/chronicle/buckets.
+ *
+ * - Keyed by fingerprint-relevant scope, viewport ISO range, quantized pixel
+ *   width, and lanes.
+ * - Viewport-driven refetch is debounced 150ms (interaction state stays local).
+ * - POST uses the query AbortSignal so stale pans cancel (PERF-003).
+ * - placeholderData: keepPreviousData so prior lanes stay during refetch (§16.2).
+ */
+export function useChronicleBuckets({
+  viewport,
+  pixelWidth,
+  scope,
+  lanes = CHRONICLE_LANES,
+  enabled = true,
+}: UseChronicleBucketsArgs) {
+  const quantizedWidth = quantizePixelWidth(pixelWidth)
+  const iso = viewportToIso(viewport)
+
+  // Debounce only the query-key viewport; callers keep live interaction state.
+  const [debouncedIso, setDebouncedIso] = useState(iso)
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      setDebouncedIso(iso)
+    }, 150)
+    return () => window.clearTimeout(handle)
+  }, [iso.from, iso.to])
+
+  const fp = scopeKey(scope)
+  const laneList = useMemo(() => [...lanes], [lanes])
+
+  const queryKey = chronicleBucketsQueryKey({
+    scopeFingerprint: fp,
+    viewportFromIso: debouncedIso.from,
+    viewportToIso: debouncedIso.to,
+    pixelWidth: quantizedWidth,
+    lanes: laneList,
+  })
+
+  return useQuery({
+    queryKey,
+    queryFn: ({ signal }) => {
+      const body: ChronicleRequest = {
+        scope: scope ?? {},
+        viewport: {
+          from: debouncedIso.from,
+          to: debouncedIso.to,
+        },
+        pixel_width: quantizedWidth,
+        aggregation: 'auto',
+        lanes: laneList,
+      }
+      return apiPost<ChronicleBuckets>('/api/chronicle/buckets', body, signal)
+    },
+    enabled: enabled && quantizedWidth >= 32,
+    placeholderData: keepPreviousData,
+    retry: false,
+  })
+}

--- a/apps/chronicle/web/src/focus/FocusMode.test.tsx
+++ b/apps/chronicle/web/src/focus/FocusMode.test.tsx
@@ -1,0 +1,211 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetWorkingSetStore, useWorkingSetStore } from '../workingset/store'
+import { FocusMode } from './FocusMode'
+
+const focus = {
+  fromMs: Date.UTC(2015, 0, 1),
+  toMs: Date.UTC(2016, 0, 1),
+}
+
+function mockBucketsFiner() {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      scope_fingerprint: 'qs_focus',
+      aggregation: 'month',
+      unit: 'month',
+      viewport: {
+        from: '2015-01-01T00:00:00.000Z',
+        to: '2016-01-01T00:00:00.000Z',
+      },
+      lanes: {
+        messages: [
+          { bucket: '2015-01-01T00:00:00.000Z', count: 10 },
+          { bucket: '2015-06-01T00:00:00.000Z', count: 20 },
+        ],
+        attachments: [
+          { bucket: '2015-01-01T00:00:00.000Z', count: 2 },
+          { bucket: '2015-06-01T00:00:00.000Z', count: 3 },
+        ],
+      },
+      density: { unit: 'year', buckets: [] },
+      extent: {
+        from: '2014-01-01T00:00:00.000Z',
+        to: '2019-01-01T00:00:00.000Z',
+      },
+      generated_at: '2026-01-01T00:00:00.000Z',
+    }),
+  } as Response
+}
+
+function mockList(items: unknown[] = [], next: string | null = null) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      items,
+      next_cursor: next,
+      scope_fingerprint: 'qs',
+    }),
+  } as Response
+}
+
+function renderFocus(props: Partial<Parameters<typeof FocusMode>[0]> = {}) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const onExit = vi.fn()
+  const onSetAsScopeDate = vi.fn()
+  const onSelectMessage = vi.fn()
+  const result = render(
+    <QueryClientProvider client={client}>
+      <FocusMode
+        focus={focus}
+        scope={{ mailboxes: ['me@example.com'] }}
+        mainUnit="year"
+        onExit={onExit}
+        onSetAsScopeDate={onSetAsScopeDate}
+        onSelectMessage={onSelectMessage}
+        {...props}
+      />
+    </QueryClientProvider>,
+  )
+  return { ...result, onExit, onSetAsScopeDate, onSelectMessage, client }
+}
+
+describe('FocusMode', () => {
+  beforeEach(() => {
+    resetWorkingSetStore()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetWorkingSetStore()
+  })
+
+  it('local chronology fetch uses focus viewport and narrow pixel width', async () => {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes('/api/chronicle/buckets')) return mockBucketsFiner()
+      if (String(url).includes('/api/sources/list')) return mockList()
+      throw new Error(`unexpected: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderFocus()
+
+    await waitFor(() => {
+      const bucketCall = fetchMock.mock.calls.find((c) =>
+        String(c[0]).includes('/api/chronicle/buckets'),
+      )
+      expect(bucketCall).toBeTruthy()
+      const body = JSON.parse(String((bucketCall![1] as RequestInit).body)) as {
+        viewport: { from: string; to: string }
+        pixel_width: number
+      }
+      expect(body.viewport.from.startsWith('2015-01-01')).toBe(true)
+      expect(body.viewport.to.startsWith('2016-01-01')).toBe(true)
+      // Narrower rail width (~200) quantized to 32px steps → 192
+      expect(body.pixel_width).toBeLessThanOrEqual(224)
+      expect(body.pixel_width).toBeGreaterThanOrEqual(160)
+    })
+
+    expect(await screen.findByTestId('focus-mode')).toBeInTheDocument()
+    expect(screen.getByTestId('focus-period-label')).toHaveTextContent(/Jan 2015/)
+    // Finer unit than main year view
+    expect(screen.getByTestId('focus-totals')).toHaveTextContent(/month/)
+  })
+
+  it('sub-period click narrows the source list date_from', async () => {
+    const listBodies: { date_from: string; date_to: string }[] = []
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (String(url).includes('/api/chronicle/buckets')) return mockBucketsFiner()
+      if (String(url).includes('/api/sources/list')) {
+        const body = JSON.parse(String((init as RequestInit).body)) as {
+          date_from: string
+          date_to: string
+        }
+        listBodies.push(body)
+        return mockList([
+          {
+            id: 'msg_1',
+            subject: 'Hi',
+            sender_name: 'A',
+            sender_address: 'a@b.com',
+            date: '2015-06-02T00:00:00Z',
+            mailbox: 'me@example.com',
+            has_attachment: false,
+            attachment_count: 0,
+            thread_id: null,
+          },
+        ])
+      }
+      throw new Error(`unexpected: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderFocus()
+
+    await screen.findByTestId('focus-local-chronology')
+    const sub = await screen.findByTestId(
+      'focus-subperiod-2015-06-01T00:00:00.000Z',
+    )
+    fireEvent.click(sub)
+
+    await waitFor(() => {
+      expect(listBodies.some((b) => b.date_from.startsWith('2015-06-01'))).toBe(
+        true,
+      )
+    })
+  })
+
+  it('Set as scope date writes scope and exits focus', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        if (String(url).includes('/api/chronicle/buckets')) return mockBucketsFiner()
+        if (String(url).includes('/api/sources/list')) return mockList()
+        throw new Error(`unexpected: ${url}`)
+      }),
+    )
+
+    // Use store-connected path for applyFocusAsScopeDate semantics
+    useWorkingSetStore.getState().setFocus(focus)
+    useWorkingSetStore.getState().addMailbox('me@example.com')
+
+    const onSetAsScopeDate = () => {
+      useWorkingSetStore.getState().applyFocusAsScopeDate()
+    }
+    const onExit = vi.fn()
+
+    renderFocus({
+      onSetAsScopeDate,
+      onExit,
+      scope: { mailboxes: ['me@example.com'] },
+    })
+
+    fireEvent.click(await screen.findByTestId('focus-set-scope-date'))
+
+    const s = useWorkingSetStore.getState()
+    expect(s.focus).toBeNull()
+    expect(s.scope.date).toEqual({ from: '2015-01-01', to: '2016-01-01' })
+    expect(s.scope.mailboxes).toEqual(['me@example.com'])
+  })
+
+  it('Exit calls onExit', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        if (String(url).includes('/api/chronicle/buckets')) return mockBucketsFiner()
+        if (String(url).includes('/api/sources/list')) return mockList()
+        throw new Error(`unexpected: ${url}`)
+      }),
+    )
+    const { onExit } = renderFocus()
+    fireEvent.click(await screen.findByTestId('focus-exit'))
+    expect(onExit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/chronicle/web/src/focus/FocusMode.tsx
+++ b/apps/chronicle/web/src/focus/FocusMode.tsx
@@ -1,0 +1,233 @@
+import { useMemo, useState } from 'react'
+
+import type { QueryScope } from '../api/types'
+import { isBucketSeries } from '../api/types'
+import { useChronicleBuckets } from '../chronicle/useChronicleBuckets'
+import {
+  formatPeriodLabel,
+  formatPeriodRange,
+  type Viewport,
+} from '../chronicle/timeScale'
+import { SourceList } from '../inspector/SourceList'
+import { useWorkingSetStore } from '../workingset/store'
+
+export interface FocusModeProps {
+  focus: Viewport
+  scope: QueryScope
+  /** Main timeline unit — local chronology uses a finer auto aggregation. */
+  mainUnit: string
+  onExit: () => void
+  onSetAsScopeDate: () => void
+  onSelectMessage: (sid: string) => void
+}
+
+const btnClass =
+  'rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-primary enabled:hover:bg-graphite-900 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-action'
+
+function sumCounts(points: { count: number }[] | undefined): number {
+  if (!points) return 0
+  return points.reduce((acc, p) => acc + (p.count ?? 0), 0)
+}
+
+function toIso(ms: number): string {
+  return new Date(ms).toISOString()
+}
+
+/**
+ * Bounded analytical workspace over a selected period (spec §4.6).
+ * Replaces the canvas region; scope bar and inspector stay mounted.
+ */
+export function FocusMode({
+  focus,
+  scope,
+  mainUnit,
+  onExit,
+  onSetAsScopeDate,
+  onSelectMessage,
+}: FocusModeProps) {
+  // List range starts as the full focus period; sub-period clicks narrow it.
+  const [listFromMs, setListFromMs] = useState(focus.fromMs)
+  const [listToMs, setListToMs] = useState(focus.toMs)
+
+  // Local chronology: focus viewport + narrower pixel width → finer buckets.
+  // ~200px rail width as specified.
+  const localBuckets = useChronicleBuckets({
+    viewport: focus,
+    pixelWidth: 200,
+    scope,
+    lanes: ['messages', 'attachments'],
+    enabled: true,
+  })
+
+  const localUnit = localBuckets.data?.unit ?? localBuckets.data?.aggregation ?? mainUnit
+  const messagePoints = isBucketSeries(localBuckets.data?.lanes?.messages)
+    ? localBuckets.data!.lanes.messages
+    : []
+  const attachmentPoints = isBucketSeries(localBuckets.data?.lanes?.attachments)
+    ? localBuckets.data!.lanes.attachments
+    : []
+  const msgTotal = sumCounts(messagePoints)
+  const attTotal = sumCounts(attachmentPoints)
+
+  const periodLabel = formatPeriodRange(focus)
+
+  const listDateFrom = useMemo(() => toIso(listFromMs), [listFromMs])
+  const listDateTo = useMemo(() => toIso(listToMs), [listToMs])
+
+  const onSubPeriodClick = (bucketIso: string) => {
+    const fromMs = Date.parse(bucketIso)
+    if (!Number.isFinite(fromMs)) return
+    // Narrow the source sequence to this sub-period (sets list date_from / date_to).
+    // Span is the local unit width when known; otherwise open-ended to focus end.
+    const unitMsGuess = (() => {
+      const u = localUnit
+      if (u === 'hour') return 60 * 60 * 1000
+      if (u === 'day') return 24 * 60 * 60 * 1000
+      if (u === 'week') return 7 * 24 * 60 * 60 * 1000
+      if (u === 'month') return 30 * 24 * 60 * 60 * 1000
+      if (u === 'quarter') return 91 * 24 * 60 * 60 * 1000
+      if (u === 'year') return 365 * 24 * 60 * 60 * 1000
+      return Math.max(focus.toMs - fromMs, 60 * 60 * 1000)
+    })()
+    const toMs = Math.min(fromMs + unitMsGuess, focus.toMs)
+    setListFromMs(fromMs)
+    setListToMs(toMs > fromMs ? toMs : focus.toMs)
+  }
+
+  return (
+    <div
+      className="flex min-h-[20rem] flex-col gap-2 rounded-lg border border-steel bg-graphite-900"
+      data-testid="focus-mode"
+    >
+      <header
+        className="flex flex-wrap items-center gap-2 border-b border-steel px-3 py-2"
+        data-testid="focus-header"
+      >
+        <h2 className="text-sm font-medium text-text-primary">
+          Focus: <span data-testid="focus-period-label">{periodLabel}</span>
+        </h2>
+        <span
+          className="tabular-nums text-[11px] text-text-muted"
+          data-testid="focus-totals"
+        >
+          {msgTotal.toLocaleString()} messages · {attTotal.toLocaleString()} attachments
+          {localUnit ? ` · ${localUnit}` : ''}
+        </span>
+        <div className="ml-auto flex flex-wrap items-center gap-1">
+          <button
+            type="button"
+            className={btnClass}
+            onClick={onSetAsScopeDate}
+            data-testid="focus-set-scope-date"
+            title="Copy focus range into the scope date filter and exit focus"
+          >
+            Set as scope date
+          </button>
+          <button
+            type="button"
+            className={btnClass}
+            onClick={onExit}
+            data-testid="focus-exit"
+          >
+            Exit
+          </button>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1 gap-0">
+        {/* Left rail: local chronology */}
+        <aside
+          className="w-[200px] shrink-0 overflow-auto border-r border-steel p-2"
+          data-testid="focus-local-chronology"
+          aria-label="Local chronology"
+        >
+          <p className="mb-1 text-[11px] font-medium text-text-muted">
+            Local chronology
+            {localUnit ? ` · ${localUnit}` : ''}
+          </p>
+          {localBuckets.isLoading ? (
+            <div className="space-y-1" aria-busy="true">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="h-6 animate-pulse rounded bg-graphite-800" />
+              ))}
+            </div>
+          ) : null}
+          {localBuckets.isError ? (
+            <p className="text-[11px] text-conflict">Failed to load chronology</p>
+          ) : null}
+          <ul className="space-y-0.5">
+            {messagePoints.map((pt) => {
+              const ms = Date.parse(pt.bucket)
+              const label = Number.isFinite(ms)
+                ? formatPeriodLabel(ms)
+                : pt.bucket
+              const att =
+                attachmentPoints.find((a) => a.bucket === pt.bucket)?.count ?? 0
+              return (
+                <li key={pt.bucket}>
+                  <button
+                    type="button"
+                    className="flex w-full flex-col rounded px-1.5 py-1 text-left hover:bg-graphite-800"
+                    onClick={() => onSubPeriodClick(pt.bucket)}
+                    data-testid={`focus-subperiod-${pt.bucket}`}
+                  >
+                    <span className="text-[12px] text-text-primary">{label}</span>
+                    <span className="tabular-nums text-[10px] text-text-muted">
+                      {pt.count.toLocaleString()} msg
+                      {att > 0 ? ` · ${att} att` : ''}
+                    </span>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+          {!localBuckets.isLoading && messagePoints.length === 0 ? (
+            <p className="text-[11px] text-text-muted">No buckets in period</p>
+          ) : null}
+        </aside>
+
+        {/* Center: chronological source sequence */}
+        <div
+          className="flex min-h-0 min-w-0 flex-1 flex-col p-2"
+          data-testid="focus-source-sequence"
+        >
+          <p className="mb-1 text-[11px] font-medium text-text-muted">
+            Sources
+            {listFromMs !== focus.fromMs || listToMs !== focus.toMs
+              ? ` · narrowed to ${formatPeriodLabel(listFromMs)}`
+              : ''}
+          </p>
+          <SourceList
+            scope={scope}
+            dateFrom={listDateFrom}
+            dateTo={listDateTo}
+            onSelectMessage={onSelectMessage}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Convenience: read focus from store and wire default actions. */
+export function FocusModeConnected() {
+  const focus = useWorkingSetStore((s) => s.focus)
+  const scope = useWorkingSetStore((s) => s.scope)
+  const mainUnit = useWorkingSetStore((s) => s.timelineUnit) ?? 'month'
+  const exitFocus = useWorkingSetStore((s) => s.exitFocus)
+  const applyFocusAsScopeDate = useWorkingSetStore((s) => s.applyFocusAsScopeDate)
+  const setSelection = useWorkingSetStore((s) => s.setSelection)
+
+  if (!focus) return null
+
+  return (
+    <FocusMode
+      focus={focus}
+      scope={scope}
+      mainUnit={mainUnit}
+      onExit={exitFocus}
+      onSetAsScopeDate={applyFocusAsScopeDate}
+      onSelectMessage={(sid) => setSelection({ kind: 'message', sid })}
+    />
+  )
+}

--- a/apps/chronicle/web/src/inspector/InspectorPanel.test.tsx
+++ b/apps/chronicle/web/src/inspector/InspectorPanel.test.tsx
@@ -1,0 +1,158 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetWorkingSetStore, useWorkingSetStore } from '../workingset/store'
+import { InspectorPanel } from './InspectorPanel'
+
+function renderPanel() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <InspectorPanel />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const msgSource = {
+  kind: 'msg' as const,
+  envelope: {
+    id: 'msg_1',
+    thread_id: 'thr_YQ',
+    subject: 'Hello world',
+    sender_name: 'Alice',
+    sender_address: 'alice@example.com',
+    recipients: { to: ['bob@example.com'], cc: [], bcc: [] },
+    date: '2014-06-01T12:00:00Z',
+    mailbox: 'test@example.com',
+    labels: ['INBOX'],
+    has_attachment: false,
+    attachments: [],
+  },
+  body: {
+    text: 'Line one\n> quoted\nLine two',
+    html: null,
+    remote_resources_blocked: 2,
+    had_active_content: false,
+  },
+}
+
+describe('InspectorPanel flow', () => {
+  beforeEach(() => {
+    resetWorkingSetStore()
+    useWorkingSetStore.getState().setTimelineUnit('month')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetWorkingSetStore()
+  })
+
+  it('shows empty state with no selection', () => {
+    renderPanel()
+    expect(screen.getByTestId('inspector-empty')).toBeInTheDocument()
+  })
+
+  it('bucket → list → message with mocked API', async () => {
+    const listPage = {
+      items: [
+        {
+          id: 'msg_1',
+          subject: 'Hello world',
+          sender_name: 'Alice',
+          sender_address: 'alice@example.com',
+          date: '2014-06-01T12:00:00Z',
+          mailbox: 'test@example.com',
+          has_attachment: false,
+          attachment_count: 0,
+          thread_id: 'thr_YQ',
+        },
+      ],
+      next_cursor: null,
+      scope_fingerprint: 'qs_test',
+    }
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        const u = String(url)
+        if (u.includes('/api/sources/list')) {
+          return { ok: true, status: 200, json: async () => listPage } as Response
+        }
+        if (u.includes('/api/sources/msg_1')) {
+          return { ok: true, status: 200, json: async () => msgSource } as Response
+        }
+        throw new Error(`unexpected fetch: ${u}`)
+      }),
+    )
+
+    useWorkingSetStore.getState().setSelection({
+      kind: 'bucket',
+      lane: 'messages',
+      bucketIso: '2014-06-01T00:00:00.000Z',
+    })
+
+    renderPanel()
+
+    expect(await screen.findByTestId('inspector-bucket')).toBeInTheDocument()
+    expect(screen.getByText(/messages ·/i)).toBeInTheDocument()
+    expect(await screen.findByTestId('source-list')).toBeInTheDocument()
+    expect(screen.getByText('Hello world')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('source-row-msg_1'))
+
+    expect(await screen.findByTestId('message-card')).toBeInTheDocument()
+    expect(screen.getByText('Hello world')).toBeInTheDocument()
+    expect(screen.getByTestId('remote-blocked')).toHaveTextContent(
+      '2 remote resources blocked',
+    )
+    expect(screen.getByTestId('open-full-source')).toHaveAttribute(
+      'href',
+      '/source/msg_1',
+    )
+    // Quoted plain-text collapse
+    expect(screen.getByText(/Show quoted text/i)).toBeInTheDocument()
+  })
+
+  it('message close restores bucket', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        if (String(url).includes('/api/sources/msg_1')) {
+          return { ok: true, status: 200, json: async () => msgSource } as Response
+        }
+        if (String(url).includes('/api/sources/list')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              items: [],
+              next_cursor: null,
+              scope_fingerprint: 'qs',
+            }),
+          } as Response
+        }
+        throw new Error(`unexpected: ${url}`)
+      }),
+    )
+
+    useWorkingSetStore.getState().setSelection({
+      kind: 'bucket',
+      lane: 'messages',
+      bucketIso: '2014-06-01T00:00:00.000Z',
+    })
+    useWorkingSetStore.getState().setSelection({ kind: 'message', sid: 'msg_1' })
+
+    renderPanel()
+    expect(await screen.findByTestId('message-card')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('message-close'))
+    await waitFor(() => {
+      expect(useWorkingSetStore.getState().selection?.kind).toBe('bucket')
+    })
+  })
+})

--- a/apps/chronicle/web/src/inspector/InspectorPanel.tsx
+++ b/apps/chronicle/web/src/inspector/InspectorPanel.tsx
@@ -1,0 +1,74 @@
+import { useWorkingSetStore } from '../workingset/store'
+import { formatPeriodLabel, UNIT_MS, type Unit } from '../chronicle/timeScale'
+import { MessageCard } from './MessageCard'
+import { SourceList } from './SourceList'
+
+export interface InspectorPanelProps {
+  /** Message count for the selected bucket when known. */
+  bucketCount?: number | null
+}
+
+function unitMs(unit: string | null | undefined): number {
+  if (unit && unit in UNIT_MS) return UNIT_MS[unit as Unit]
+  return UNIT_MS.month
+}
+
+function bucketLabel(bucketIso: string): string {
+  const ms = Date.parse(bucketIso)
+  if (!Number.isFinite(ms)) return bucketIso
+  return formatPeriodLabel(ms)
+}
+
+export function InspectorPanel({ bucketCount }: InspectorPanelProps) {
+  const selection = useWorkingSetStore((s) => s.selection)
+  const scope = useWorkingSetStore((s) => s.scope)
+  const unit = useWorkingSetStore((s) => s.timelineUnit)
+  const setSelection = useWorkingSetStore((s) => s.setSelection)
+
+  if (!selection) {
+    return (
+      <p className="text-text-muted" data-testid="inspector-empty">
+        Select a mark to inspect evidence
+      </p>
+    )
+  }
+
+  if (selection.kind === 'message') {
+    return (
+      <MessageCard
+        sid={selection.sid}
+        onClose={() => {
+          // Spec: Close clears back to the parent bucket selection.
+          useWorkingSetStore.getState().clearMessageToBucket()
+        }}
+      />
+    )
+  }
+
+  // Bucket selection
+  const { bucketIso, lane } = selection
+  const dateFrom = bucketIso
+  const dateTo = new Date(Date.parse(bucketIso) + unitMs(unit)).toISOString()
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2" data-testid="inspector-bucket">
+      <div>
+        <h3 className="text-sm font-medium text-text-primary">
+          {lane} · {bucketLabel(bucketIso)}
+        </h3>
+        {bucketCount != null ? (
+          <p className="tabular-nums text-[11px] text-text-muted">
+            {bucketCount.toLocaleString()} in bucket
+          </p>
+        ) : null}
+      </div>
+      <p className="text-[11px] font-medium text-text-muted">Open as list</p>
+      <SourceList
+        scope={scope}
+        dateFrom={dateFrom}
+        dateTo={dateTo}
+        onSelectMessage={(sid) => setSelection({ kind: 'message', sid })}
+      />
+    </div>
+  )
+}

--- a/apps/chronicle/web/src/inspector/MessageCard.tsx
+++ b/apps/chronicle/web/src/inspector/MessageCard.tsx
@@ -1,0 +1,169 @@
+import { useQuery } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { Link } from 'react-router'
+
+import { apiGet } from '../api/client'
+import type { MessageSource, SourceResponse } from '../api/types'
+import { collapsePlainQuotedText, wrapBlockquotesInDetails } from './quotedText'
+
+export interface MessageCardProps {
+  sid: string
+  onClose: () => void
+}
+
+function isMessage(src: SourceResponse): src is MessageSource {
+  return src.kind === 'msg'
+}
+
+function formatTimestamp(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (!Number.isFinite(d.getTime())) return iso
+  // Exact timestamp with timezone text (ISO keeps offset / Z)
+  return iso
+}
+
+function recipientsSummary(recipients: unknown): string {
+  if (!recipients || typeof recipients !== 'object') return '—'
+  const r = recipients as Record<string, unknown>
+  const parts: string[] = []
+  for (const key of ['to', 'cc', 'bcc'] as const) {
+    const v = r[key]
+    if (Array.isArray(v) && v.length > 0) {
+      parts.push(`${key}: ${v.map(String).join(', ')}`)
+    }
+  }
+  return parts.length > 0 ? parts.join(' · ') : '—'
+}
+
+export function MessageCard({ sid, onClose }: MessageCardProps) {
+  const query = useQuery({
+    queryKey: ['sources', sid],
+    queryFn: ({ signal }) => apiGet<SourceResponse>(`/api/sources/${sid}`, signal),
+    retry: false,
+  })
+
+  if (query.isLoading) {
+    return (
+      <div className="space-y-2" data-testid="message-card-skeleton" aria-busy="true">
+        <div className="h-4 w-3/4 animate-pulse rounded bg-graphite-800" />
+        <div className="h-3 w-full animate-pulse rounded bg-graphite-800" />
+        <div className="h-24 animate-pulse rounded bg-graphite-800" />
+      </div>
+    )
+  }
+
+  if (query.isError || !query.data) {
+    return (
+      <div role="alert" className="text-conflict">
+        <p className="mb-2">Failed to load message</p>
+        <button
+          type="button"
+          onClick={() => void query.refetch()}
+          className="rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-primary"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  if (!isMessage(query.data)) {
+    return <p className="text-text-muted">Not a message source</p>
+  }
+
+  const { envelope, body } = query.data
+  const remote = body.remote_resources_blocked ?? 0
+
+  let bodyPreview: ReactNode
+  if (body.html) {
+    const wrapped = wrapBlockquotesInDetails(body.html)
+    bodyPreview = (
+      <div
+        className="prose-invert max-h-[1200px] overflow-auto text-text-primary [&_a]:text-action"
+        // Server-sanitized HTML only
+        dangerouslySetInnerHTML={{ __html: wrapped }}
+        data-testid="message-body-html"
+      />
+    )
+  } else if (body.text) {
+    bodyPreview = (
+      <div
+        className="max-h-[1200px] overflow-auto font-mono text-text-primary"
+        data-testid="message-body-text"
+      >
+        {collapsePlainQuotedText(body.text)}
+      </div>
+    )
+  } else {
+    bodyPreview = <p className="text-text-muted">No body</p>
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2" data-testid="message-card">
+      <div>
+        <h3 className="text-sm font-medium text-text-primary">
+          {envelope.subject || '(no subject)'}
+        </h3>
+        <p className="mt-1 text-[11px] text-text-muted">
+          {envelope.sender_name || envelope.sender_address || '—'}
+          {envelope.sender_name && envelope.sender_address
+            ? ` <${envelope.sender_address}>`
+            : ''}
+        </p>
+        <p className="tabular-nums font-mono text-[11px] text-text-muted">
+          {formatTimestamp(envelope.date)}
+        </p>
+        <p className="text-[11px] text-text-muted">
+          {recipientsSummary(envelope.recipients)}
+        </p>
+        <p className="text-[11px] text-text-muted">
+          Mailbox: {envelope.mailbox || '—'}
+        </p>
+        <p className="font-mono text-[10px] text-text-muted">{envelope.id}</p>
+      </div>
+
+      <div className="text-[11px] text-text-muted">
+        Source status: sanitized
+        {body.had_active_content ? ' · active content removed' : ''}
+      </div>
+
+      {remote > 0 ? (
+        <p className="text-[11px] text-event" data-testid="remote-blocked">
+          {remote} remote resource{remote === 1 ? '' : 's'} blocked
+        </p>
+      ) : null}
+
+      <div className="min-h-0 flex-1 overflow-hidden rounded border border-steel bg-graphite-950 p-2">
+        {bodyPreview}
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        <Link
+          to={`/source/${encodeURIComponent(sid)}`}
+          className="rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-primary"
+          data-testid="open-full-source"
+        >
+          Open full source
+        </Link>
+        {envelope.thread_id ? (
+          <Link
+            to={`/source/${encodeURIComponent(sid)}?thread=1`}
+            className="rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-primary"
+            data-testid="open-thread"
+          >
+            Open thread
+          </Link>
+        ) : null}
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-primary"
+          data-testid="message-close"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/chronicle/web/src/inspector/SourceList.tsx
+++ b/apps/chronicle/web/src/inspector/SourceList.tsx
@@ -1,0 +1,134 @@
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+
+import { apiPost } from '../api/client'
+import type { QueryScope, SourceListItem, SourceListResponse } from '../api/types'
+
+export interface SourceListProps {
+  scope: QueryScope
+  dateFrom: string
+  dateTo: string
+  onSelectMessage: (sid: string) => void
+}
+
+function formatListDate(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (!Number.isFinite(d.getTime())) return iso
+  return d.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, 'Z')
+}
+
+function senderLabel(item: SourceListItem): string {
+  if (item.sender_name && item.sender_address) {
+    return `${item.sender_name} <${item.sender_address}>`
+  }
+  return item.sender_name || item.sender_address || '—'
+}
+
+export function SourceList({
+  scope,
+  dateFrom,
+  dateTo,
+  onSelectMessage,
+}: SourceListProps) {
+  const query = useInfiniteQuery({
+    queryKey: ['sources', 'list', dateFrom, dateTo, JSON.stringify(scope)],
+    queryFn: ({ pageParam, signal }) =>
+      apiPost<SourceListResponse>(
+        '/api/sources/list',
+        {
+          scope,
+          date_from: dateFrom,
+          date_to: dateTo,
+          cursor: pageParam ?? null,
+          limit: 50,
+        },
+        signal,
+      ),
+    initialPageParam: null as string | null,
+    getNextPageParam: (last) => last.next_cursor ?? undefined,
+    retry: false,
+  })
+
+  const items = useMemo(
+    () => query.data?.pages.flatMap((p) => p.items) ?? [],
+    [query.data?.pages],
+  )
+
+  if (query.isLoading) {
+    return (
+      <div className="space-y-2" data-testid="source-list-skeleton" aria-busy="true">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-10 animate-pulse rounded bg-graphite-800" />
+        ))}
+      </div>
+    )
+  }
+
+  if (query.isError) {
+    return (
+      <div role="alert" className="text-conflict">
+        <p className="mb-2">Failed to load sources</p>
+        <button
+          type="button"
+          onClick={() => void query.refetch()}
+          className="rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-primary"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  if (items.length === 0) {
+    return <p className="text-text-muted">No messages in this period</p>
+  }
+
+  return (
+    <div data-testid="source-list" className="flex min-h-0 flex-1 flex-col">
+      <ul className="min-h-0 flex-1 space-y-0.5 overflow-auto">
+        {items.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              onClick={() => onSelectMessage(item.id)}
+              className="flex w-full flex-col gap-0.5 rounded px-1.5 py-1.5 text-left hover:bg-graphite-800 focus-visible:bg-graphite-800"
+              data-testid={`source-row-${item.id}`}
+            >
+              <div className="flex items-center gap-2">
+                <span className="tabular-nums font-mono text-[11px] text-text-muted">
+                  {formatListDate(item.date)}
+                </span>
+                {item.has_attachment || item.attachment_count > 0 ? (
+                  <span
+                    className="rounded bg-attachment/20 px-1 text-[10px] text-attachment"
+                    title={`${item.attachment_count} attachment(s)`}
+                  >
+                    att{item.attachment_count > 0 ? ` · ${item.attachment_count}` : ''}
+                  </span>
+                ) : null}
+              </div>
+              <span className="truncate text-text-primary">
+                {item.subject || '(no subject)'}
+              </span>
+              <span className="truncate text-[11px] text-text-muted">
+                {senderLabel(item)}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      {query.hasNextPage ? (
+        <button
+          type="button"
+          onClick={() => void query.fetchNextPage()}
+          disabled={query.isFetchingNextPage}
+          className="mt-2 w-full rounded-md border border-steel bg-graphite-800 px-2 py-1.5 text-text-primary"
+          data-testid="source-list-load-more"
+        >
+          {query.isFetchingNextPage ? 'Loading…' : 'Load more'}
+        </button>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/chronicle/web/src/inspector/quotedText.test.ts
+++ b/apps/chronicle/web/src/inspector/quotedText.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  collapsePlainQuotedText,
+  collapsePureQuotedBlocks,
+  wrapBlockquotesInDetails,
+} from './quotedText'
+
+describe('collapsePureQuotedBlocks / collapsePlainQuotedText', () => {
+  it('collapses consecutive > lines into a quote block', () => {
+    const text = ['Hello', '> quoted one', '> quoted two', 'After'].join('\n')
+    const blocks = collapsePureQuotedBlocks(text)
+    expect(blocks).toEqual([
+      { type: 'text', content: 'Hello', lines: 1 },
+      { type: 'quote', content: '> quoted one\n> quoted two', lines: 2 },
+      { type: 'text', content: 'After', lines: 1 },
+    ])
+
+    const nodes = collapsePlainQuotedText(text)
+    expect(nodes.length).toBe(3)
+  })
+
+  it('handles all-quoted and empty', () => {
+    expect(collapsePureQuotedBlocks('> only')).toEqual([
+      { type: 'quote', content: '> only', lines: 1 },
+    ])
+    expect(collapsePureQuotedBlocks('')).toEqual([])
+  })
+})
+
+describe('wrapBlockquotesInDetails', () => {
+  it('wraps top-level blockquote in details', () => {
+    const html = '<p>Hi</p><blockquote><p>quoted</p></blockquote><p>Bye</p>'
+    const out = wrapBlockquotesInDetails(html)
+    expect(out).toContain('<details')
+    expect(out).toContain('Show quoted text')
+    expect(out).toContain('<blockquote>')
+    expect(out).toContain('Hi')
+    expect(out).toContain('Bye')
+  })
+
+  it('leaves nested-only content without inventing blockquotes', () => {
+    const html = '<p>No quotes here</p>'
+    expect(wrapBlockquotesInDetails(html)).toContain('No quotes here')
+    expect(wrapBlockquotesInDetails(html)).not.toContain('<details')
+  })
+})

--- a/apps/chronicle/web/src/inspector/quotedText.tsx
+++ b/apps/chronicle/web/src/inspector/quotedText.tsx
@@ -1,0 +1,111 @@
+/**
+ * Quoted-text collapse for plain text and sanitized HTML.
+ * Never inserts unsanitized HTML — server already sanitized; DOM transforms
+ * run on a detached container after parsing trusted markup.
+ */
+
+import type { ReactNode } from 'react'
+
+/** Collapse consecutive lines starting with `>` into a <details> block. */
+export function collapsePureQuotedBlocks(
+  text: string,
+): { type: 'text' | 'quote'; content: string; lines: number }[] {
+  const lines = text.split('\n')
+  const blocks: { type: 'text' | 'quote'; content: string; lines: number }[] = []
+  let i = 0
+  while (i < lines.length) {
+    if (lines[i]!.startsWith('>')) {
+      const start = i
+      while (i < lines.length && lines[i]!.startsWith('>')) i += 1
+      blocks.push({
+        type: 'quote',
+        content: lines.slice(start, i).join('\n'),
+        lines: i - start,
+      })
+    } else {
+      const start = i
+      while (i < lines.length && !lines[i]!.startsWith('>')) i += 1
+      const content = lines.slice(start, i).join('\n')
+      // Skip a single empty line from a pure empty string input.
+      if (content.length > 0) {
+        blocks.push({ type: 'text', content, lines: i - start })
+      } else if (i - start > 1 || (i - start === 1 && lines[start] !== '')) {
+        blocks.push({ type: 'text', content, lines: i - start })
+      }
+    }
+  }
+  return blocks
+}
+
+/** Collapse consecutive lines starting with `>` into a <details> block. */
+export function collapsePlainQuotedText(text: string): ReactNode[] {
+  const lines = text.split('\n')
+  const nodes: React.ReactNode[] = []
+  let i = 0
+  let key = 0
+  while (i < lines.length) {
+    if (lines[i]!.startsWith('>')) {
+      const start = i
+      while (i < lines.length && lines[i]!.startsWith('>')) i += 1
+      const block = lines.slice(start, i).join('\n')
+      const n = i - start
+      nodes.push(
+        <details key={`q-${key++}`} className="my-1 rounded border border-steel bg-graphite-800 px-2 py-1">
+          <summary className="cursor-pointer text-text-muted">
+            Show quoted text · {n} line{n === 1 ? '' : 's'}
+          </summary>
+          <pre className="mt-1 whitespace-pre-wrap font-mono text-text-muted">{block}</pre>
+        </details>,
+      )
+    } else {
+      const start = i
+      while (i < lines.length && !lines[i]!.startsWith('>')) i += 1
+      const block = lines.slice(start, i).join('\n')
+      if (block.length > 0) {
+        nodes.push(
+          <span key={`t-${key++}`} className="whitespace-pre-wrap">
+            {block}
+            {i < lines.length ? '\n' : ''}
+          </span>,
+        )
+      }
+    }
+  }
+  return nodes
+}
+
+/**
+ * Wrap top-level <blockquote> elements in <details> on a detached container.
+ * Input must already be sanitized HTML from the server.
+ */
+export function wrapBlockquotesInDetails(sanitizedHtml: string): string {
+  if (typeof DOMParser === 'undefined') {
+    // SSR / non-DOM: return as-is
+    return sanitizedHtml
+  }
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(
+    `<div id="root">${sanitizedHtml}</div>`,
+    'text/html',
+  )
+  const root = doc.getElementById('root')
+  if (!root) return sanitizedHtml
+
+  // Only direct-child blockquotes (top-level within the body fragment)
+  const children = Array.from(root.childNodes)
+  for (const child of children) {
+    if (child.nodeType !== 1) continue
+    const el = child as Element
+    if (el.tagName.toLowerCase() !== 'blockquote') continue
+    const details = doc.createElement('details')
+    details.className = 'my-1 rounded border border-steel bg-graphite-800 px-2 py-1'
+    const summary = doc.createElement('summary')
+    summary.className = 'cursor-pointer text-text-muted'
+    summary.textContent = 'Show quoted text'
+    details.appendChild(summary)
+    // Move the blockquote into details
+    root.insertBefore(details, el)
+    details.appendChild(el)
+  }
+  return root.innerHTML
+}

--- a/apps/chronicle/web/src/reader/SourcePage.test.tsx
+++ b/apps/chronicle/web/src/reader/SourcePage.test.tsx
@@ -135,6 +135,7 @@ describe('SourcePage reader', () => {
         kind: 'message' as const,
         sid: 'msg_42',
       },
+      lanes: null,
     }
     const qs = encodeState(chronicleState).toString()
     window.history.replaceState(null, '', qs ? `/?${qs}` : '/')

--- a/apps/chronicle/web/src/reader/SourcePage.test.tsx
+++ b/apps/chronicle/web/src/reader/SourcePage.test.tsx
@@ -1,0 +1,194 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { encodeState } from '../workingset/urlState'
+import { resetWorkingSetStore, useWorkingSetStore } from '../workingset/store'
+import { SourcePage } from './SourcePage'
+import { useUrlSync, resetUrlSyncForTests } from '../workingset/useUrlSync'
+
+const msgSource = {
+  kind: 'msg' as const,
+  envelope: {
+    id: 'msg_42',
+    thread_id: 'thr_YQ',
+    subject: 'Reader subject',
+    sender_name: 'Alice',
+    sender_address: 'alice@example.com',
+    recipients: { to: ['bob@example.com'], cc: ['carol@example.com'], bcc: [] },
+    date: '2014-06-01T12:00:00+00:00',
+    mailbox: 'personal@example.com',
+    labels: ['INBOX', 'Archive'],
+    has_attachment: true,
+    attachments: [
+      {
+        id: 'att_7',
+        filename: 'note.txt',
+        content_type: 'text/plain',
+        size: 12,
+      },
+    ],
+  },
+  body: {
+    text: 'Plain body line\n> quote',
+    html: '<p>Hello</p><blockquote><p>q</p></blockquote>',
+    remote_resources_blocked: 1,
+    had_active_content: true,
+  },
+}
+
+function renderSource(path = '/source/msg_42') {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/source/:sid" element={<SourcePage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('SourcePage reader', () => {
+  beforeEach(() => {
+    resetWorkingSetStore()
+    resetUrlSyncForTests()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetWorkingSetStore()
+    resetUrlSyncForTests()
+  })
+
+  it('renders envelope, modes, attachments, and quoted HTML collapse', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        if (String(url).includes('/api/sources/msg_42')) {
+          return { ok: true, status: 200, json: async () => msgSource } as Response
+        }
+        if (String(url).includes('/api/sources/att_7')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              kind: 'att',
+              id: 'att_7',
+              filename: 'note.txt',
+              content_type: 'text/plain',
+              size: 12,
+              extraction_status: 'extracted',
+              extraction_reason: null,
+              markdown: 'hi',
+              truncated: false,
+              text_offset: 0,
+              source_message_id: 'msg_42',
+              source_envelope: null,
+            }),
+          } as Response
+        }
+        throw new Error(`unexpected: ${url}`)
+      }),
+    )
+
+    renderSource()
+
+    expect(
+      await screen.findByRole('heading', { name: 'Reader subject' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/alice@example.com/i)).toBeInTheDocument()
+    expect(screen.getByText(/carol@example.com/)).toBeInTheDocument()
+    expect(screen.getByText(/personal@example.com/)).toBeInTheDocument()
+    expect(screen.getByText('msg_42')).toBeInTheDocument()
+    expect(screen.getByText('INBOX')).toBeInTheDocument()
+
+    // HTML reading mode with blockquote collapsed
+    expect(screen.getByTestId('reader-body-html')).toBeInTheDocument()
+    expect(screen.getByText(/Show quoted text/i)).toBeInTheDocument()
+
+    // Plain text mode
+    fireEvent.click(screen.getByTestId('mode-plain'))
+    expect(screen.getByText(/Plain body line/)).toBeInTheDocument()
+
+    // Attachment card
+    expect(screen.getByText('note.txt')).toBeInTheDocument()
+    expect(screen.getByText('att_7')).toBeInTheDocument()
+  })
+
+  it('return contract: back restores viewport + selection', async () => {
+    // Chronicle URL serializes viewport + selection; navigating to /source/:sid
+    // is a pushState route change; history.back() + popstate rehydrates the store.
+    const chronicleState = {
+      scope: {},
+      viewport: {
+        fromMs: Date.UTC(2014, 0, 1),
+        toMs: Date.UTC(2016, 0, 1),
+      },
+      aggregation: 'auto' as const,
+      view: 'canvas' as const,
+      selection: {
+        kind: 'message' as const,
+        sid: 'msg_42',
+      },
+    }
+    const qs = encodeState(chronicleState).toString()
+    window.history.replaceState(null, '', qs ? `/?${qs}` : '/')
+    useWorkingSetStore.getState().hydrate(chronicleState)
+
+    // pushState like react-router navigating to the reader
+    window.history.pushState(null, '', '/source/msg_42')
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        if (String(url).includes('/api/sources/msg_42')) {
+          return { ok: true, status: 200, json: async () => msgSource } as Response
+        }
+        throw new Error(`unexpected: ${url}`)
+      }),
+    )
+
+    function Harness() {
+      useUrlSync()
+      return <SourcePage />
+    }
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    // Provide :sid via MemoryRouter while Back uses window.history
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/source/msg_42']}>
+          <Routes>
+            <Route path="/source/:sid" element={<Harness />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    expect(await screen.findByTestId('source-page')).toBeInTheDocument()
+
+    // Mutate store so restore is observable (reader does not clear it, but
+    // simulates any intermediate drift / remount)
+    useWorkingSetStore.setState({
+      viewport: { fromMs: 0, toMs: 1 },
+      selection: null,
+      historyIntent: 'silent',
+    })
+
+    fireEvent.click(screen.getByTestId('source-back'))
+
+    await waitFor(() => {
+      const s = useWorkingSetStore.getState()
+      expect(s.viewport?.fromMs).toBe(Date.UTC(2014, 0, 1))
+      expect(s.viewport?.toMs).toBe(Date.UTC(2016, 0, 1))
+      expect(s.selection).toEqual({ kind: 'message', sid: 'msg_42' })
+    })
+  })
+})

--- a/apps/chronicle/web/src/reader/SourcePage.tsx
+++ b/apps/chronicle/web/src/reader/SourcePage.tsx
@@ -1,0 +1,415 @@
+import { useQuery } from '@tanstack/react-query'
+import { useMemo, useState, type ReactNode } from 'react'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router'
+
+import { apiGet } from '../api/client'
+import type {
+  AttachmentMeta,
+  MessageSource,
+  SourceResponse,
+  ThreadResponse,
+} from '../api/types'
+import {
+  collapsePlainQuotedText,
+  wrapBlockquotesInDetails,
+} from '../inspector/quotedText'
+
+function isMessage(src: SourceResponse): src is MessageSource {
+  return src.kind === 'msg'
+}
+
+function formatBytes(size: number | null | undefined): string {
+  if (size == null || !Number.isFinite(size)) return '—'
+  if (size < 1024) return `${size} B`
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function recipientsBlock(recipients: unknown): ReactNode {
+  if (!recipients || typeof recipients !== 'object') return <span>—</span>
+  const r = recipients as Record<string, unknown>
+  const rows: { label: string; value: string }[] = []
+  for (const key of ['to', 'cc', 'bcc'] as const) {
+    const v = r[key]
+    if (Array.isArray(v) && v.length > 0) {
+      rows.push({ label: key, value: v.map(String).join(', ') })
+    }
+  }
+  if (rows.length === 0) return <span>—</span>
+  return (
+    <ul className="space-y-0.5">
+      {rows.map((row) => (
+        <li key={row.label}>
+          <span className="text-text-muted">{row.label}: </span>
+          {row.value}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function AttachmentCard({ att }: { att: AttachmentMeta }) {
+  const [open, setOpen] = useState(false)
+  const detail = useQuery({
+    queryKey: ['sources', att.id],
+    queryFn: ({ signal }) => apiGet<SourceResponse>(`/api/sources/${att.id}`, signal),
+    enabled: open,
+    retry: false,
+  })
+
+  return (
+    <div className="rounded border border-steel bg-graphite-900 p-2" data-testid={`att-${att.id}`}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full text-left"
+      >
+        <div className="font-medium text-text-primary">{att.filename}</div>
+        <div className="text-[11px] text-text-muted">
+          {att.content_type || 'unknown type'} · {formatBytes(att.size)}
+        </div>
+        <div className="font-mono text-[10px] text-text-muted">{att.id}</div>
+      </button>
+      {open ? (
+        <div className="mt-2 border-t border-steel pt-2 text-[11px] text-text-muted">
+          {detail.isLoading ? (
+            <span>Loading extraction status…</span>
+          ) : detail.isError ? (
+            <span className="text-conflict">Failed to load attachment</span>
+          ) : detail.data && detail.data.kind === 'att' ? (
+            <div>
+              <div>
+                Extraction: {detail.data.extraction_status || 'unknown'}
+                {detail.data.extraction_reason
+                  ? ` (${detail.data.extraction_reason})`
+                  : ''}
+              </div>
+              <div>
+                Extracted text:{' '}
+                {detail.data.markdown != null && detail.data.markdown.length > 0
+                  ? 'available (preview in Phase 2)'
+                  : 'not available'}
+              </div>
+            </div>
+          ) : (
+            <span>No extraction metadata</span>
+          )}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function ThreadPanel({
+  thrSid,
+  currentSid,
+}: {
+  thrSid: string
+  currentSid: string
+}) {
+  const query = useQuery({
+    queryKey: ['threads', thrSid],
+    queryFn: ({ signal }) => apiGet<ThreadResponse>(`/api/threads/${thrSid}`, signal),
+    retry: false,
+  })
+
+  if (query.isLoading) {
+    return (
+      <div className="animate-pulse space-y-1" aria-busy="true">
+        <div className="h-3 w-1/2 rounded bg-graphite-800" />
+        <div className="h-8 rounded bg-graphite-800" />
+      </div>
+    )
+  }
+  if (query.isError || !query.data) {
+    return (
+      <div role="alert" className="text-conflict">
+        Failed to load thread
+        <button
+          type="button"
+          className="ml-2 underline"
+          onClick={() => void query.refetch()}
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  const t = query.data
+  return (
+    <div data-testid="thread-panel" className="space-y-2">
+      <div className="text-[11px] text-text-muted">
+        {t.message_count} message{t.message_count === 1 ? '' : 's'}
+        {t.date_range.from || t.date_range.to
+          ? ` · ${t.date_range.from ?? '—'} – ${t.date_range.to ?? '—'}`
+          : ''}
+      </div>
+      <div className="text-[11px] text-text-muted">
+        Participants:{' '}
+        {t.participants
+          .map((p) => p.name || p.address || '?')
+          .join(', ') || '—'}
+      </div>
+      <ul className="space-y-0.5">
+        {t.messages.map((m) => {
+          const active = m.id === currentSid
+          return (
+            <li key={m.id}>
+              <Link
+                to={`/source/${encodeURIComponent(m.id)}?thread=1`}
+                className={`block rounded px-2 py-1.5 ${
+                  active
+                    ? 'border border-action bg-action/10'
+                    : 'hover:bg-graphite-800'
+                }`}
+                aria-current={active ? 'true' : undefined}
+              >
+                <div className="truncate text-text-primary">
+                  {m.subject || '(no subject)'}
+                </div>
+                <div className="flex gap-2 text-[11px] text-text-muted">
+                  <span className="tabular-nums font-mono">
+                    {m.date ? m.date.replace('T', ' ').replace(/\.\d{3}.*/, '') : '—'}
+                  </span>
+                  <span className="truncate">
+                    {m.sender_name || m.sender_address || '—'}
+                  </span>
+                </div>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+      {t.truncated ? (
+        <p className="text-[11px] text-event">Thread truncated at 500 messages</p>
+      ) : null}
+    </div>
+  )
+}
+
+export function SourcePage() {
+  const { sid: rawSid } = useParams<{ sid: string }>()
+  const sid = rawSid ? decodeURIComponent(rawSid) : ''
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const threadOpenDefault = searchParams.get('thread') === '1'
+  const [mode, setMode] = useState<'reading' | 'plain'>('reading')
+  const [threadOpen, setThreadOpen] = useState(threadOpenDefault)
+
+  const query = useQuery({
+    queryKey: ['sources', sid],
+    queryFn: ({ signal }) => apiGet<SourceResponse>(`/api/sources/${sid}`, signal),
+    enabled: !!sid,
+    retry: false,
+  })
+
+  const bodyNodes = useMemo(() => {
+    if (!query.data || !isMessage(query.data)) return null
+    const { body } = query.data
+    if (mode === 'plain') {
+      return (
+        <pre className="whitespace-pre-wrap font-mono text-text-primary">
+          {body.text ?? ''}
+        </pre>
+      )
+    }
+    if (body.html) {
+      const wrapped = wrapBlockquotesInDetails(body.html)
+      return (
+        <div
+          className="prose-invert text-text-primary [&_a]:text-action"
+          dangerouslySetInnerHTML={{ __html: wrapped }}
+          data-testid="reader-body-html"
+        />
+      )
+    }
+    if (body.text) {
+      return (
+        <div className="font-mono text-text-primary" data-testid="reader-body-text">
+          {collapsePlainQuotedText(body.text)}
+        </div>
+      )
+    }
+    return <p className="text-text-muted">No body</p>
+  }, [mode, query.data])
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4" data-testid="source-page">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            // Return contract: history.back() restores chronicle viewport + selection.
+            if (window.history.length > 1) {
+              window.history.back()
+            } else {
+              void navigate('/')
+            }
+          }}
+          className="rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-primary"
+          data-testid="source-back"
+        >
+          ← Back
+        </button>
+      </div>
+
+      {query.isLoading ? (
+        <div className="space-y-2" aria-busy="true" data-testid="source-skeleton">
+          <div className="h-6 w-2/3 animate-pulse rounded bg-graphite-800" />
+          <div className="h-4 w-full animate-pulse rounded bg-graphite-800" />
+          <div className="h-40 animate-pulse rounded bg-graphite-800" />
+        </div>
+      ) : null}
+
+      {query.isError ? (
+        <div role="alert" className="text-conflict">
+          Failed to load source
+          <button
+            type="button"
+            className="ml-2 underline"
+            onClick={() => void query.refetch()}
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {query.data && isMessage(query.data) ? (
+        <>
+          <header className="space-y-1 border-b border-steel pb-3">
+            <h1 className="text-base font-medium text-text-primary">
+              {query.data.envelope.subject || '(no subject)'}
+            </h1>
+            <div className="text-[12px] text-text-muted">
+              <div>
+                From:{' '}
+                {query.data.envelope.sender_name ||
+                  query.data.envelope.sender_address ||
+                  '—'}
+                {query.data.envelope.sender_name && query.data.envelope.sender_address
+                  ? ` <${query.data.envelope.sender_address}>`
+                  : ''}
+              </div>
+              <div className="mt-1">{recipientsBlock(query.data.envelope.recipients)}</div>
+              <div className="mt-1 tabular-nums font-mono">
+                {query.data.envelope.date || '—'}
+              </div>
+              <div>Mailbox: {query.data.envelope.mailbox || '—'}</div>
+              <div className="font-mono text-[11px]">{query.data.envelope.id}</div>
+              {query.data.envelope.labels?.length ? (
+                <div className="flex flex-wrap gap-1 pt-1">
+                  {query.data.envelope.labels.map((lab) => (
+                    <span
+                      key={lab}
+                      className="rounded bg-graphite-800 px-1.5 py-0.5 text-[10px] text-text-muted"
+                    >
+                      {lab}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </header>
+
+          {query.data.body.remote_resources_blocked > 0 ? (
+            <p className="text-[12px] text-event">
+              {query.data.body.remote_resources_blocked} remote resource
+              {query.data.body.remote_resources_blocked === 1 ? '' : 's'} blocked
+            </p>
+          ) : null}
+
+          <div
+            role="tablist"
+            aria-label="Source modes"
+            className="flex gap-1 border-b border-steel"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={mode === 'reading'}
+              onClick={() => setMode('reading')}
+              className={`px-3 py-1.5 ${
+                mode === 'reading'
+                  ? 'border-b-2 border-action text-text-primary'
+                  : 'text-text-muted'
+              }`}
+            >
+              Reading
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={mode === 'plain'}
+              onClick={() => setMode('plain')}
+              className={`px-3 py-1.5 ${
+                mode === 'plain'
+                  ? 'border-b-2 border-action text-text-primary'
+                  : 'text-text-muted'
+              }`}
+              data-testid="mode-plain"
+            >
+              Plain text
+            </button>
+          </div>
+
+          <article className="min-h-[12rem] rounded-lg border border-steel bg-graphite-900 p-4">
+            {bodyNodes}
+          </article>
+
+          {query.data.envelope.attachments?.length ? (
+            <section aria-label="Attachments" className="space-y-2">
+              <h2 className="text-sm font-medium text-text-primary">Attachments</h2>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {query.data.envelope.attachments.map((att) => (
+                  <AttachmentCard key={att.id} att={att} />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {query.data.envelope.thread_id ? (
+            <section aria-label="Thread" className="rounded-lg border border-steel bg-graphite-900">
+              <button
+                type="button"
+                className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-text-primary"
+                onClick={() => setThreadOpen((v) => !v)}
+                aria-expanded={threadOpen}
+                data-testid="thread-toggle"
+              >
+                <span>Thread</span>
+                <span className="text-text-muted">{threadOpen ? '▾' : '▸'}</span>
+              </button>
+              {threadOpen ? (
+                <div className="border-t border-steel p-3">
+                  <ThreadPanel
+                    thrSid={query.data.envelope.thread_id}
+                    currentSid={sid}
+                  />
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+        </>
+      ) : null}
+
+      {query.data && !isMessage(query.data) ? (
+        <div className="space-y-2">
+          <h1 className="text-base font-medium">{query.data.filename}</h1>
+          <p className="font-mono text-[11px] text-text-muted">{query.data.id}</p>
+          <p className="text-text-muted">
+            {query.data.content_type || 'unknown'} · {formatBytes(query.data.size)}
+          </p>
+          <p className="text-text-muted">
+            Extraction: {query.data.extraction_status || 'unknown'}
+          </p>
+          {query.data.markdown ? (
+            <pre className="whitespace-pre-wrap rounded border border-steel bg-graphite-900 p-3 font-mono">
+              {query.data.markdown}
+            </pre>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/chronicle/web/src/routes/ChroniclePage.test.tsx
+++ b/apps/chronicle/web/src/routes/ChroniclePage.test.tsx
@@ -190,4 +190,58 @@ describe('ChroniclePage working-set wiring', () => {
     expect(useWorkingSetStore.getState().view).toBe('table')
     expect(await screen.findByTestId('timeline-table')).toBeInTheDocument()
   })
+
+  it('lane config toggle/reorder update store and URL', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        if (String(url).includes('/api/auth/session')) return mockSessionOk()
+        if (String(url).includes('/api/archive/summary')) return mockArchiveSummary()
+        if (String(url).includes('/api/chronicle/buckets')) return mockBucketsOk()
+        throw new Error(`unexpected fetch: ${url}`)
+      }),
+    )
+
+    renderApp(['/'])
+    expect(await screen.findByTestId('lane-config-panel')).toBeInTheDocument()
+    expect(await screen.findByTestId('timeline-canvas-wrap')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Show People (distinct)'))
+    expect(useWorkingSetStore.getState().lanes).toContain('people')
+
+    await waitFor(() => {
+      expect(window.location.search).toMatch(/ln=/)
+    })
+    expect(window.location.search).toMatch(/people/)
+
+    fireEvent.click(screen.getByLabelText('Move Messages down'))
+    const lanes = useWorkingSetStore.getState().lanes
+    expect(lanes.indexOf('messages')).toBeGreaterThan(0)
+  })
+
+  it('canvas height responds to lane config', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        if (String(url).includes('/api/auth/session')) return mockSessionOk()
+        if (String(url).includes('/api/archive/summary')) return mockArchiveSummary()
+        if (String(url).includes('/api/chronicle/buckets')) return mockBucketsOk()
+        throw new Error(`unexpected fetch: ${url}`)
+      }),
+    )
+
+    renderApp(['/'])
+    const wrap = await screen.findByTestId('timeline-canvas-wrap')
+    const hBefore = Number(wrap.getAttribute('data-canvas-h'))
+    expect(hBefore).toBeGreaterThan(0)
+
+    // Hide attachments → fewer bars → shorter canvas
+    fireEvent.click(screen.getByLabelText('Show Attachments'))
+    await waitFor(() => {
+      const hAfter = Number(
+        screen.getByTestId('timeline-canvas-wrap').getAttribute('data-canvas-h'),
+      )
+      expect(hAfter).toBeLessThan(hBefore)
+    })
+  })
 })

--- a/apps/chronicle/web/src/routes/ChroniclePage.test.tsx
+++ b/apps/chronicle/web/src/routes/ChroniclePage.test.tsx
@@ -8,6 +8,23 @@ import {
   renderApp,
 } from '../test/test-utils'
 
+function mockBucketsOk() {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      scope_fingerprint: 'qs_test',
+      aggregation: 'month',
+      unit: 'month',
+      viewport: { from: '2014-01-01T00:00:00.000Z', to: '2019-01-01T00:00:00.000Z' },
+      lanes: { messages: [], attachments: [] },
+      density: { unit: 'year', buckets: [] },
+      extent: { from: '2014-01-01T00:00:00.000Z', to: '2019-01-01T00:00:00.000Z' },
+      generated_at: '2026-01-01T00:00:00.000Z',
+    }),
+  } as Response
+}
+
 describe('Archive summary panel', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
@@ -21,14 +38,16 @@ describe('Archive summary panel', () => {
         if (String(url).includes('/api/archive/summary')) {
           return mockArchiveSummary()
         }
+        if (String(url).includes('/api/chronicle/buckets')) return mockBucketsOk()
         throw new Error(`unexpected fetch: ${url}`)
       }),
     )
 
     renderApp(['/'])
 
-    expect(await screen.findByText('Archive coverage')).toBeInTheDocument()
-    expect(screen.getByText('1,280,000')).toBeInTheDocument()
+    // Summary label is always in the collapsible details; wait for loaded counts.
+    expect(await screen.findByText('1,280,000')).toBeInTheDocument()
+    expect(screen.getByText('Archive coverage')).toBeInTheDocument()
     expect(screen.getByText('400,000')).toBeInTheDocument()
     expect(screen.getByText('50,000')).toBeInTheDocument()
     expect(screen.getByText('12,000')).toBeInTheDocument()
@@ -48,30 +67,39 @@ describe('Archive summary panel', () => {
           json: async () => ({ detail: 'boom' }),
         } as Response
       }
+      if (String(url).includes('/api/chronicle/buckets')) return mockBucketsOk()
       throw new Error(`unexpected fetch: ${url}`)
     })
     vi.stubGlobal('fetch', fetchMock)
 
     renderApp(['/'])
 
-    expect(await screen.findByRole('alert')).toHaveTextContent(
-      /Failed to load archive coverage/,
+    const alerts = await screen.findAllByRole('alert')
+    const coverageAlert = alerts.find((a) =>
+      /Failed to load archive coverage/.test(a.textContent ?? ''),
     )
-    const retry = screen.getByRole('button', { name: /retry/i })
-    expect(retry).toBeInTheDocument()
+    expect(coverageAlert).toBeTruthy()
+    const retry = screen
+      .getAllByRole('button', { name: /retry/i })
+      .find((b) => coverageAlert!.contains(b))
+    expect(retry).toBeTruthy()
 
     fetchMock.mockImplementation(async (url: string) => {
       if (String(url).includes('/api/auth/session')) return mockSessionOk()
       if (String(url).includes('/api/archive/summary')) {
         return mockArchiveSummary()
       }
+      if (String(url).includes('/api/chronicle/buckets')) return mockBucketsOk()
       throw new Error(`unexpected fetch: ${url}`)
     })
 
-    fireEvent.click(retry)
+    fireEvent.click(retry!)
 
     await waitFor(() => {
       expect(screen.getByText('Archive coverage')).toBeInTheDocument()
+      expect(
+        screen.queryByText(/Failed to load archive coverage/),
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/apps/chronicle/web/src/routes/ChroniclePage.test.tsx
+++ b/apps/chronicle/web/src/routes/ChroniclePage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   mockArchiveSummary,
@@ -7,6 +7,7 @@ import {
   mockUnauthorized,
   renderApp,
 } from '../test/test-utils'
+import { resetWorkingSetStore, useWorkingSetStore } from '../workingset/store'
 
 function mockBucketsOk() {
   return {
@@ -26,8 +27,15 @@ function mockBucketsOk() {
 }
 
 describe('Archive summary panel', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/')
+    resetWorkingSetStore()
+  })
+
   afterEach(() => {
     vi.unstubAllGlobals()
+    window.history.replaceState(null, '', '/')
+    resetWorkingSetStore()
   })
 
   it('renders mocked ArchiveSummary counts', async () => {
@@ -116,5 +124,70 @@ describe('Archive summary panel', () => {
 
     expect(await screen.findByLabelText(/username/i)).toBeInTheDocument()
     expect(screen.queryByTestId('workstation-shell')).not.toBeInTheDocument()
+  })
+})
+
+describe('ChroniclePage working-set wiring', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/')
+    resetWorkingSetStore()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.history.replaceState(null, '', '/')
+    resetWorkingSetStore()
+  })
+
+  it('sends store scope on buckets request', async () => {
+    // Deep-link scope so mount hydrate restores it before the buckets fetch.
+    window.history.replaceState(
+      null,
+      '',
+      '/?mb=me%40example.com&df=2014-01-01&dt=2018-01-01',
+    )
+
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes('/api/auth/session')) return mockSessionOk()
+      if (String(url).includes('/api/archive/summary')) return mockArchiveSummary()
+      if (String(url).includes('/api/chronicle/buckets')) return mockBucketsOk()
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderApp(['/'])
+
+    await waitFor(() => {
+      const scoped = fetchMock.mock.calls.some((c) => {
+        if (!String(c[0]).includes('/api/chronicle/buckets')) return false
+        const body = JSON.parse(String((c[1] as RequestInit).body)) as {
+          scope: { mailboxes?: string[]; date?: { from?: string; to?: string } }
+        }
+        return (
+          body.scope?.mailboxes?.[0] === 'me@example.com' &&
+          body.scope?.date?.from === '2014-01-01'
+        )
+      })
+      expect(scoped).toBe(true)
+    })
+  })
+
+  it('View as table toggles store view', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        if (String(url).includes('/api/auth/session')) return mockSessionOk()
+        if (String(url).includes('/api/archive/summary')) return mockArchiveSummary()
+        if (String(url).includes('/api/chronicle/buckets')) return mockBucketsOk()
+        throw new Error(`unexpected fetch: ${url}`)
+      }),
+    )
+
+    renderApp(['/'])
+    expect(await screen.findByTestId('visible-period')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /view as table/i }))
+    expect(useWorkingSetStore.getState().view).toBe('table')
+    expect(await screen.findByTestId('timeline-table')).toBeInTheDocument()
   })
 })

--- a/apps/chronicle/web/src/routes/ChroniclePage.test.tsx
+++ b/apps/chronicle/web/src/routes/ChroniclePage.test.tsx
@@ -244,4 +244,44 @@ describe('ChroniclePage working-set wiring', () => {
       expect(hAfter).toBeLessThan(hBefore)
     })
   })
+
+  it('Enter key enters focus when a brush exists', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        if (String(url).includes('/api/auth/session')) return mockSessionOk()
+        if (String(url).includes('/api/archive/summary')) return mockArchiveSummary()
+        if (String(url).includes('/api/chronicle/buckets')) return mockBucketsOk()
+        if (String(url).includes('/api/sources/list')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              items: [],
+              next_cursor: null,
+              scope_fingerprint: 'qs',
+            }),
+          } as Response
+        }
+        throw new Error(`unexpected fetch: ${url}`)
+      }),
+    )
+
+    renderApp(['/'])
+    expect(await screen.findByTestId('timeline-toolbar')).toBeInTheDocument()
+
+    const brush = {
+      fromMs: Date.UTC(2015, 0, 1),
+      toMs: Date.UTC(2016, 0, 1),
+    }
+    useWorkingSetStore.getState().setBrush(brush)
+
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(useWorkingSetStore.getState().focus).toEqual(brush)
+    })
+    expect(await screen.findByTestId('focus-mode')).toBeInTheDocument()
+    expect(useWorkingSetStore.getState().brush).toBeNull()
+  })
 })

--- a/apps/chronicle/web/src/routes/ChroniclePage.tsx
+++ b/apps/chronicle/web/src/routes/ChroniclePage.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import type { ArchiveSummary } from '../api/types'
+import type { ArchiveSummary, LaneData } from '../api/types'
+import { isBucketSeries } from '../api/types'
 import { DensityNavigator } from '../chronicle/DensityNavigator'
+import { LaneConfigPanel } from '../chronicle/LaneConfigPanel'
+import { specsForKeys } from '../chronicle/laneModel'
 import { TimelineCanvas } from '../chronicle/TimelineCanvas'
 import { TimelineTable } from '../chronicle/TimelineTable'
 import { TimelineToolbar } from '../chronicle/TimelineToolbar'
@@ -139,6 +142,9 @@ export function ChroniclePage() {
   const setTimelineUnit = useWorkingSetStore((s) => s.setTimelineUnit)
   const selection = useWorkingSetStore((s) => s.selection)
   const setSelection = useWorkingSetStore((s) => s.setSelection)
+  const lanes = useWorkingSetStore((s) => s.lanes)
+  const toggleLane = useWorkingSetStore((s) => s.toggleLane)
+  const moveLane = useWorkingSetStore((s) => s.moveLane)
 
   const [pixelWidth, setPixelWidth] = useState(920)
   // False until URL hydrate or extent bootstrap resolves (layout hydrate may set
@@ -146,11 +152,13 @@ export function ChroniclePage() {
   const [bootstrapped, setBootstrapped] = useState(false)
 
   const activeViewport = viewport ?? BOOTSTRAP_VIEWPORT
+  const laneSpecs = useMemo(() => specsForKeys(lanes), [lanes])
 
   const buckets = useChronicleBuckets({
     viewport: activeViewport,
     pixelWidth,
     scope,
+    lanes,
     enabled: pixelWidth > 0,
   })
 
@@ -182,7 +190,8 @@ export function ChroniclePage() {
   // Live result framing for the scope bar + unit for inspector bucket ranges.
   useEffect(() => {
     if (!buckets.data) return
-    setResultCount(sumLaneCounts(buckets.data.lanes.messages))
+    const messages = buckets.data.lanes.messages
+    setResultCount(sumLaneCounts(isBucketSeries(messages) ? messages : undefined))
     setTimelineUnit(buckets.data.unit ?? buckets.data.aggregation ?? null)
   }, [buckets.data, setResultCount, setTimelineUnit])
 
@@ -236,10 +245,9 @@ export function ChroniclePage() {
     return () => window.removeEventListener('keydown', onKey)
   }, [setBrush, zoomAroundCenter])
 
-  const messages = buckets.data?.lanes.messages ?? []
-  const attachments = buckets.data?.lanes.attachments ?? []
   const unit = buckets.data?.unit ?? buckets.data?.aggregation ?? 'month'
   const densityBuckets = buckets.data?.density.buckets ?? []
+  const laneData: Record<string, LaneData> = buckets.data?.lanes ?? {}
 
   const showTimeline = viewport != null
 
@@ -291,37 +299,46 @@ export function ChroniclePage() {
           </div>
         ) : null}
 
-        {/* Keep prior data visible on error when present */}
+        {/* Config rail (left) + canvas/table — shell has no config slot yet. */}
         {showTimeline && (buckets.data || !buckets.isError) ? (
-          viewMode === 'table' ? (
-            <TimelineTable
-              viewport={viewport}
-              unit={unit}
-              messages={messages}
-              attachments={attachments}
+          <div className="flex gap-2" data-testid="timeline-with-config">
+            <LaneConfigPanel
+              lanes={lanes}
+              onToggle={toggleLane}
+              onMove={moveLane}
             />
-          ) : (
-            <TimelineCanvas
-              viewport={viewport}
-              extent={extent}
-              unit={unit}
-              messages={messages}
-              attachments={attachments}
-              isFetching={buckets.isFetching}
-              brush={brush}
-              selectedBucket={
-                selection?.kind === 'bucket'
-                  ? { bucketIso: selection.bucketIso, lane: selection.lane }
-                  : null
-              }
-              onViewportChange={applyViewport}
-              onBrushChange={setBrush}
-              onWidthChange={onWidthChange}
-              onSelectBucket={(bucketIso, laneName) =>
-                setSelection({ kind: 'bucket', bucketIso, lane: laneName })
-              }
-            />
-          )
+            <div className="min-w-0 flex-1">
+              {viewMode === 'table' ? (
+                <TimelineTable
+                  viewport={viewport}
+                  unit={unit}
+                  lanes={laneSpecs}
+                  laneData={laneData}
+                />
+              ) : (
+                <TimelineCanvas
+                  viewport={viewport}
+                  extent={extent}
+                  unit={unit}
+                  lanes={laneSpecs}
+                  laneData={laneData}
+                  isFetching={buckets.isFetching}
+                  brush={brush}
+                  selectedBucket={
+                    selection?.kind === 'bucket'
+                      ? { bucketIso: selection.bucketIso, lane: selection.lane }
+                      : null
+                  }
+                  onViewportChange={applyViewport}
+                  onBrushChange={setBrush}
+                  onWidthChange={onWidthChange}
+                  onSelectBucket={(bucketIso, laneName) =>
+                    setSelection({ kind: 'bucket', bucketIso, lane: laneName })
+                  }
+                />
+              )}
+            </div>
+          </div>
         ) : null}
 
         {/* Bootstrap: measure width even before viewport is set */}

--- a/apps/chronicle/web/src/routes/ChroniclePage.tsx
+++ b/apps/chronicle/web/src/routes/ChroniclePage.tsx
@@ -136,6 +136,9 @@ export function ChroniclePage() {
   const applyBrushAsViewport = useWorkingSetStore((s) => s.applyBrushAsViewport)
   const setView = useWorkingSetStore((s) => s.setView)
   const setResultCount = useWorkingSetStore((s) => s.setResultCount)
+  const setTimelineUnit = useWorkingSetStore((s) => s.setTimelineUnit)
+  const selection = useWorkingSetStore((s) => s.selection)
+  const setSelection = useWorkingSetStore((s) => s.setSelection)
 
   const [pixelWidth, setPixelWidth] = useState(920)
   // False until URL hydrate or extent bootstrap resolves (layout hydrate may set
@@ -176,11 +179,12 @@ export function ChroniclePage() {
     setBootstrapped(true)
   }, [bootstrapped, buckets.data?.extent, setViewport, viewport])
 
-  // Live result framing for the scope bar.
+  // Live result framing for the scope bar + unit for inspector bucket ranges.
   useEffect(() => {
     if (!buckets.data) return
     setResultCount(sumLaneCounts(buckets.data.lanes.messages))
-  }, [buckets.data, setResultCount])
+    setTimelineUnit(buckets.data.unit ?? buckets.data.aggregation ?? null)
+  }, [buckets.data, setResultCount, setTimelineUnit])
 
   const applyViewport = useCallback(
     (next: Viewport) => {
@@ -305,9 +309,17 @@ export function ChroniclePage() {
               attachments={attachments}
               isFetching={buckets.isFetching}
               brush={brush}
+              selectedBucket={
+                selection?.kind === 'bucket'
+                  ? { bucketIso: selection.bucketIso, lane: selection.lane }
+                  : null
+              }
               onViewportChange={applyViewport}
               onBrushChange={setBrush}
               onWidthChange={onWidthChange}
+              onSelectBucket={(bucketIso, laneName) =>
+                setSelection({ kind: 'bucket', bucketIso, lane: laneName })
+              }
             />
           )
         ) : null}

--- a/apps/chronicle/web/src/routes/ChroniclePage.tsx
+++ b/apps/chronicle/web/src/routes/ChroniclePage.tsx
@@ -12,6 +12,7 @@ import {
   zoomViewport,
 } from '../chronicle/timeScale'
 import { useChronicleBuckets } from '../chronicle/useChronicleBuckets'
+import { useWorkingSetStore } from '../workingset/store'
 import { useArchiveSummary } from './useArchiveSummary'
 
 function SummarySkeleton() {
@@ -115,16 +116,30 @@ function extentFromResponse(
   return { fromMs, toMs }
 }
 
+function sumLaneCounts(points: { count: number }[] | undefined): number {
+  if (!points) return 0
+  return points.reduce((acc, p) => acc + (p.count ?? 0), 0)
+}
+
 export function ChroniclePage() {
   const archive = useArchiveSummary()
 
-  // Owns viewport, brush, viewMode state.
-  // Bootstrap: fetch once with sentinel full-range viewport 1970-01-01..2100-01-01,
-  // then set viewport := extent from the first response.
-  const [viewport, setViewport] = useState<Viewport | null>(null)
-  const [brush, setBrush] = useState<Viewport | null>(null)
-  const [viewMode, setViewMode] = useState<'canvas' | 'table'>('canvas')
+  // Viewport / scope / view / brush come from the shared working-set store.
+  // Bootstrap: if URL had no viewport, fetch with sentinel full-range
+  // 1970-01-01..2100-01-01, then set viewport := extent (transient → replace-state).
+  const viewport = useWorkingSetStore((s) => s.viewport)
+  const brush = useWorkingSetStore((s) => s.brush)
+  const viewMode = useWorkingSetStore((s) => s.view)
+  const scope = useWorkingSetStore((s) => s.scope)
+  const setViewport = useWorkingSetStore((s) => s.setViewport)
+  const setBrush = useWorkingSetStore((s) => s.setBrush)
+  const applyBrushAsViewport = useWorkingSetStore((s) => s.applyBrushAsViewport)
+  const setView = useWorkingSetStore((s) => s.setView)
+  const setResultCount = useWorkingSetStore((s) => s.setResultCount)
+
   const [pixelWidth, setPixelWidth] = useState(920)
+  // False until URL hydrate or extent bootstrap resolves (layout hydrate may set
+  // viewport after this component's first render).
   const [bootstrapped, setBootstrapped] = useState(false)
 
   const activeViewport = viewport ?? BOOTSTRAP_VIEWPORT
@@ -132,6 +147,7 @@ export function ChroniclePage() {
   const buckets = useChronicleBuckets({
     viewport: activeViewport,
     pixelWidth,
+    scope,
     enabled: pixelWidth > 0,
   })
 
@@ -142,9 +158,14 @@ export function ChroniclePage() {
     return null
   }, [buckets.data?.extent])
 
-  // Apply bootstrap: first response with extent sets viewport := extent
+  // Apply bootstrap: if store/URL already has a viewport, mark done; otherwise
+  // first response with extent sets viewport := extent (transient → replace-state).
   useEffect(() => {
     if (bootstrapped) return
+    if (viewport != null) {
+      setBootstrapped(true)
+      return
+    }
     if (!buckets.data?.extent) return
     const ext = extentFromResponse(buckets.data.extent.from, buckets.data.extent.to)
     if (!ext) {
@@ -153,7 +174,13 @@ export function ChroniclePage() {
     }
     setViewport(ext)
     setBootstrapped(true)
-  }, [bootstrapped, buckets.data?.extent])
+  }, [bootstrapped, buckets.data?.extent, setViewport, viewport])
+
+  // Live result framing for the scope bar.
+  useEffect(() => {
+    if (!buckets.data) return
+    setResultCount(sumLaneCounts(buckets.data.lanes.messages))
+  }, [buckets.data, setResultCount])
 
   const applyViewport = useCallback(
     (next: Viewport) => {
@@ -163,7 +190,7 @@ export function ChroniclePage() {
         setViewport(next)
       }
     },
-    [extent],
+    [extent, setViewport],
   )
 
   const onWidthChange = useCallback((w: number) => {
@@ -203,7 +230,7 @@ export function ChroniclePage() {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [zoomAroundCenter])
+  }, [setBrush, zoomAroundCenter])
 
   const messages = buckets.data?.lanes.messages ?? []
   const attachments = buckets.data?.lanes.attachments ?? []
@@ -230,14 +257,11 @@ export function ChroniclePage() {
               if (extent) applyViewport(extent)
             }}
             onZoomToSelection={() => {
-              if (brush) {
-                applyViewport(brush)
-                setBrush(null)
-              }
+              applyBrushAsViewport()
             }}
             onClearSelection={() => setBrush(null)}
             onToggleViewMode={() =>
-              setViewMode((m) => (m === 'canvas' ? 'table' : 'canvas'))
+              setView(viewMode === 'canvas' ? 'table' : 'canvas')
             }
           />
         ) : null}

--- a/apps/chronicle/web/src/routes/ChroniclePage.tsx
+++ b/apps/chronicle/web/src/routes/ChroniclePage.tsx
@@ -15,6 +15,7 @@ import {
   zoomViewport,
 } from '../chronicle/timeScale'
 import { useChronicleBuckets } from '../chronicle/useChronicleBuckets'
+import { FocusModeConnected } from '../focus/FocusMode'
 import { useWorkingSetStore } from '../workingset/store'
 import { useArchiveSummary } from './useArchiveSummary'
 
@@ -132,10 +133,12 @@ export function ChroniclePage() {
   // 1970-01-01..2100-01-01, then set viewport := extent (transient → replace-state).
   const viewport = useWorkingSetStore((s) => s.viewport)
   const brush = useWorkingSetStore((s) => s.brush)
+  const focus = useWorkingSetStore((s) => s.focus)
   const viewMode = useWorkingSetStore((s) => s.view)
   const scope = useWorkingSetStore((s) => s.scope)
   const setViewport = useWorkingSetStore((s) => s.setViewport)
   const setBrush = useWorkingSetStore((s) => s.setBrush)
+  const setFocus = useWorkingSetStore((s) => s.setFocus)
   const applyBrushAsViewport = useWorkingSetStore((s) => s.applyBrushAsViewport)
   const setView = useWorkingSetStore((s) => s.setView)
   const setResultCount = useWorkingSetStore((s) => s.setResultCount)
@@ -219,7 +222,8 @@ export function ChroniclePage() {
     [applyViewport, pixelWidth, viewport],
   )
 
-  // Keyboard shortcuts [ / ] zoom out/in around center — page-scoped, cleaned up on unmount.
+  // Keyboard shortcuts [ / ] zoom, Enter → focus period when brush exists —
+  // page-scoped, cleaned up on unmount.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null
@@ -239,134 +243,161 @@ export function ChroniclePage() {
         zoomAroundCenter(0.5) // zoom in
       } else if (e.key === 'Escape') {
         setBrush(null)
+      } else if (e.key === 'Enter') {
+        // Focus period when a brush exists (spec §4.6 entry).
+        const b = useWorkingSetStore.getState().brush
+        if (b && b.toMs > b.fromMs) {
+          e.preventDefault()
+          setFocus(b)
+        }
       }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [setBrush, zoomAroundCenter])
+  }, [setBrush, setFocus, zoomAroundCenter])
 
   const unit = buckets.data?.unit ?? buckets.data?.aggregation ?? 'month'
   const densityBuckets = buckets.data?.density.buckets ?? []
   const laneData: Record<string, LaneData> = buckets.data?.lanes ?? {}
 
   const showTimeline = viewport != null
+  const inFocus = focus != null
 
   return (
     <div className="space-y-4">
       <h1 className="text-base font-medium text-text-primary">Chronicle</h1>
 
-      {/* Timeline region */}
+      {/* Timeline region — replaced by FocusMode while focus is active. */}
       <section className="space-y-2" aria-label="Timeline">
-        {showTimeline ? (
-          <TimelineToolbar
-            viewport={viewport}
-            unit={unit}
-            brush={brush}
-            viewMode={viewMode}
-            onZoomIn={() => zoomAroundCenter(0.5)}
-            onZoomOut={() => zoomAroundCenter(2)}
-            onFitAll={() => {
-              if (extent) applyViewport(extent)
-            }}
-            onZoomToSelection={() => {
-              applyBrushAsViewport()
-            }}
-            onClearSelection={() => setBrush(null)}
-            onToggleViewMode={() =>
-              setView(viewMode === 'canvas' ? 'table' : 'canvas')
-            }
-          />
-        ) : null}
+        {inFocus ? (
+          <FocusModeConnected />
+        ) : (
+          <>
+            {showTimeline ? (
+              <TimelineToolbar
+                viewport={viewport}
+                unit={unit}
+                brush={brush}
+                viewMode={viewMode}
+                onZoomIn={() => zoomAroundCenter(0.5)}
+                onZoomOut={() => zoomAroundCenter(2)}
+                onFitAll={() => {
+                  if (extent) applyViewport(extent)
+                }}
+                onZoomToSelection={() => {
+                  applyBrushAsViewport()
+                }}
+                onClearSelection={() => setBrush(null)}
+                onToggleViewMode={() =>
+                  setView(viewMode === 'canvas' ? 'table' : 'canvas')
+                }
+                onFocusPeriod={() => {
+                  if (brush) setFocus(brush)
+                }}
+              />
+            ) : null}
 
-        {buckets.isError ? (
-          <div
-            role="alert"
-            data-testid="timeline-error"
-            className="rounded-lg border border-conflict bg-graphite-900 p-4 text-conflict"
-          >
-            <p className="mb-2">
-              Failed to load timeline
-              {buckets.error instanceof Error ? `: ${buckets.error.message}` : ''}
-            </p>
-            <button
-              type="button"
-              onClick={() => void buckets.refetch()}
-              disabled={buckets.isFetching}
-              className="rounded-md border border-steel bg-graphite-800 px-3 py-1.5 text-text-primary"
-            >
-              Retry
-            </button>
-          </div>
-        ) : null}
+            {buckets.isError ? (
+              <div
+                role="alert"
+                data-testid="timeline-error"
+                className="rounded-lg border border-conflict bg-graphite-900 p-4 text-conflict"
+              >
+                <p className="mb-2">
+                  Failed to load timeline
+                  {buckets.error instanceof Error
+                    ? `: ${buckets.error.message}`
+                    : ''}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => void buckets.refetch()}
+                  disabled={buckets.isFetching}
+                  className="rounded-md border border-steel bg-graphite-800 px-3 py-1.5 text-text-primary"
+                >
+                  Retry
+                </button>
+              </div>
+            ) : null}
 
-        {/* Config rail (left) + canvas/table — shell has no config slot yet. */}
-        {showTimeline && (buckets.data || !buckets.isError) ? (
-          <div className="flex gap-2" data-testid="timeline-with-config">
-            <LaneConfigPanel
-              lanes={lanes}
-              onToggle={toggleLane}
-              onMove={moveLane}
-            />
-            <div className="min-w-0 flex-1">
-              {viewMode === 'table' ? (
-                <TimelineTable
-                  viewport={viewport}
-                  unit={unit}
-                  lanes={laneSpecs}
-                  laneData={laneData}
+            {/* Config rail (left) + canvas/table — shell has no config slot yet. */}
+            {showTimeline && (buckets.data || !buckets.isError) ? (
+              <div className="flex gap-2" data-testid="timeline-with-config">
+                <LaneConfigPanel
+                  lanes={lanes}
+                  onToggle={toggleLane}
+                  onMove={moveLane}
                 />
-              ) : (
-                <TimelineCanvas
-                  viewport={viewport}
-                  extent={extent}
-                  unit={unit}
-                  lanes={laneSpecs}
-                  laneData={laneData}
-                  isFetching={buckets.isFetching}
-                  brush={brush}
-                  selectedBucket={
-                    selection?.kind === 'bucket'
-                      ? { bucketIso: selection.bucketIso, lane: selection.lane }
-                      : null
-                  }
-                  onViewportChange={applyViewport}
-                  onBrushChange={setBrush}
-                  onWidthChange={onWidthChange}
-                  onSelectBucket={(bucketIso, laneName) =>
-                    setSelection({ kind: 'bucket', bucketIso, lane: laneName })
-                  }
-                />
-              )}
-            </div>
-          </div>
-        ) : null}
+                <div className="min-w-0 flex-1">
+                  {viewMode === 'table' ? (
+                    <TimelineTable
+                      viewport={viewport}
+                      unit={unit}
+                      lanes={laneSpecs}
+                      laneData={laneData}
+                    />
+                  ) : (
+                    <TimelineCanvas
+                      viewport={viewport}
+                      extent={extent}
+                      unit={unit}
+                      lanes={laneSpecs}
+                      laneData={laneData}
+                      isFetching={buckets.isFetching}
+                      brush={brush}
+                      selectedBucket={
+                        selection?.kind === 'bucket'
+                          ? {
+                              bucketIso: selection.bucketIso,
+                              lane: selection.lane,
+                            }
+                          : null
+                      }
+                      onViewportChange={applyViewport}
+                      onBrushChange={setBrush}
+                      onWidthChange={onWidthChange}
+                      onSelectBucket={(bucketIso, laneName) =>
+                        setSelection({
+                          kind: 'bucket',
+                          bucketIso,
+                          lane: laneName,
+                        })
+                      }
+                      onFocusBucket={(period) => setFocus(period)}
+                    />
+                  )}
+                </div>
+              </div>
+            ) : null}
 
-        {/* Bootstrap: measure width even before viewport is set */}
-        {!showTimeline && !buckets.isError ? (
-          <div
-            className="h-40 w-full rounded-lg border border-steel bg-graphite-900"
-            ref={(el) => {
-              if (el) {
-                const w = el.clientWidth
-                if (w > 0 && w !== pixelWidth) setPixelWidth(w)
-              }
-            }}
-            data-testid="timeline-bootstrap"
-            aria-busy={buckets.isLoading || buckets.isFetching}
-            aria-label="Loading timeline"
-          >
-            <div className="h-0.5 w-full animate-pulse bg-action" />
-          </div>
-        ) : null}
+            {/* Bootstrap: measure width even before viewport is set */}
+            {!showTimeline && !buckets.isError ? (
+              <div
+                className="h-40 w-full rounded-lg border border-steel bg-graphite-900"
+                ref={(el) => {
+                  if (el) {
+                    const w = el.clientWidth
+                    if (w > 0 && w !== pixelWidth) setPixelWidth(w)
+                  }
+                }}
+                data-testid="timeline-bootstrap"
+                aria-busy={buckets.isLoading || buckets.isFetching}
+                aria-label="Loading timeline"
+              >
+                <div className="h-0.5 w-full animate-pulse bg-action" />
+              </div>
+            ) : null}
 
-        {showTimeline && extent ? (
-          <DensityNavigator
-            extent={extent}
-            viewport={viewport}
-            densityBuckets={densityBuckets}
-            onViewportChange={applyViewport}
-          />
-        ) : null}
+            {showTimeline && extent ? (
+              <DensityNavigator
+                extent={extent}
+                viewport={viewport}
+                densityBuckets={densityBuckets}
+                onViewportChange={applyViewport}
+              />
+            ) : null}
+          </>
+        )}
       </section>
 
       {/* Archive coverage stays available behind a collapsed details element */}

--- a/apps/chronicle/web/src/routes/ChroniclePage.tsx
+++ b/apps/chronicle/web/src/routes/ChroniclePage.tsx
@@ -1,4 +1,17 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
 import type { ArchiveSummary } from '../api/types'
+import { DensityNavigator } from '../chronicle/DensityNavigator'
+import { TimelineCanvas } from '../chronicle/TimelineCanvas'
+import { TimelineTable } from '../chronicle/TimelineTable'
+import { TimelineToolbar } from '../chronicle/TimelineToolbar'
+import {
+  clampViewport,
+  MIN_SPAN_MS,
+  type Viewport,
+  zoomViewport,
+} from '../chronicle/timeScale'
+import { useChronicleBuckets } from '../chronicle/useChronicleBuckets'
 import { useArchiveSummary } from './useArchiveSummary'
 
 function SummarySkeleton() {
@@ -25,8 +38,7 @@ function formatYear(iso: string | null): string {
 function CoverageTable({ data }: { data: ArchiveSummary }) {
   const { counts, extraction, embedding, date_range } = data
   return (
-    <div className="rounded-lg border border-steel bg-graphite-900 p-4">
-      <h2 className="mb-3 text-sm font-medium text-text-primary">Archive coverage</h2>
+    <div>
       <table className="w-full border-collapse text-left">
         <tbody className="tabular-nums font-mono text-text-primary">
           <tr className="border-b border-steel">
@@ -84,33 +96,255 @@ function CoverageTable({ data }: { data: ArchiveSummary }) {
   )
 }
 
+/** Sentinel full-range viewport used only for the bootstrap extent fetch. */
+const BOOTSTRAP_VIEWPORT: Viewport = {
+  fromMs: Date.parse('1970-01-01T00:00:00.000Z'),
+  toMs: Date.parse('2100-01-01T00:00:00.000Z'),
+}
+
+function extentFromResponse(
+  from: string | null | undefined,
+  to: string | null | undefined,
+): Viewport | null {
+  if (!from || !to) return null
+  const fromMs = Date.parse(from)
+  const toMs = Date.parse(to)
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs) || toMs <= fromMs) {
+    return null
+  }
+  return { fromMs, toMs }
+}
+
 export function ChroniclePage() {
-  const { data, isLoading, isError, error, refetch, isFetching } = useArchiveSummary()
+  const archive = useArchiveSummary()
+
+  // Owns viewport, brush, viewMode state.
+  // Bootstrap: fetch once with sentinel full-range viewport 1970-01-01..2100-01-01,
+  // then set viewport := extent from the first response.
+  const [viewport, setViewport] = useState<Viewport | null>(null)
+  const [brush, setBrush] = useState<Viewport | null>(null)
+  const [viewMode, setViewMode] = useState<'canvas' | 'table'>('canvas')
+  const [pixelWidth, setPixelWidth] = useState(920)
+  const [bootstrapped, setBootstrapped] = useState(false)
+
+  const activeViewport = viewport ?? BOOTSTRAP_VIEWPORT
+
+  const buckets = useChronicleBuckets({
+    viewport: activeViewport,
+    pixelWidth,
+    enabled: pixelWidth > 0,
+  })
+
+  const extent = useMemo(() => {
+    if (buckets.data?.extent) {
+      return extentFromResponse(buckets.data.extent.from, buckets.data.extent.to)
+    }
+    return null
+  }, [buckets.data?.extent])
+
+  // Apply bootstrap: first response with extent sets viewport := extent
+  useEffect(() => {
+    if (bootstrapped) return
+    if (!buckets.data?.extent) return
+    const ext = extentFromResponse(buckets.data.extent.from, buckets.data.extent.to)
+    if (!ext) {
+      setBootstrapped(true)
+      return
+    }
+    setViewport(ext)
+    setBootstrapped(true)
+  }, [bootstrapped, buckets.data?.extent])
+
+  const applyViewport = useCallback(
+    (next: Viewport) => {
+      if (extent) {
+        setViewport(clampViewport(next, extent, MIN_SPAN_MS))
+      } else {
+        setViewport(next)
+      }
+    },
+    [extent],
+  )
+
+  const onWidthChange = useCallback((w: number) => {
+    if (w > 0) setPixelWidth(w)
+  }, [])
+
+  const zoomAroundCenter = useCallback(
+    (factor: number) => {
+      if (!viewport) return
+      const centerPx = pixelWidth / 2
+      applyViewport(zoomViewport(viewport, factor, centerPx, Math.max(1, pixelWidth)))
+    },
+    [applyViewport, pixelWidth, viewport],
+  )
+
+  // Keyboard shortcuts [ / ] zoom out/in around center — page-scoped, cleaned up on unmount.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return
+      }
+      if (e.key === '[') {
+        e.preventDefault()
+        zoomAroundCenter(2) // zoom out
+      } else if (e.key === ']') {
+        e.preventDefault()
+        zoomAroundCenter(0.5) // zoom in
+      } else if (e.key === 'Escape') {
+        setBrush(null)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [zoomAroundCenter])
+
+  const messages = buckets.data?.lanes.messages ?? []
+  const attachments = buckets.data?.lanes.attachments ?? []
+  const unit = buckets.data?.unit ?? buckets.data?.aggregation ?? 'month'
+  const densityBuckets = buckets.data?.density.buckets ?? []
+
+  const showTimeline = viewport != null
 
   return (
     <div className="space-y-4">
       <h1 className="text-base font-medium text-text-primary">Chronicle</h1>
-      {isLoading ? <SummarySkeleton /> : null}
-      {isError ? (
-        <div
-          role="alert"
-          className="rounded-lg border border-conflict bg-graphite-900 p-4 text-conflict"
-        >
-          <p className="mb-2">
-            Failed to load archive coverage
-            {error instanceof Error ? `: ${error.message}` : ''}
-          </p>
-          <button
-            type="button"
-            onClick={() => void refetch()}
-            disabled={isFetching}
-            className="rounded-md border border-steel bg-graphite-800 px-3 py-1.5 text-text-primary"
+
+      {/* Timeline region */}
+      <section className="space-y-2" aria-label="Timeline">
+        {showTimeline ? (
+          <TimelineToolbar
+            viewport={viewport}
+            unit={unit}
+            brush={brush}
+            viewMode={viewMode}
+            onZoomIn={() => zoomAroundCenter(0.5)}
+            onZoomOut={() => zoomAroundCenter(2)}
+            onFitAll={() => {
+              if (extent) applyViewport(extent)
+            }}
+            onZoomToSelection={() => {
+              if (brush) {
+                applyViewport(brush)
+                setBrush(null)
+              }
+            }}
+            onClearSelection={() => setBrush(null)}
+            onToggleViewMode={() =>
+              setViewMode((m) => (m === 'canvas' ? 'table' : 'canvas'))
+            }
+          />
+        ) : null}
+
+        {buckets.isError ? (
+          <div
+            role="alert"
+            data-testid="timeline-error"
+            className="rounded-lg border border-conflict bg-graphite-900 p-4 text-conflict"
           >
-            Retry
-          </button>
+            <p className="mb-2">
+              Failed to load timeline
+              {buckets.error instanceof Error ? `: ${buckets.error.message}` : ''}
+            </p>
+            <button
+              type="button"
+              onClick={() => void buckets.refetch()}
+              disabled={buckets.isFetching}
+              className="rounded-md border border-steel bg-graphite-800 px-3 py-1.5 text-text-primary"
+            >
+              Retry
+            </button>
+          </div>
+        ) : null}
+
+        {/* Keep prior data visible on error when present */}
+        {showTimeline && (buckets.data || !buckets.isError) ? (
+          viewMode === 'table' ? (
+            <TimelineTable
+              viewport={viewport}
+              unit={unit}
+              messages={messages}
+              attachments={attachments}
+            />
+          ) : (
+            <TimelineCanvas
+              viewport={viewport}
+              extent={extent}
+              unit={unit}
+              messages={messages}
+              attachments={attachments}
+              isFetching={buckets.isFetching}
+              brush={brush}
+              onViewportChange={applyViewport}
+              onBrushChange={setBrush}
+              onWidthChange={onWidthChange}
+            />
+          )
+        ) : null}
+
+        {/* Bootstrap: measure width even before viewport is set */}
+        {!showTimeline && !buckets.isError ? (
+          <div
+            className="h-40 w-full rounded-lg border border-steel bg-graphite-900"
+            ref={(el) => {
+              if (el) {
+                const w = el.clientWidth
+                if (w > 0 && w !== pixelWidth) setPixelWidth(w)
+              }
+            }}
+            data-testid="timeline-bootstrap"
+            aria-busy={buckets.isLoading || buckets.isFetching}
+            aria-label="Loading timeline"
+          >
+            <div className="h-0.5 w-full animate-pulse bg-action" />
+          </div>
+        ) : null}
+
+        {showTimeline && extent ? (
+          <DensityNavigator
+            extent={extent}
+            viewport={viewport}
+            densityBuckets={densityBuckets}
+            onViewportChange={applyViewport}
+          />
+        ) : null}
+      </section>
+
+      {/* Archive coverage stays available behind a collapsed details element */}
+      <details className="rounded-lg border border-steel bg-graphite-900">
+        <summary className="cursor-pointer px-4 py-2 text-sm font-medium text-text-primary">
+          Archive coverage
+        </summary>
+        <div className="space-y-2 border-t border-steel p-4">
+          {archive.isLoading ? <SummarySkeleton /> : null}
+          {archive.isError ? (
+            <div
+              role="alert"
+              className="rounded-lg border border-conflict bg-graphite-900 p-4 text-conflict"
+            >
+              <p className="mb-2">
+                Failed to load archive coverage
+                {archive.error instanceof Error ? `: ${archive.error.message}` : ''}
+              </p>
+              <button
+                type="button"
+                onClick={() => void archive.refetch()}
+                disabled={archive.isFetching}
+                className="rounded-md border border-steel bg-graphite-800 px-3 py-1.5 text-text-primary"
+              >
+                Retry
+              </button>
+            </div>
+          ) : null}
+          {archive.data ? <CoverageTable data={archive.data} /> : null}
         </div>
-      ) : null}
-      {data ? <CoverageTable data={data} /> : null}
+      </details>
     </div>
   )
 }

--- a/apps/chronicle/web/src/shell/Inspector.tsx
+++ b/apps/chronicle/web/src/shell/Inspector.tsx
@@ -1,12 +1,27 @@
+import { InspectorPanel } from '../inspector/InspectorPanel'
+import { useWorkingSetStore } from '../workingset/store'
+
+/**
+ * Evidence inspector host. Content swaps on selection kind (bucket / message / none).
+ * Bucket count and unit are optional context; unit defaults to month in the panel.
+ */
 export function Inspector() {
+  // unit is refined by ChroniclePage via a lightweight store field if needed;
+  // for now InspectorPanel defaults unit for date_to computation.
+  const selection = useWorkingSetStore((s) => s.selection)
+  void selection // re-render on selection change
+
   return (
     <aside
-      className="flex flex-col border-l border-steel bg-graphite-900 p-3"
+      className="flex min-h-0 flex-col border-l border-steel bg-graphite-900 p-3"
       style={{ width: 360 }}
       aria-label="Evidence inspector"
+      data-testid="evidence-inspector"
     >
       <h2 className="mb-2 text-text-muted">Inspector</h2>
-      <p className="text-text-muted">Select a mark to inspect evidence</p>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <InspectorPanel />
+      </div>
     </aside>
   )
 }

--- a/apps/chronicle/web/src/shell/ScopeBar.tsx
+++ b/apps/chronicle/web/src/shell/ScopeBar.tsx
@@ -1,4 +1,53 @@
+import { useMemo, useState } from 'react'
+
+import { useArchiveSummary } from '../routes/useArchiveSummary'
+import { ScopeChipList, useScopeChips } from '../workingset/ScopeChips'
+import { useWorkingSetStore } from '../workingset/store'
+import { isScopePristine } from '../workingset/urlState'
+import { useUrlSync } from '../workingset/useUrlSync'
+
+const btnClass =
+  'rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-primary enabled:hover:bg-graphite-900 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-action'
+
 export function ScopeBar() {
+  // URL contract lives on the shell-mounted scope bar so working-set state
+  // hydrates once and persists across lens route changes.
+  useUrlSync()
+
+  const chips = useScopeChips()
+  const scope = useWorkingSetStore((s) => s.scope)
+  const resultCount = useWorkingSetStore((s) => s.resultCount)
+  const setScopeDate = useWorkingSetStore((s) => s.setScopeDate)
+  const addMailbox = useWorkingSetStore((s) => s.addMailbox)
+  const clearScope = useWorkingSetStore((s) => s.clearScope)
+
+  const archive = useArchiveSummary()
+  const accounts = archive.data?.accounts ?? []
+
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
+  const [showDateEditor, setShowDateEditor] = useState(false)
+  const [showMailboxPicker, setShowMailboxPicker] = useState(false)
+
+  const pristine = useMemo(() => isScopePristine(scope), [scope])
+
+  const applyDateRange = () => {
+    if (!dateFrom && !dateTo) {
+      setScopeDate(null)
+    } else {
+      setScopeDate({
+        ...(dateFrom ? { from: dateFrom } : {}),
+        ...(dateTo ? { to: dateTo } : {}),
+      })
+    }
+    setShowDateEditor(false)
+  }
+
+  const framing =
+    resultCount != null
+      ? `${resultCount.toLocaleString()} messages in scope`
+      : null
+
   return (
     <div
       className="col-span-3 flex items-center gap-2 border-b border-steel bg-graphite-900 px-3"
@@ -6,16 +55,122 @@ export function ScopeBar() {
       role="region"
       aria-label="Working set scope"
     >
-      <span className="rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-primary">
-        Archive: all mailboxes
-      </span>
-      <button
-        type="button"
-        disabled
-        className="rounded-md border border-steel px-2 py-1 text-text-muted disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        Reset working set
-      </button>
+      <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto">
+        <ScopeChipList chips={chips} />
+
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className={btnClass}
+            aria-expanded={showDateEditor}
+            aria-label="Add date filter"
+            onClick={() => {
+              setShowDateEditor((v) => !v)
+              setShowMailboxPicker(false)
+              setDateFrom(scope.date?.from ?? '')
+              setDateTo(scope.date?.to ?? '')
+            }}
+          >
+            Date
+          </button>
+          <button
+            type="button"
+            className={btnClass}
+            aria-expanded={showMailboxPicker}
+            aria-label="Add mailbox filter"
+            onClick={() => {
+              setShowMailboxPicker((v) => !v)
+              setShowDateEditor(false)
+            }}
+          >
+            Mailbox
+          </button>
+        </div>
+
+        {showDateEditor ? (
+          <div
+            className="flex items-center gap-1 rounded-md border border-steel bg-graphite-800 px-2 py-1"
+            data-testid="date-range-editor"
+          >
+            <label className="sr-only" htmlFor="scope-date-from">
+              Date from
+            </label>
+            <input
+              id="scope-date-from"
+              type="date"
+              value={dateFrom}
+              onChange={(e) => setDateFrom(e.target.value)}
+              className="rounded border border-steel bg-graphite-900 px-1 text-text-primary"
+            />
+            <span className="text-text-muted">–</span>
+            <label className="sr-only" htmlFor="scope-date-to">
+              Date to
+            </label>
+            <input
+              id="scope-date-to"
+              type="date"
+              value={dateTo}
+              onChange={(e) => setDateTo(e.target.value)}
+              className="rounded border border-steel bg-graphite-900 px-1 text-text-primary"
+            />
+            <button type="button" className={btnClass} onClick={applyDateRange}>
+              Apply
+            </button>
+          </div>
+        ) : null}
+
+        {showMailboxPicker ? (
+          <div
+            className="flex items-center gap-1 rounded-md border border-steel bg-graphite-800 px-2 py-1"
+            data-testid="mailbox-picker"
+          >
+            <label className="sr-only" htmlFor="scope-mailbox">
+              Mailbox
+            </label>
+            <select
+              id="scope-mailbox"
+              className="max-w-[12rem] rounded border border-steel bg-graphite-900 px-1 text-text-primary"
+              defaultValue=""
+              onChange={(e) => {
+                const v = e.target.value
+                if (v) {
+                  addMailbox(v)
+                  e.target.value = ''
+                  setShowMailboxPicker(false)
+                }
+              }}
+            >
+              <option value="" disabled>
+                Select mailbox…
+              </option>
+              {accounts.map((a) => (
+                <option key={a.account} value={a.account}>
+                  {a.account}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        {framing ? (
+          <span
+            className="tabular-nums text-text-muted"
+            data-testid="scope-result-count"
+          >
+            {framing}
+          </span>
+        ) : null}
+        <button
+          type="button"
+          className={btnClass}
+          disabled={pristine}
+          onClick={() => clearScope()}
+        >
+          Reset scope
+        </button>
+      </div>
     </div>
   )
 }

--- a/apps/chronicle/web/src/workingset/ScopeBar.test.tsx
+++ b/apps/chronicle/web/src/workingset/ScopeBar.test.tsx
@@ -1,0 +1,115 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ScopeBar } from '../shell/ScopeBar'
+import { resetWorkingSetStore, useWorkingSetStore } from './store'
+
+function renderScopeBar() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <ScopeBar />
+    </QueryClientProvider>,
+  )
+}
+
+describe('ScopeBar', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/')
+    resetWorkingSetStore()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          accounts: [
+            { account: 'me@example.com', messages: 100 },
+            { account: 'work@example.com', messages: 50 },
+          ],
+          date_range: { from: '2010-01-01', to: '2024-01-01' },
+          counts: { messages: 1, threads: 1, attachments: 0, contacts: 0 },
+          extraction: { extracted: 0, failed: 0, skipped: 0, pending: 0 },
+          embedding: { embedded: 0, missing: 0 },
+          versions: { schema: 'maildb', api: '0.1.0' },
+        }),
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.history.replaceState(null, '', '/')
+    resetWorkingSetStore()
+  })
+
+  it('renders chips from store', () => {
+    renderScopeBar()
+    // After mount hydrate; then mutate store (analytical) so chips appear.
+    act(() => {
+      useWorkingSetStore.getState().setScopeDate({ from: '2014-01-01', to: '2018-12-31' })
+      useWorkingSetStore.getState().addMailbox('me@example.com')
+      useWorkingSetStore.getState().addSender('alice@x.com')
+    })
+
+    const region = screen.getByRole('region', { name: 'Working set scope' })
+    expect(within(region).getByLabelText('Date: 2014 – 2018')).toBeInTheDocument()
+    expect(within(region).getByLabelText('Mailbox: me@example.com')).toBeInTheDocument()
+    expect(within(region).getByLabelText('Sender: alice@x.com')).toBeInTheDocument()
+  })
+
+  it('remove button updates store', () => {
+    renderScopeBar()
+    act(() => {
+      useWorkingSetStore.getState().addMailbox('me@example.com')
+    })
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove filter Mailbox me@example.com' }),
+    )
+    expect(useWorkingSetStore.getState().scope.mailboxes).toBeUndefined()
+  })
+
+  it('reset clears scope and is disabled when pristine', () => {
+    renderScopeBar()
+    const reset = screen.getByRole('button', { name: 'Reset scope' })
+    expect(reset).toBeDisabled()
+
+    act(() => {
+      useWorkingSetStore.getState().addMailbox('me@example.com')
+    })
+    expect(screen.getByRole('button', { name: 'Reset scope' })).not.toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset scope' }))
+    expect(useWorkingSetStore.getState().scope).toEqual({})
+    expect(screen.getByRole('button', { name: 'Reset scope' })).toBeDisabled()
+  })
+
+  it('arrow-key focus movement within chip list', () => {
+    renderScopeBar()
+    act(() => {
+      useWorkingSetStore.getState().setScopeDate({ from: '2014-01-01', to: '2015-01-01' })
+      useWorkingSetStore.getState().addMailbox('me@example.com')
+    })
+
+    const dateBtn = screen.getByRole('button', { name: 'Date: 2014 – 2015' })
+    const removeDate = screen.getByRole('button', {
+      name: 'Remove filter Date 2014 – 2015',
+    })
+    dateBtn.focus()
+    expect(document.activeElement).toBe(dateBtn)
+
+    fireEvent.keyDown(dateBtn, { key: 'ArrowRight' })
+    expect(document.activeElement).toBe(removeDate)
+
+    fireEvent.keyDown(removeDate, { key: 'ArrowRight' })
+    const mailboxBtn = screen.getByRole('button', { name: 'Mailbox: me@example.com' })
+    expect(document.activeElement).toBe(mailboxBtn)
+
+    fireEvent.keyDown(mailboxBtn, { key: 'ArrowLeft' })
+    expect(document.activeElement).toBe(removeDate)
+  })
+})

--- a/apps/chronicle/web/src/workingset/ScopeChips.tsx
+++ b/apps/chronicle/web/src/workingset/ScopeChips.tsx
@@ -1,0 +1,150 @@
+import { type KeyboardEvent, useRef } from 'react'
+
+import type { QueryScope } from '../api/types'
+import { useWorkingSetStore } from './store'
+
+export interface ScopeChipItem {
+  id: string
+  category: 'Date' | 'Mailbox' | 'Sender'
+  label: string
+  onRemove: () => void
+  removeAriaLabel: string
+}
+
+export function chipsFromScope(
+  scope: QueryScope,
+  actions: {
+    setScopeDate: (date: null) => void
+    removeMailbox: (m: string) => void
+    removeSender: (s: string) => void
+  },
+): ScopeChipItem[] {
+  const chips: ScopeChipItem[] = []
+
+  if (scope.date?.from || scope.date?.to) {
+    const fromY = scope.date.from?.slice(0, 4) ?? '…'
+    const toY = scope.date.to?.slice(0, 4) ?? '…'
+    const value = `${fromY} – ${toY}`
+    chips.push({
+      id: 'date',
+      category: 'Date',
+      label: `Date: ${value}`,
+      removeAriaLabel: `Remove filter Date ${value}`,
+      onRemove: () => actions.setScopeDate(null),
+    })
+  }
+
+  for (const mb of scope.mailboxes ?? []) {
+    chips.push({
+      id: `mailbox:${mb}`,
+      category: 'Mailbox',
+      label: `Mailbox: ${mb}`,
+      removeAriaLabel: `Remove filter Mailbox ${mb}`,
+      onRemove: () => actions.removeMailbox(mb),
+    })
+  }
+
+  for (const sd of scope.senders ?? []) {
+    chips.push({
+      id: `sender:${sd}`,
+      category: 'Sender',
+      label: `Sender: ${sd}`,
+      removeAriaLabel: `Remove filter Sender ${sd}`,
+      onRemove: () => actions.removeSender(sd),
+    })
+  }
+
+  return chips
+}
+
+const chipClass =
+  'inline-flex items-center gap-1 rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-action'
+
+const removeClass =
+  'rounded px-1 text-text-muted hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-action'
+
+/**
+ * Keyboard-reachable chip list: each chip is a button group; Left/Right
+ * moves focus within the bar.
+ */
+export function ScopeChipList({ chips }: { chips: ScopeChipItem[] }) {
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+    const root = listRef.current
+    if (!root) return
+    const focusables = Array.from(
+      root.querySelectorAll<HTMLElement>('[data-scope-chip-focus]'),
+    )
+    if (focusables.length === 0) return
+    const active = document.activeElement as HTMLElement | null
+    const idx = focusables.indexOf(active as HTMLElement)
+    if (idx < 0) return
+    e.preventDefault()
+    const next =
+      e.key === 'ArrowRight'
+        ? Math.min(focusables.length - 1, idx + 1)
+        : Math.max(0, idx - 1)
+    focusables[next]?.focus()
+  }
+
+  if (chips.length === 0) {
+    return (
+      <span className="rounded-md border border-steel bg-graphite-800 px-2 py-1 text-text-muted">
+        Archive: all mailboxes
+      </span>
+    )
+  }
+
+  return (
+    <div
+      ref={listRef}
+      className="flex flex-wrap items-center gap-1"
+      role="list"
+      aria-label="Scope filters"
+      onKeyDown={onKeyDown}
+    >
+      {chips.map((chip) => (
+        <span
+          key={chip.id}
+          role="listitem"
+          className={chipClass}
+          data-testid={`scope-chip-${chip.category.toLowerCase()}`}
+        >
+          <button
+            type="button"
+            data-scope-chip-focus
+            className="text-left"
+            aria-label={chip.label}
+          >
+            <span className="text-text-muted">{chip.category}:</span>{' '}
+            {chip.label.replace(/^[^:]+:\s*/, '')}
+          </button>
+          <button
+            type="button"
+            data-scope-chip-focus
+            className={removeClass}
+            aria-label={chip.removeAriaLabel}
+            onClick={chip.onRemove}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+/** Hook-friendly chip builder bound to the working-set store. */
+export function useScopeChips(): ScopeChipItem[] {
+  const scope = useWorkingSetStore((s) => s.scope)
+  const setScopeDate = useWorkingSetStore((s) => s.setScopeDate)
+  const removeMailbox = useWorkingSetStore((s) => s.removeMailbox)
+  const removeSender = useWorkingSetStore((s) => s.removeSender)
+  return chipsFromScope(scope, {
+    setScopeDate: () => setScopeDate(null),
+    removeMailbox,
+    removeSender,
+  })
+}

--- a/apps/chronicle/web/src/workingset/store.test.ts
+++ b/apps/chronicle/web/src/workingset/store.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { resetWorkingSetStore, useWorkingSetStore } from './store'
+
+describe('working set store', () => {
+  beforeEach(() => {
+    resetWorkingSetStore()
+  })
+
+  it('setViewport is transient and does not clear brush', () => {
+    const brush = { fromMs: 1, toMs: 2 }
+    useWorkingSetStore.getState().setBrush(brush)
+    useWorkingSetStore.getState().setViewport({ fromMs: 10, toMs: 20 })
+    const s = useWorkingSetStore.getState()
+    expect(s.viewport).toEqual({ fromMs: 10, toMs: 20 })
+    expect(s.brush).toEqual(brush)
+    expect(s.historyIntent).toBe('transient')
+  })
+
+  it('applyBrushAsViewport sets viewport, clears brush, analytical', () => {
+    useWorkingSetStore.getState().setBrush({ fromMs: 100, toMs: 200 })
+    useWorkingSetStore.getState().applyBrushAsViewport()
+    const s = useWorkingSetStore.getState()
+    expect(s.viewport).toEqual({ fromMs: 100, toMs: 200 })
+    expect(s.brush).toBeNull()
+    expect(s.historyIntent).toBe('analytical')
+  })
+
+  it('applyBrushAsViewport is a no-op without brush', () => {
+    useWorkingSetStore.getState().setViewport({ fromMs: 1, toMs: 2 })
+    useWorkingSetStore.getState().applyBrushAsViewport()
+    expect(useWorkingSetStore.getState().viewport).toEqual({ fromMs: 1, toMs: 2 })
+  })
+
+  it('scope date / mailbox / sender mutations are analytical', () => {
+    useWorkingSetStore.getState().setScopeDate({ from: '2014-01-01', to: '2018-01-01' })
+    expect(useWorkingSetStore.getState().scope.date).toEqual({
+      from: '2014-01-01',
+      to: '2018-01-01',
+    })
+    expect(useWorkingSetStore.getState().historyIntent).toBe('analytical')
+
+    useWorkingSetStore.getState().addMailbox('a@b.com')
+    useWorkingSetStore.getState().addMailbox('a@b.com') // dedupe
+    expect(useWorkingSetStore.getState().scope.mailboxes).toEqual(['a@b.com'])
+
+    useWorkingSetStore.getState().addSender('s@t.com')
+    expect(useWorkingSetStore.getState().scope.senders).toEqual(['s@t.com'])
+
+    useWorkingSetStore.getState().removeMailbox('a@b.com')
+    expect(useWorkingSetStore.getState().scope.mailboxes).toBeUndefined()
+
+    useWorkingSetStore.getState().removeSender('s@t.com')
+    expect(useWorkingSetStore.getState().scope.senders).toBeUndefined()
+  })
+
+  it('clearScope empties constraints', () => {
+    useWorkingSetStore.getState().setScopeDate({ from: '2014-01-01' })
+    useWorkingSetStore.getState().addMailbox('x@y.com')
+    useWorkingSetStore.getState().clearScope()
+    expect(useWorkingSetStore.getState().scope).toEqual({})
+    expect(useWorkingSetStore.getState().historyIntent).toBe('analytical')
+  })
+
+  it('setView and setAggregation are analytical', () => {
+    useWorkingSetStore.getState().setView('table')
+    expect(useWorkingSetStore.getState().view).toBe('table')
+    expect(useWorkingSetStore.getState().historyIntent).toBe('analytical')
+
+    useWorkingSetStore.getState().setAggregation('week')
+    expect(useWorkingSetStore.getState().aggregation).toBe('week')
+  })
+
+  it('hydrate restores decoded fields and clears brush silently', () => {
+    useWorkingSetStore.getState().setBrush({ fromMs: 1, toMs: 2 })
+    useWorkingSetStore.getState().hydrate({
+      scope: { mailboxes: ['m@x.com'] },
+      viewport: { fromMs: 10, toMs: 20 },
+      aggregation: 'year',
+      view: 'table',
+    })
+    const s = useWorkingSetStore.getState()
+    expect(s.scope).toEqual({ mailboxes: ['m@x.com'] })
+    expect(s.viewport).toEqual({ fromMs: 10, toMs: 20 })
+    expect(s.aggregation).toBe('year')
+    expect(s.view).toBe('table')
+    expect(s.brush).toBeNull()
+    expect(s.historyIntent).toBe('silent')
+  })
+})

--- a/apps/chronicle/web/src/workingset/store.test.ts
+++ b/apps/chronicle/web/src/workingset/store.test.ts
@@ -125,4 +125,64 @@ describe('working set store', () => {
     useWorkingSetStore.getState().toggleLane('messages')
     expect(useWorkingSetStore.getState().lanes).toEqual(['messages'])
   })
+
+  it('setFocus is analytical and clears brush', () => {
+    useWorkingSetStore.getState().setBrush({ fromMs: 1, toMs: 2 })
+    useWorkingSetStore.getState().setFocus({
+      fromMs: Date.UTC(2015, 0, 1),
+      toMs: Date.UTC(2016, 0, 1),
+    })
+    const s = useWorkingSetStore.getState()
+    expect(s.focus).toEqual({
+      fromMs: Date.UTC(2015, 0, 1),
+      toMs: Date.UTC(2016, 0, 1),
+    })
+    expect(s.brush).toBeNull()
+    expect(s.historyIntent).toBe('analytical')
+  })
+
+  it('exitFocus clears focus analytically', () => {
+    useWorkingSetStore.getState().setFocus({
+      fromMs: Date.UTC(2015, 0, 1),
+      toMs: Date.UTC(2016, 0, 1),
+    })
+    useWorkingSetStore.getState().exitFocus()
+    expect(useWorkingSetStore.getState().focus).toBeNull()
+    expect(useWorkingSetStore.getState().historyIntent).toBe('analytical')
+  })
+
+  it('exitFocus is a no-op when not in focus', () => {
+    useWorkingSetStore.getState().setView('table')
+    useWorkingSetStore.getState().exitFocus()
+    expect(useWorkingSetStore.getState().focus).toBeNull()
+    expect(useWorkingSetStore.getState().view).toBe('table')
+  })
+
+  it('applyFocusAsScopeDate writes scope date and exits focus', () => {
+    useWorkingSetStore.getState().addMailbox('me@x.com')
+    useWorkingSetStore.getState().setFocus({
+      fromMs: Date.UTC(2014, 5, 15, 12, 0, 0),
+      toMs: Date.UTC(2015, 2, 1, 0, 0, 0),
+    })
+    useWorkingSetStore.getState().applyFocusAsScopeDate()
+    const s = useWorkingSetStore.getState()
+    expect(s.focus).toBeNull()
+    expect(s.scope.date).toEqual({ from: '2014-06-15', to: '2015-03-01' })
+    expect(s.scope.mailboxes).toEqual(['me@x.com'])
+    expect(s.historyIntent).toBe('analytical')
+  })
+
+  it('hydrate restores focus silently', () => {
+    useWorkingSetStore.getState().hydrate({
+      scope: {},
+      viewport: null,
+      aggregation: 'auto',
+      view: 'canvas',
+      selection: null,
+      lanes: null,
+      focus: { fromMs: 10, toMs: 20 },
+    })
+    expect(useWorkingSetStore.getState().focus).toEqual({ fromMs: 10, toMs: 20 })
+    expect(useWorkingSetStore.getState().historyIntent).toBe('silent')
+  })
 })

--- a/apps/chronicle/web/src/workingset/store.test.ts
+++ b/apps/chronicle/web/src/workingset/store.test.ts
@@ -78,13 +78,29 @@ describe('working set store', () => {
       viewport: { fromMs: 10, toMs: 20 },
       aggregation: 'year',
       view: 'table',
+      selection: { kind: 'message', sid: 'msg_1' },
     })
     const s = useWorkingSetStore.getState()
     expect(s.scope).toEqual({ mailboxes: ['m@x.com'] })
     expect(s.viewport).toEqual({ fromMs: 10, toMs: 20 })
     expect(s.aggregation).toBe('year')
     expect(s.view).toBe('table')
+    expect(s.selection).toEqual({ kind: 'message', sid: 'msg_1' })
     expect(s.brush).toBeNull()
     expect(s.historyIntent).toBe('silent')
+  })
+
+  it('setSelection is transient', () => {
+    useWorkingSetStore.getState().setSelection({
+      kind: 'bucket',
+      lane: 'messages',
+      bucketIso: '2014-01-01T00:00:00.000Z',
+    })
+    const s = useWorkingSetStore.getState()
+    expect(s.selection?.kind).toBe('bucket')
+    expect(s.historyIntent).toBe('transient')
+
+    useWorkingSetStore.getState().setSelection(null)
+    expect(useWorkingSetStore.getState().selection).toBeNull()
   })
 })

--- a/apps/chronicle/web/src/workingset/store.test.ts
+++ b/apps/chronicle/web/src/workingset/store.test.ts
@@ -79,6 +79,7 @@ describe('working set store', () => {
       aggregation: 'year',
       view: 'table',
       selection: { kind: 'message', sid: 'msg_1' },
+      lanes: ['people', 'messages'],
     })
     const s = useWorkingSetStore.getState()
     expect(s.scope).toEqual({ mailboxes: ['m@x.com'] })
@@ -86,6 +87,7 @@ describe('working set store', () => {
     expect(s.aggregation).toBe('year')
     expect(s.view).toBe('table')
     expect(s.selection).toEqual({ kind: 'message', sid: 'msg_1' })
+    expect(s.lanes).toEqual(['people', 'messages'])
     expect(s.brush).toBeNull()
     expect(s.historyIntent).toBe('silent')
   })
@@ -102,5 +104,25 @@ describe('working set store', () => {
 
     useWorkingSetStore.getState().setSelection(null)
     expect(useWorkingSetStore.getState().selection).toBeNull()
+  })
+
+  it('toggleLane and moveLane are analytical', () => {
+    // default: messages, attachments, top_people
+    useWorkingSetStore.getState().toggleLane('people')
+    expect(useWorkingSetStore.getState().lanes).toContain('people')
+    expect(useWorkingSetStore.getState().historyIntent).toBe('analytical')
+
+    useWorkingSetStore.getState().moveLane('people', 'up')
+    const afterUp = useWorkingSetStore.getState().lanes
+    expect(afterUp.indexOf('people')).toBeLessThan(afterUp.length - 1)
+
+    useWorkingSetStore.getState().toggleLane('people')
+    expect(useWorkingSetStore.getState().lanes).not.toContain('people')
+  })
+
+  it('toggleLane refuses to hide the last lane', () => {
+    useWorkingSetStore.setState({ lanes: ['messages'] })
+    useWorkingSetStore.getState().toggleLane('messages')
+    expect(useWorkingSetStore.getState().lanes).toEqual(['messages'])
   })
 })

--- a/apps/chronicle/web/src/workingset/store.ts
+++ b/apps/chronicle/web/src/workingset/store.ts
@@ -5,13 +5,14 @@ import type { Viewport } from '../chronicle/timeScale'
 import {
   type Aggregation,
   DEFAULT_URL_STATE,
+  type Selection,
   type UrlWorkingState,
   type ViewMode,
 } from './urlState'
 
 /**
  * History intent set by actions so useUrlSync can apply the URL contract:
- * - transient → debounced replaceState (pan/zoom)
+ * - transient → debounced replaceState (pan/zoom, selection)
  * - analytical → immediate pushState (scope, brush-apply, view, …)
  * - silent → no URL write (hydrate, brush drag, result count)
  */
@@ -23,8 +24,17 @@ export interface WorkingSetState {
   aggregation: Aggregation
   view: ViewMode
   brush: Viewport | null
+  /** Timeline / inspector selection; URL param `sel`; transient intent. */
+  selection: Selection
+  /**
+   * Last bucket selection — used by MessageCard Close to restore bucket view.
+   * Not URL-serialised.
+   */
+  priorBucket: Extract<Selection, { kind: 'bucket' }> | null
   /** Live framing for the scope bar; not URL-serialised. */
   resultCount: number | null
+  /** Current timeline aggregation unit (for bucket date_to); not URL-serialised. */
+  timelineUnit: string | null
   historyIntent: HistoryIntent
 
   setViewport: (viewport: Viewport) => void
@@ -38,7 +48,10 @@ export interface WorkingSetState {
   clearScope: () => void
   setView: (view: ViewMode) => void
   setAggregation: (aggregation: Aggregation) => void
+  setSelection: (selection: Selection) => void
+  clearMessageToBucket: () => void
   setResultCount: (count: number | null) => void
+  setTimelineUnit: (unit: string | null) => void
   hydrate: (decoded: UrlWorkingState) => void
 }
 
@@ -50,7 +63,10 @@ export const useWorkingSetStore = create<WorkingSetState>((set, get) => ({
   aggregation: DEFAULT_URL_STATE.aggregation,
   view: DEFAULT_URL_STATE.view,
   brush: null,
+  selection: DEFAULT_URL_STATE.selection,
+  priorBucket: null,
   resultCount: null,
+  timelineUnit: null,
   historyIntent: 'silent',
 
   setViewport: (viewport) =>
@@ -129,7 +145,30 @@ export const useWorkingSetStore = create<WorkingSetState>((set, get) => ({
   setAggregation: (aggregation) =>
     set({ aggregation, historyIntent: 'analytical' }),
 
+  setSelection: (selection) => {
+    const prev = get().selection
+    let priorBucket = get().priorBucket
+    if (selection?.kind === 'bucket') {
+      priorBucket = selection
+    } else if (selection?.kind === 'message' && prev?.kind === 'bucket') {
+      priorBucket = prev
+    } else if (selection == null) {
+      priorBucket = null
+    }
+    set({ selection, priorBucket, historyIntent: 'transient' })
+  },
+
+  clearMessageToBucket: () => {
+    const prior = get().priorBucket
+    set({
+      selection: prior,
+      historyIntent: 'transient',
+    })
+  },
+
   setResultCount: (count) => set({ resultCount: count, historyIntent: 'silent' }),
+
+  setTimelineUnit: (unit) => set({ timelineUnit: unit, historyIntent: 'silent' }),
 
   hydrate: (decoded) =>
     set({
@@ -137,6 +176,9 @@ export const useWorkingSetStore = create<WorkingSetState>((set, get) => ({
       viewport: decoded.viewport,
       aggregation: decoded.aggregation,
       view: decoded.view,
+      selection: decoded.selection ?? null,
+      priorBucket:
+        decoded.selection?.kind === 'bucket' ? decoded.selection : get().priorBucket,
       brush: null,
       historyIntent: 'silent',
     }),
@@ -150,7 +192,10 @@ export function resetWorkingSetStore(): void {
     aggregation: 'auto',
     view: 'canvas',
     brush: null,
+    selection: null,
+    priorBucket: null,
     resultCount: null,
+    timelineUnit: null,
     historyIntent: 'silent',
   })
 }

--- a/apps/chronicle/web/src/workingset/store.ts
+++ b/apps/chronicle/web/src/workingset/store.ts
@@ -4,7 +4,9 @@ import type { QueryScope, QueryScopeDate } from '../api/types'
 import type { Viewport } from '../chronicle/timeScale'
 import {
   type Aggregation,
+  DEFAULT_LANES,
   DEFAULT_URL_STATE,
+  resolveLanes,
   type Selection,
   type UrlWorkingState,
   type ViewMode,
@@ -13,10 +15,12 @@ import {
 /**
  * History intent set by actions so useUrlSync can apply the URL contract:
  * - transient → debounced replaceState (pan/zoom, selection)
- * - analytical → immediate pushState (scope, brush-apply, view, …)
+ * - analytical → immediate pushState (scope, brush-apply, view, lanes, …)
  * - silent → no URL write (hydrate, brush drag, result count)
  */
 export type HistoryIntent = 'transient' | 'analytical' | 'silent'
+
+export type MoveLaneDir = 'up' | 'down'
 
 export interface WorkingSetState {
   scope: QueryScope
@@ -35,6 +39,8 @@ export interface WorkingSetState {
   resultCount: number | null
   /** Current timeline aggregation unit (for bucket date_to); not URL-serialised. */
   timelineUnit: string | null
+  /** Ordered visible lane keys; URL param `ln`; analytical intent. */
+  lanes: string[]
   historyIntent: HistoryIntent
 
   setViewport: (viewport: Viewport) => void
@@ -52,6 +58,8 @@ export interface WorkingSetState {
   clearMessageToBucket: () => void
   setResultCount: (count: number | null) => void
   setTimelineUnit: (unit: string | null) => void
+  toggleLane: (key: string) => void
+  moveLane: (key: string, dir: MoveLaneDir) => void
   hydrate: (decoded: UrlWorkingState) => void
 }
 
@@ -67,6 +75,7 @@ export const useWorkingSetStore = create<WorkingSetState>((set, get) => ({
   priorBucket: null,
   resultCount: null,
   timelineUnit: null,
+  lanes: [...DEFAULT_LANES],
   historyIntent: 'silent',
 
   setViewport: (viewport) =>
@@ -170,6 +179,31 @@ export const useWorkingSetStore = create<WorkingSetState>((set, get) => ({
 
   setTimelineUnit: (unit) => set({ timelineUnit: unit, historyIntent: 'silent' }),
 
+  toggleLane: (key) => {
+    const current = get().lanes
+    const idx = current.indexOf(key)
+    let next: string[]
+    if (idx >= 0) {
+      // Keep at least one lane visible.
+      if (current.length <= 1) return
+      next = current.filter((k) => k !== key)
+    } else {
+      next = [...current, key]
+    }
+    set({ lanes: next, historyIntent: 'analytical' })
+  },
+
+  moveLane: (key, dir) => {
+    const current = get().lanes
+    const idx = current.indexOf(key)
+    if (idx < 0) return
+    const swapWith = dir === 'up' ? idx - 1 : idx + 1
+    if (swapWith < 0 || swapWith >= current.length) return
+    const next = [...current]
+    ;[next[idx], next[swapWith]] = [next[swapWith]!, next[idx]!]
+    set({ lanes: next, historyIntent: 'analytical' })
+  },
+
   hydrate: (decoded) =>
     set({
       scope: decoded.scope ?? emptyScope(),
@@ -179,6 +213,7 @@ export const useWorkingSetStore = create<WorkingSetState>((set, get) => ({
       selection: decoded.selection ?? null,
       priorBucket:
         decoded.selection?.kind === 'bucket' ? decoded.selection : get().priorBucket,
+      lanes: resolveLanes(decoded.lanes),
       brush: null,
       historyIntent: 'silent',
     }),
@@ -196,6 +231,7 @@ export function resetWorkingSetStore(): void {
     priorBucket: null,
     resultCount: null,
     timelineUnit: null,
+    lanes: [...DEFAULT_LANES],
     historyIntent: 'silent',
   })
 }

--- a/apps/chronicle/web/src/workingset/store.ts
+++ b/apps/chronicle/web/src/workingset/store.ts
@@ -28,6 +28,11 @@ export interface WorkingSetState {
   aggregation: Aggregation
   view: ViewMode
   brush: Viewport | null
+  /**
+   * Focus-mode period (temporary analytical workspace). URL params `ff`/`ft`.
+   * Analytical intent on enter/exit.
+   */
+  focus: Viewport | null
   /** Timeline / inspector selection; URL param `sel`; transient intent. */
   selection: Selection
   /**
@@ -46,6 +51,15 @@ export interface WorkingSetState {
   setViewport: (viewport: Viewport) => void
   setBrush: (brush: Viewport | null) => void
   applyBrushAsViewport: () => void
+  /** Enter focus mode on a period; clears brush; analytical. */
+  setFocus: (focus: Viewport) => void
+  /** Exit focus mode; analytical (URL drops ff/ft; Back is equivalent). */
+  exitFocus: () => void
+  /**
+   * Explicit confirmation: copy focus range into the scope date filter and
+   * exit focus (always temporary until this action). Analytical.
+   */
+  applyFocusAsScopeDate: () => void
   setScopeDate: (date: QueryScopeDate | null) => void
   addMailbox: (mailbox: string) => void
   removeMailbox: (mailbox: string) => void
@@ -63,6 +77,11 @@ export interface WorkingSetState {
   hydrate: (decoded: UrlWorkingState) => void
 }
 
+/** Format epoch ms as UTC ISO date (`YYYY-MM-DD`) for scope date filters. */
+function toIsoDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10)
+}
+
 const emptyScope = (): QueryScope => ({})
 
 export const useWorkingSetStore = create<WorkingSetState>((set, get) => ({
@@ -71,6 +90,7 @@ export const useWorkingSetStore = create<WorkingSetState>((set, get) => ({
   aggregation: DEFAULT_URL_STATE.aggregation,
   view: DEFAULT_URL_STATE.view,
   brush: null,
+  focus: null,
   selection: DEFAULT_URL_STATE.selection,
   priorBucket: null,
   resultCount: null,
@@ -89,6 +109,37 @@ export const useWorkingSetStore = create<WorkingSetState>((set, get) => ({
     set({
       viewport: brush,
       brush: null,
+      historyIntent: 'analytical',
+    })
+  },
+
+  setFocus: (focus) => {
+    if (!focus || !(focus.toMs > focus.fromMs)) return
+    set({
+      focus: { fromMs: focus.fromMs, toMs: focus.toMs },
+      brush: null,
+      historyIntent: 'analytical',
+    })
+  },
+
+  exitFocus: () => {
+    if (get().focus == null) return
+    set({ focus: null, historyIntent: 'analytical' })
+  },
+
+  applyFocusAsScopeDate: () => {
+    const { focus, scope } = get()
+    if (!focus) return
+    const nextScope = {
+      ...scope,
+      date: {
+        from: toIsoDate(focus.fromMs),
+        to: toIsoDate(focus.toMs),
+      },
+    }
+    set({
+      scope: nextScope,
+      focus: null,
       historyIntent: 'analytical',
     })
   },
@@ -214,6 +265,7 @@ export const useWorkingSetStore = create<WorkingSetState>((set, get) => ({
       priorBucket:
         decoded.selection?.kind === 'bucket' ? decoded.selection : get().priorBucket,
       lanes: resolveLanes(decoded.lanes),
+      focus: decoded.focus ?? null,
       brush: null,
       historyIntent: 'silent',
     }),
@@ -227,6 +279,7 @@ export function resetWorkingSetStore(): void {
     aggregation: 'auto',
     view: 'canvas',
     brush: null,
+    focus: null,
     selection: null,
     priorBucket: null,
     resultCount: null,

--- a/apps/chronicle/web/src/workingset/store.ts
+++ b/apps/chronicle/web/src/workingset/store.ts
@@ -1,0 +1,156 @@
+import { create } from 'zustand'
+
+import type { QueryScope, QueryScopeDate } from '../api/types'
+import type { Viewport } from '../chronicle/timeScale'
+import {
+  type Aggregation,
+  DEFAULT_URL_STATE,
+  type UrlWorkingState,
+  type ViewMode,
+} from './urlState'
+
+/**
+ * History intent set by actions so useUrlSync can apply the URL contract:
+ * - transient → debounced replaceState (pan/zoom)
+ * - analytical → immediate pushState (scope, brush-apply, view, …)
+ * - silent → no URL write (hydrate, brush drag, result count)
+ */
+export type HistoryIntent = 'transient' | 'analytical' | 'silent'
+
+export interface WorkingSetState {
+  scope: QueryScope
+  viewport: Viewport | null
+  aggregation: Aggregation
+  view: ViewMode
+  brush: Viewport | null
+  /** Live framing for the scope bar; not URL-serialised. */
+  resultCount: number | null
+  historyIntent: HistoryIntent
+
+  setViewport: (viewport: Viewport) => void
+  setBrush: (brush: Viewport | null) => void
+  applyBrushAsViewport: () => void
+  setScopeDate: (date: QueryScopeDate | null) => void
+  addMailbox: (mailbox: string) => void
+  removeMailbox: (mailbox: string) => void
+  addSender: (sender: string) => void
+  removeSender: (sender: string) => void
+  clearScope: () => void
+  setView: (view: ViewMode) => void
+  setAggregation: (aggregation: Aggregation) => void
+  setResultCount: (count: number | null) => void
+  hydrate: (decoded: UrlWorkingState) => void
+}
+
+const emptyScope = (): QueryScope => ({})
+
+export const useWorkingSetStore = create<WorkingSetState>((set, get) => ({
+  scope: { ...DEFAULT_URL_STATE.scope },
+  viewport: DEFAULT_URL_STATE.viewport,
+  aggregation: DEFAULT_URL_STATE.aggregation,
+  view: DEFAULT_URL_STATE.view,
+  brush: null,
+  resultCount: null,
+  historyIntent: 'silent',
+
+  setViewport: (viewport) =>
+    set({ viewport, historyIntent: 'transient' }),
+
+  setBrush: (brush) => set({ brush, historyIntent: 'silent' }),
+
+  applyBrushAsViewport: () => {
+    const { brush } = get()
+    if (!brush) return
+    set({
+      viewport: brush,
+      brush: null,
+      historyIntent: 'analytical',
+    })
+  },
+
+  setScopeDate: (date) => {
+    const scope = { ...get().scope }
+    if (!date || (!date.from && !date.to)) {
+      delete scope.date
+    } else {
+      scope.date = {
+        ...(date.from ? { from: date.from } : {}),
+        ...(date.to ? { to: date.to } : {}),
+      }
+    }
+    set({ scope, historyIntent: 'analytical' })
+  },
+
+  addMailbox: (mailbox) => {
+    const trimmed = mailbox.trim()
+    if (!trimmed) return
+    const current = get().scope.mailboxes ?? []
+    if (current.includes(trimmed)) return
+    set({
+      scope: { ...get().scope, mailboxes: [...current, trimmed] },
+      historyIntent: 'analytical',
+    })
+  },
+
+  removeMailbox: (mailbox) => {
+    const current = get().scope.mailboxes ?? []
+    const next = current.filter((m) => m !== mailbox)
+    const scope = { ...get().scope }
+    if (next.length === 0) delete scope.mailboxes
+    else scope.mailboxes = next
+    set({ scope, historyIntent: 'analytical' })
+  },
+
+  addSender: (sender) => {
+    const trimmed = sender.trim()
+    if (!trimmed) return
+    const current = get().scope.senders ?? []
+    if (current.includes(trimmed)) return
+    set({
+      scope: { ...get().scope, senders: [...current, trimmed] },
+      historyIntent: 'analytical',
+    })
+  },
+
+  removeSender: (sender) => {
+    const current = get().scope.senders ?? []
+    const next = current.filter((s) => s !== sender)
+    const scope = { ...get().scope }
+    if (next.length === 0) delete scope.senders
+    else scope.senders = next
+    set({ scope, historyIntent: 'analytical' })
+  },
+
+  clearScope: () =>
+    set({ scope: emptyScope(), historyIntent: 'analytical' }),
+
+  setView: (view) => set({ view, historyIntent: 'analytical' }),
+
+  setAggregation: (aggregation) =>
+    set({ aggregation, historyIntent: 'analytical' }),
+
+  setResultCount: (count) => set({ resultCount: count, historyIntent: 'silent' }),
+
+  hydrate: (decoded) =>
+    set({
+      scope: decoded.scope ?? emptyScope(),
+      viewport: decoded.viewport,
+      aggregation: decoded.aggregation,
+      view: decoded.view,
+      brush: null,
+      historyIntent: 'silent',
+    }),
+}))
+
+/** Reset store to defaults (tests). Does not touch the URL. */
+export function resetWorkingSetStore(): void {
+  useWorkingSetStore.setState({
+    scope: emptyScope(),
+    viewport: null,
+    aggregation: 'auto',
+    view: 'canvas',
+    brush: null,
+    resultCount: null,
+    historyIntent: 'silent',
+  })
+}

--- a/apps/chronicle/web/src/workingset/urlState.test.ts
+++ b/apps/chronicle/web/src/workingset/urlState.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 
 import type { Unit } from '../chronicle/timeScale'
 import {
+  decodeSelection,
   decodeState,
   DEFAULT_URL_STATE,
+  encodeSelection,
   encodeState,
   isScopePristine,
   toIsoSeconds,
@@ -29,6 +31,11 @@ describe('encodeState / decodeState', () => {
       },
       aggregation: 'month',
       view: 'table',
+      selection: {
+        kind: 'bucket',
+        lane: 'messages',
+        bucketIso: '2014-06-01T00:00:00.000Z',
+      },
     }
 
     const encoded = encodeState(state)
@@ -41,6 +48,7 @@ describe('encodeState / decodeState', () => {
     expect(decoded.viewport?.toMs).toBe(state.viewport!.toMs)
     expect(decoded.aggregation).toBe('month')
     expect(decoded.view).toBe('table')
+    expect(decoded.selection).toEqual(state.selection)
 
     // Second roundtrip is stable
     expect(decodeState(encodeState(decoded))).toEqual(decoded)
@@ -125,5 +133,38 @@ describe('isScopePristine', () => {
     expect(isScopePristine({ date: { from: '2014-01-01' } })).toBe(false)
     expect(isScopePristine({ mailboxes: ['a@b.com'] })).toBe(false)
     expect(isScopePristine({ senders: ['x@y.com'] })).toBe(false)
+  })
+})
+
+describe('selection codec (sel)', () => {
+  it('roundtrips bucket and message selections', () => {
+    const bucket = {
+      kind: 'bucket' as const,
+      lane: 'messages',
+      bucketIso: '2014-01-01T00:00:00.000Z',
+    }
+    const msg = { kind: 'message' as const, sid: 'msg_12345' }
+    expect(decodeSelection(encodeSelection(bucket))).toEqual(bucket)
+    expect(decodeSelection(encodeSelection(msg))).toEqual(msg)
+    expect(encodeSelection(null)).toBeNull()
+    expect(decodeSelection(null)).toBeNull()
+  })
+
+  it('falls back to null on malformed values', () => {
+    expect(decodeSelection('')).toBeNull()
+    expect(decodeSelection('x:foo')).toBeNull()
+    expect(decodeSelection('b:')).toBeNull()
+    expect(decodeSelection('b:messages')).toBeNull()
+    expect(decodeSelection('b:messages:not-a-date')).toBeNull()
+    expect(decodeSelection('m:')).toBeNull()
+    expect(decodeSelection('m:bad')).toBeNull()
+  })
+
+  it('encodes into URL params via encodeState', () => {
+    const params = encodeState({
+      ...DEFAULT_URL_STATE,
+      selection: { kind: 'message', sid: 'msg_99' },
+    })
+    expect(params.get('sel')).toBe('m:msg_99')
   })
 })

--- a/apps/chronicle/web/src/workingset/urlState.test.ts
+++ b/apps/chronicle/web/src/workingset/urlState.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Unit } from '../chronicle/timeScale'
+import {
+  decodeState,
+  DEFAULT_URL_STATE,
+  encodeState,
+  isScopePristine,
+  toIsoSeconds,
+  type UrlWorkingState,
+} from './urlState'
+
+describe('encodeState / decodeState', () => {
+  it('pristine state encodes to empty query string', () => {
+    const params = encodeState(DEFAULT_URL_STATE)
+    expect(params.toString()).toBe('')
+  })
+
+  it('roundtrips full state including unicode addresses', () => {
+    const state: UrlWorkingState = {
+      scope: {
+        date: { from: '2014-01-01', to: '2018-12-31' },
+        mailboxes: ['personal@exämple.com', 'work@foo.com'],
+        senders: ['alice@x.com', '佐藤@例.jp'],
+      },
+      viewport: {
+        fromMs: Date.UTC(2014, 0, 1, 0, 0, 0),
+        toMs: Date.UTC(2015, 5, 15, 12, 30, 45),
+      },
+      aggregation: 'month',
+      view: 'table',
+    }
+
+    const encoded = encodeState(state)
+    const decoded = decodeState(encoded)
+
+    expect(decoded.scope.date).toEqual(state.scope.date)
+    expect(decoded.scope.mailboxes).toEqual(state.scope.mailboxes)
+    expect(decoded.scope.senders).toEqual(state.scope.senders)
+    expect(decoded.viewport?.fromMs).toBe(state.viewport!.fromMs)
+    expect(decoded.viewport?.toMs).toBe(state.viewport!.toMs)
+    expect(decoded.aggregation).toBe('month')
+    expect(decoded.view).toBe('table')
+
+    // Second roundtrip is stable
+    expect(decodeState(encodeState(decoded))).toEqual(decoded)
+  })
+
+  it('uses second-precision viewport ISO (no milliseconds)', () => {
+    const state: UrlWorkingState = {
+      ...DEFAULT_URL_STATE,
+      viewport: {
+        fromMs: Date.UTC(2014, 0, 1, 0, 0, 0),
+        toMs: Date.UTC(2014, 0, 2, 0, 0, 0),
+      },
+    }
+    const params = encodeState(state)
+    expect(params.get('vf')).toBe('2014-01-01T00:00:00Z')
+    expect(params.get('vt')).toBe('2014-01-02T00:00:00Z')
+    expect(params.get('vf')).not.toMatch(/\.\d{3}/)
+  })
+
+  it('omits canvas view and auto aggregation', () => {
+    const params = encodeState({
+      ...DEFAULT_URL_STATE,
+      scope: { mailboxes: ['a@b.com'] },
+      aggregation: 'auto',
+      view: 'canvas',
+    })
+    expect(params.has('view')).toBe(false)
+    expect(params.has('agg')).toBe(false)
+    expect(params.get('mb')).toBe('a@b.com')
+  })
+
+  it('bad params fall back to defaults without throwing', () => {
+    const params = new URLSearchParams({
+      df: 'not-a-date',
+      dt: '99-99-99',
+      vf: 'garbage',
+      vt: 'also-bad',
+      agg: 'fortnight',
+      view: 'map',
+      mb: '',
+      sd: ',,,',
+    })
+    const decoded = decodeState(params)
+    expect(decoded).toEqual(DEFAULT_URL_STATE)
+  })
+
+  it('rejects inverted or partial viewport', () => {
+    const inverted = decodeState(
+      new URLSearchParams({
+        vf: '2015-01-01T00:00:00Z',
+        vt: '2014-01-01T00:00:00Z',
+      }),
+    )
+    expect(inverted.viewport).toBeNull()
+
+    const partial = decodeState(
+      new URLSearchParams({ vf: '2014-01-01T00:00:00Z' }),
+    )
+    expect(partial.viewport).toBeNull()
+  })
+
+  it('accepts known aggregation units', () => {
+    const units: Unit[] = ['hour', 'day', 'week', 'month', 'quarter', 'year']
+    for (const u of units) {
+      expect(decodeState(new URLSearchParams({ agg: u })).aggregation).toBe(u)
+    }
+  })
+
+  it('toIsoSeconds strips milliseconds', () => {
+    expect(toIsoSeconds(Date.UTC(2014, 0, 1, 0, 0, 0, 123))).toBe(
+      '2014-01-01T00:00:00Z',
+    )
+  })
+})
+
+describe('isScopePristine', () => {
+  it('is true for empty scope', () => {
+    expect(isScopePristine({})).toBe(true)
+  })
+
+  it('is false when any constraint is set', () => {
+    expect(isScopePristine({ date: { from: '2014-01-01' } })).toBe(false)
+    expect(isScopePristine({ mailboxes: ['a@b.com'] })).toBe(false)
+    expect(isScopePristine({ senders: ['x@y.com'] })).toBe(false)
+  })
+})

--- a/apps/chronicle/web/src/workingset/urlState.test.ts
+++ b/apps/chronicle/web/src/workingset/urlState.test.ts
@@ -255,3 +255,41 @@ describe('lanes codec (ln) and saved lens', () => {
     expect(decodeState(new URLSearchParams()).lanes).toBeNull()
   })
 })
+
+describe('focus codec (ff/ft)', () => {
+  it('roundtrips focus period with second-precision ISO', () => {
+    const state: UrlWorkingState = {
+      ...DEFAULT_URL_STATE,
+      focus: {
+        fromMs: Date.UTC(2015, 0, 1, 0, 0, 0),
+        toMs: Date.UTC(2016, 5, 15, 12, 30, 0),
+      },
+    }
+    const params = encodeState(state)
+    expect(params.get('ff')).toBe('2015-01-01T00:00:00Z')
+    expect(params.get('ft')).toBe('2016-06-15T12:30:00Z')
+    expect(decodeState(params).focus).toEqual(state.focus)
+    expect(decodeState(encodeState(decodeState(params))).focus).toEqual(state.focus)
+  })
+
+  it('omits ff/ft when focus is null', () => {
+    const params = encodeState(DEFAULT_URL_STATE)
+    expect(params.has('ff')).toBe(false)
+    expect(params.has('ft')).toBe(false)
+    expect(decodeState(params).focus).toBeNull()
+  })
+
+  it('rejects inverted or partial focus', () => {
+    expect(
+      decodeState(
+        new URLSearchParams({
+          ff: '2016-01-01T00:00:00Z',
+          ft: '2015-01-01T00:00:00Z',
+        }),
+      ).focus,
+    ).toBeNull()
+    expect(
+      decodeState(new URLSearchParams({ ff: '2015-01-01T00:00:00Z' })).focus,
+    ).toBeNull()
+  })
+})

--- a/apps/chronicle/web/src/workingset/urlState.test.ts
+++ b/apps/chronicle/web/src/workingset/urlState.test.ts
@@ -1,13 +1,19 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { Unit } from '../chronicle/timeScale'
 import {
   decodeSelection,
   decodeState,
+  DEFAULT_LANES,
   DEFAULT_URL_STATE,
   encodeSelection,
   encodeState,
   isScopePristine,
+  LANES_STORAGE_KEY,
+  loadSavedLanes,
+  parseLanesParam,
+  resolveLanes,
+  saveLanesAsDefault,
   toIsoSeconds,
   type UrlWorkingState,
 } from './urlState'
@@ -36,6 +42,7 @@ describe('encodeState / decodeState', () => {
         lane: 'messages',
         bucketIso: '2014-06-01T00:00:00.000Z',
       },
+      lanes: ['top_people', 'messages'],
     }
 
     const encoded = encodeState(state)
@@ -49,6 +56,7 @@ describe('encodeState / decodeState', () => {
     expect(decoded.aggregation).toBe('month')
     expect(decoded.view).toBe('table')
     expect(decoded.selection).toEqual(state.selection)
+    expect(decoded.lanes).toEqual(state.lanes)
 
     // Second roundtrip is stable
     expect(decodeState(encodeState(decoded))).toEqual(decoded)
@@ -166,5 +174,84 @@ describe('selection codec (sel)', () => {
       selection: { kind: 'message', sid: 'msg_99' },
     })
     expect(params.get('sel')).toBe('m:msg_99')
+  })
+})
+
+/** In-memory localStorage for environments where jsdom omits it. */
+function installMemoryLocalStorage(): Storage {
+  const map = new Map<string, string>()
+  const storage: Storage = {
+    get length() {
+      return map.size
+    },
+    clear() {
+      map.clear()
+    },
+    getItem(key: string) {
+      return map.has(key) ? map.get(key)! : null
+    },
+    key(index: number) {
+      return [...map.keys()][index] ?? null
+    },
+    removeItem(key: string) {
+      map.delete(key)
+    },
+    setItem(key: string, value: string) {
+      map.set(key, String(value))
+    },
+  }
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storage,
+    configurable: true,
+    writable: true,
+  })
+  return storage
+}
+
+describe('lanes codec (ln) and saved lens', () => {
+  beforeEach(() => {
+    installMemoryLocalStorage()
+  })
+
+  it('roundtrips non-default ln CSV', () => {
+    const state: UrlWorkingState = {
+      ...DEFAULT_URL_STATE,
+      lanes: ['people', 'messages'],
+    }
+    const params = encodeState(state)
+    expect(params.get('ln')).toBe('people,messages')
+    expect(decodeState(params).lanes).toEqual(['people', 'messages'])
+  })
+
+  it('omits ln when lanes equal default', () => {
+    const params = encodeState({
+      ...DEFAULT_URL_STATE,
+      lanes: [...DEFAULT_LANES],
+    })
+    expect(params.has('ln')).toBe(false)
+  })
+
+  it('parseLanesParam drops unknown keys and empties', () => {
+    expect(parseLanesParam(null)).toBeNull()
+    expect(parseLanesParam('')).toBeNull()
+    expect(parseLanesParam('nope,messages,nope')).toEqual(['messages'])
+    expect(parseLanesParam('bogus')).toBeNull()
+  })
+
+  it('precedence URL > localStorage > default', () => {
+    saveLanesAsDefault(['attachments', 'people'])
+    expect(loadSavedLanes()).toEqual(['attachments', 'people'])
+
+    // URL present wins
+    expect(resolveLanes(['messages'])).toEqual(['messages'])
+    // No URL → localStorage
+    expect(resolveLanes(null)).toEqual(['attachments', 'people'])
+    // No URL, no storage → default
+    localStorage.removeItem(LANES_STORAGE_KEY)
+    expect(resolveLanes(null)).toEqual([...DEFAULT_LANES])
+  })
+
+  it('decode without ln yields null lanes (hydrate resolves)', () => {
+    expect(decodeState(new URLSearchParams()).lanes).toBeNull()
   })
 })

--- a/apps/chronicle/web/src/workingset/urlState.ts
+++ b/apps/chronicle/web/src/workingset/urlState.ts
@@ -1,0 +1,144 @@
+import type { QueryScope } from '../api/types'
+import type { Unit, Viewport } from '../chronicle/timeScale'
+
+/** Aggregation values accepted in the URL `agg` param (omit = auto). */
+const UNITS: ReadonlySet<string> = new Set([
+  'hour',
+  'day',
+  'week',
+  'month',
+  'quarter',
+  'year',
+])
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+export type Aggregation = 'auto' | Unit
+export type ViewMode = 'canvas' | 'table'
+
+/** Serializable working-set slice for the URL codec. */
+export interface UrlWorkingState {
+  scope: QueryScope
+  viewport: Viewport | null
+  aggregation: Aggregation
+  view: ViewMode
+}
+
+export const DEFAULT_URL_STATE: UrlWorkingState = {
+  scope: {},
+  viewport: null,
+  aggregation: 'auto',
+  view: 'canvas',
+}
+
+/** Format epoch ms as UTC ISO datetime with second precision (`…Z`, no ms). */
+export function toIsoSeconds(ms: number): string {
+  return new Date(ms).toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
+function parseIsoDate(value: string | null): string | null {
+  if (!value || !ISO_DATE_RE.test(value)) return null
+  // Reject obviously invalid calendar values via Date.parse of midnight UTC.
+  const ms = Date.parse(`${value}T00:00:00Z`)
+  if (!Number.isFinite(ms)) return null
+  return value
+}
+
+function parseViewportIso(value: string | null): number | null {
+  if (!value) return null
+  const ms = Date.parse(value)
+  if (!Number.isFinite(ms)) return null
+  return ms
+}
+
+function parseCsv(value: string | null): string[] {
+  if (!value) return []
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+function parseAggregation(value: string | null): Aggregation {
+  if (!value || value === 'auto') return 'auto'
+  if (UNITS.has(value)) return value as Unit
+  return 'auto'
+}
+
+function parseView(value: string | null): ViewMode {
+  if (value === 'table') return 'table'
+  return 'canvas'
+}
+
+/**
+ * Encode working-set state into short, human-readable search params.
+ * Omits defaults and empties entirely — pristine state → empty query string.
+ */
+export function encodeState(state: UrlWorkingState): URLSearchParams {
+  const params = new URLSearchParams()
+  const { scope, viewport, aggregation, view } = state
+
+  const dateFrom = scope.date?.from ?? null
+  const dateTo = scope.date?.to ?? null
+  if (dateFrom) params.set('df', dateFrom)
+  if (dateTo) params.set('dt', dateTo)
+
+  const mailboxes = scope.mailboxes ?? []
+  if (mailboxes.length > 0) params.set('mb', mailboxes.join(','))
+
+  const senders = scope.senders ?? []
+  if (senders.length > 0) params.set('sd', senders.join(','))
+
+  if (viewport) {
+    params.set('vf', toIsoSeconds(viewport.fromMs))
+    params.set('vt', toIsoSeconds(viewport.toMs))
+  }
+
+  if (aggregation !== 'auto') params.set('agg', aggregation)
+  if (view !== 'canvas') params.set('view', view)
+
+  return params
+}
+
+/**
+ * Decode search params into working-set state.
+ * Total function: bad values fall back to defaults, never throws.
+ */
+export function decodeState(params: URLSearchParams): UrlWorkingState {
+  const df = parseIsoDate(params.get('df'))
+  const dt = parseIsoDate(params.get('dt'))
+  const mailboxes = parseCsv(params.get('mb'))
+  const senders = parseCsv(params.get('sd'))
+
+  const scope: QueryScope = {}
+  if (df || dt) {
+    scope.date = {
+      ...(df ? { from: df } : {}),
+      ...(dt ? { to: dt } : {}),
+    }
+  }
+  if (mailboxes.length > 0) scope.mailboxes = mailboxes
+  if (senders.length > 0) scope.senders = senders
+
+  const vf = parseViewportIso(params.get('vf'))
+  const vt = parseViewportIso(params.get('vt'))
+  let viewport: Viewport | null = null
+  if (vf != null && vt != null && vt > vf) {
+    viewport = { fromMs: vf, toMs: vt }
+  }
+
+  return {
+    scope,
+    viewport,
+    aggregation: parseAggregation(params.get('agg')),
+    view: parseView(params.get('view')),
+  }
+}
+
+/** True when scope has no date/mailbox/sender constraints. */
+export function isScopePristine(scope: QueryScope): boolean {
+  const hasDate = !!(scope.date?.from || scope.date?.to)
+  const hasMb = (scope.mailboxes?.length ?? 0) > 0
+  const hasSd = (scope.senders?.length ?? 0) > 0
+  return !hasDate && !hasMb && !hasSd
+}

--- a/apps/chronicle/web/src/workingset/urlState.ts
+++ b/apps/chronicle/web/src/workingset/urlState.ts
@@ -49,6 +49,11 @@ export interface UrlWorkingState {
   selection: Selection
   /** Ordered visible lane keys; null means "not present in URL". */
   lanes: string[] | null
+  /**
+   * Focus-mode period (URL params `ff`/`ft`). Optional on encode input so
+   * older call sites remain valid; decode always returns Viewport | null.
+   */
+  focus?: Viewport | null
 }
 
 export const DEFAULT_URL_STATE: UrlWorkingState = {
@@ -58,6 +63,7 @@ export const DEFAULT_URL_STATE: UrlWorkingState = {
   view: 'canvas',
   selection: null,
   lanes: null,
+  focus: null,
 }
 
 /**
@@ -202,7 +208,7 @@ function lanesEqual(a: string[], b: string[]): boolean {
  */
 export function encodeState(state: UrlWorkingState): URLSearchParams {
   const params = new URLSearchParams()
-  const { scope, viewport, aggregation, view, selection, lanes } = state
+  const { scope, viewport, aggregation, view, selection, lanes, focus } = state
 
   const dateFrom = scope.date?.from ?? null
   const dateTo = scope.date?.to ?? null
@@ -229,6 +235,12 @@ export function encodeState(state: UrlWorkingState): URLSearchParams {
   // Encode ln when present and non-default (null = omit; empty array should not occur).
   if (lanes != null && lanes.length > 0 && !lanesEqual(lanes, DEFAULT_LANES)) {
     params.set('ln', lanes.join(','))
+  }
+
+  // Focus period (analytical): ff/ft ISO datetime, second precision.
+  if (focus && focus.toMs > focus.fromMs) {
+    params.set('ff', toIsoSeconds(focus.fromMs))
+    params.set('ft', toIsoSeconds(focus.toMs))
   }
 
   return params
@@ -262,6 +274,13 @@ export function decodeState(params: URLSearchParams): UrlWorkingState {
     viewport = { fromMs: vf, toMs: vt }
   }
 
+  const ff = parseViewportIso(params.get('ff'))
+  const ft = parseViewportIso(params.get('ft'))
+  let focus: Viewport | null = null
+  if (ff != null && ft != null && ft > ff) {
+    focus = { fromMs: ff, toMs: ft }
+  }
+
   return {
     scope,
     viewport,
@@ -269,6 +288,7 @@ export function decodeState(params: URLSearchParams): UrlWorkingState {
     view: parseView(params.get('view')),
     selection: decodeSelection(params.get('sel')),
     lanes: parseLanesParam(params.get('ln')),
+    focus,
   }
 }
 

--- a/apps/chronicle/web/src/workingset/urlState.ts
+++ b/apps/chronicle/web/src/workingset/urlState.ts
@@ -13,6 +13,24 @@ const UNITS: ReadonlySet<string> = new Set([
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 
+/** All lane keys the UI understands (config panel + codec). */
+export const ALL_LANE_KEYS = [
+  'messages',
+  'attachments',
+  'people',
+  'top_people',
+] as const
+
+export type LaneKey = (typeof ALL_LANE_KEYS)[number]
+
+/** Default visible lane order (store + URL fallback). */
+export const DEFAULT_LANES: LaneKey[] = ['messages', 'attachments', 'top_people']
+
+/** localStorage key for per-device saved lens (lane config). */
+export const LANES_STORAGE_KEY = 'chronicle.lanes.v1'
+
+const LANE_KEY_SET: ReadonlySet<string> = new Set(ALL_LANE_KEYS)
+
 export type Aggregation = 'auto' | Unit
 export type ViewMode = 'canvas' | 'table'
 
@@ -29,6 +47,8 @@ export interface UrlWorkingState {
   aggregation: Aggregation
   view: ViewMode
   selection: Selection
+  /** Ordered visible lane keys; null means "not present in URL". */
+  lanes: string[] | null
 }
 
 export const DEFAULT_URL_STATE: UrlWorkingState = {
@@ -37,6 +57,7 @@ export const DEFAULT_URL_STATE: UrlWorkingState = {
   aggregation: 'auto',
   view: 'canvas',
   selection: null,
+  lanes: null,
 }
 
 /**
@@ -122,12 +143,66 @@ function parseView(value: string | null): ViewMode {
 }
 
 /**
+ * Parse `ln` CSV into ordered valid lane keys. Unknown tokens dropped.
+ * Empty / all-invalid → null (caller applies localStorage / default).
+ */
+export function parseLanesParam(value: string | null): string[] | null {
+  if (value == null || value === '') return null
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const part of parseCsv(value)) {
+    if (!LANE_KEY_SET.has(part) || seen.has(part)) continue
+    seen.add(part)
+    out.push(part)
+  }
+  return out.length > 0 ? out : null
+}
+
+/** Read saved lens from localStorage. Returns null if missing/invalid. */
+export function loadSavedLanes(): string[] | null {
+  try {
+    if (typeof localStorage === 'undefined') return null
+    return parseLanesParam(localStorage.getItem(LANES_STORAGE_KEY))
+  } catch {
+    return null
+  }
+}
+
+/** Persist current lane config as per-device default (saved lens). */
+export function saveLanesAsDefault(lanes: string[]): void {
+  try {
+    if (typeof localStorage === 'undefined') return
+    const valid = parseLanesParam(lanes.join(','))
+    if (!valid) return
+    localStorage.setItem(LANES_STORAGE_KEY, valid.join(','))
+  } catch {
+    // Quota / private mode — ignore.
+  }
+}
+
+/**
+ * Resolve lanes with precedence: URL (`decoded`) > localStorage > default.
+ * When `decoded` is null (no `ln` param), localStorage is consulted.
+ */
+export function resolveLanes(urlLanes: string[] | null): string[] {
+  if (urlLanes != null && urlLanes.length > 0) return [...urlLanes]
+  const saved = loadSavedLanes()
+  if (saved != null && saved.length > 0) return [...saved]
+  return [...DEFAULT_LANES]
+}
+
+function lanesEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every((v, i) => v === b[i])
+}
+
+/**
  * Encode working-set state into short, human-readable search params.
  * Omits defaults and empties entirely — pristine state → empty query string.
  */
 export function encodeState(state: UrlWorkingState): URLSearchParams {
   const params = new URLSearchParams()
-  const { scope, viewport, aggregation, view, selection } = state
+  const { scope, viewport, aggregation, view, selection, lanes } = state
 
   const dateFrom = scope.date?.from ?? null
   const dateTo = scope.date?.to ?? null
@@ -151,12 +226,18 @@ export function encodeState(state: UrlWorkingState): URLSearchParams {
   const sel = encodeSelection(selection ?? null)
   if (sel) params.set('sel', sel)
 
+  // Encode ln when present and non-default (null = omit; empty array should not occur).
+  if (lanes != null && lanes.length > 0 && !lanesEqual(lanes, DEFAULT_LANES)) {
+    params.set('ln', lanes.join(','))
+  }
+
   return params
 }
 
 /**
  * Decode search params into working-set state.
  * Total function: bad values fall back to defaults, never throws.
+ * `lanes` is null when `ln` is absent — hydrate applies localStorage / default.
  */
 export function decodeState(params: URLSearchParams): UrlWorkingState {
   const df = parseIsoDate(params.get('df'))
@@ -187,6 +268,7 @@ export function decodeState(params: URLSearchParams): UrlWorkingState {
     aggregation: parseAggregation(params.get('agg')),
     view: parseView(params.get('view')),
     selection: decodeSelection(params.get('sel')),
+    lanes: parseLanesParam(params.get('ln')),
   }
 }
 

--- a/apps/chronicle/web/src/workingset/urlState.ts
+++ b/apps/chronicle/web/src/workingset/urlState.ts
@@ -16,12 +16,19 @@ const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 export type Aggregation = 'auto' | Unit
 export type ViewMode = 'canvas' | 'table'
 
+/** Inspector / timeline selection (URL param `sel`). */
+export type Selection =
+  | { kind: 'bucket'; bucketIso: string; lane: string }
+  | { kind: 'message'; sid: string }
+  | null
+
 /** Serializable working-set slice for the URL codec. */
 export interface UrlWorkingState {
   scope: QueryScope
   viewport: Viewport | null
   aggregation: Aggregation
   view: ViewMode
+  selection: Selection
 }
 
 export const DEFAULT_URL_STATE: UrlWorkingState = {
@@ -29,6 +36,50 @@ export const DEFAULT_URL_STATE: UrlWorkingState = {
   viewport: null,
   aggregation: 'auto',
   view: 'canvas',
+  selection: null,
+}
+
+/**
+ * Encode selection for the `sel` URL param.
+ * - bucket: `b:<lane>:<bucketIso>`
+ * - message: `m:<sid>`
+ */
+export function encodeSelection(selection: Selection): string | null {
+  if (!selection) return null
+  if (selection.kind === 'bucket') {
+    if (!selection.lane || !selection.bucketIso) return null
+    return `b:${selection.lane}:${selection.bucketIso}`
+  }
+  if (selection.kind === 'message') {
+    if (!selection.sid) return null
+    return `m:${selection.sid}`
+  }
+  return null
+}
+
+/**
+ * Decode `sel` param. Total: bad values → null, never throws.
+ */
+export function decodeSelection(raw: string | null): Selection {
+  if (!raw) return null
+  if (raw.startsWith('b:')) {
+    // b:<lane>:<bucketIso> — lane has no colons; bucketIso may contain colons (ISO).
+    const rest = raw.slice(2)
+    const colon = rest.indexOf(':')
+    if (colon <= 0) return null
+    const lane = rest.slice(0, colon)
+    const bucketIso = rest.slice(colon + 1)
+    if (!lane || !bucketIso) return null
+    const ms = Date.parse(bucketIso)
+    if (!Number.isFinite(ms)) return null
+    return { kind: 'bucket', lane, bucketIso }
+  }
+  if (raw.startsWith('m:')) {
+    const sid = raw.slice(2)
+    if (!sid || !/^(msg|att)_[A-Za-z0-9_-]+$/.test(sid)) return null
+    return { kind: 'message', sid }
+  }
+  return null
 }
 
 /** Format epoch ms as UTC ISO datetime with second precision (`…Z`, no ms). */
@@ -76,7 +127,7 @@ function parseView(value: string | null): ViewMode {
  */
 export function encodeState(state: UrlWorkingState): URLSearchParams {
   const params = new URLSearchParams()
-  const { scope, viewport, aggregation, view } = state
+  const { scope, viewport, aggregation, view, selection } = state
 
   const dateFrom = scope.date?.from ?? null
   const dateTo = scope.date?.to ?? null
@@ -96,6 +147,9 @@ export function encodeState(state: UrlWorkingState): URLSearchParams {
 
   if (aggregation !== 'auto') params.set('agg', aggregation)
   if (view !== 'canvas') params.set('view', view)
+
+  const sel = encodeSelection(selection ?? null)
+  if (sel) params.set('sel', sel)
 
   return params
 }
@@ -132,6 +186,7 @@ export function decodeState(params: URLSearchParams): UrlWorkingState {
     viewport,
     aggregation: parseAggregation(params.get('agg')),
     view: parseView(params.get('view')),
+    selection: decodeSelection(params.get('sel')),
   }
 }
 

--- a/apps/chronicle/web/src/workingset/useUrlSync.test.tsx
+++ b/apps/chronicle/web/src/workingset/useUrlSync.test.tsx
@@ -37,6 +37,7 @@ describe('useUrlSync', () => {
       aggregation: 'auto',
       view: 'table',
       selection: null,
+      lanes: null,
     })
     window.history.replaceState(null, '', `/?${params.toString()}`)
 
@@ -61,6 +62,7 @@ describe('useUrlSync', () => {
       aggregation: 'auto',
       view: 'table',
       selection: null,
+      lanes: null,
     })
     window.history.replaceState(null, '', `/?${params.toString()}`)
     resetWorkingSetStore()

--- a/apps/chronicle/web/src/workingset/useUrlSync.test.tsx
+++ b/apps/chronicle/web/src/workingset/useUrlSync.test.tsx
@@ -1,0 +1,189 @@
+import { act, cleanup, render, renderHook } from '@testing-library/react'
+import { useEffect } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetWorkingSetStore, useWorkingSetStore } from './store'
+import { resetUrlSyncForTests, useUrlSync } from './useUrlSync'
+import { encodeState } from './urlState'
+
+function clearUrl() {
+  window.history.replaceState(null, '', '/')
+}
+
+describe('useUrlSync', () => {
+  beforeEach(() => {
+    clearUrl()
+    resetUrlSyncForTests()
+    resetWorkingSetStore()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    resetUrlSyncForTests()
+    clearUrl()
+    resetWorkingSetStore()
+  })
+
+  it('hydrates from URL on mount (deep link)', () => {
+    const params = encodeState({
+      scope: { date: { from: '2014-01-01', to: '2018-01-01' } },
+      viewport: {
+        fromMs: Date.UTC(2014, 0, 1),
+        toMs: Date.UTC(2015, 0, 1),
+      },
+      aggregation: 'auto',
+      view: 'table',
+    })
+    window.history.replaceState(null, '', `/?${params.toString()}`)
+
+    function App() {
+      useUrlSync()
+      const view = useWorkingSetStore((s) => s.view)
+      return <span data-testid="view">{view}</span>
+    }
+
+    const { getByTestId } = render(<App />)
+    expect(getByTestId('view').textContent).toBe('table')
+    const s = useWorkingSetStore.getState()
+    expect(s.scope.date?.from).toBe('2014-01-01')
+    expect(s.viewport?.fromMs).toBe(Date.UTC(2014, 0, 1))
+    expect(s.viewport?.toMs).toBe(Date.UTC(2015, 0, 1))
+  })
+
+  it('mount hydration runs before consumer effects (ordering assertable via mock)', () => {
+    const params = encodeState({
+      scope: { mailboxes: ['deep@link.com'] },
+      viewport: null,
+      aggregation: 'auto',
+      view: 'table',
+    })
+    window.history.replaceState(null, '', `/?${params.toString()}`)
+    resetWorkingSetStore()
+
+    const events: string[] = []
+    const fetchMock = vi.fn(() => {
+      events.push('fetch')
+      // Store must already reflect the deep link when "first fetch" would run.
+      expect(useWorkingSetStore.getState().view).toBe('table')
+      expect(useWorkingSetStore.getState().scope.mailboxes).toEqual(['deep@link.com'])
+    })
+
+    function App() {
+      useUrlSync()
+      useEffect(() => {
+        events.push('effect')
+        fetchMock()
+      }, [])
+      return null
+    }
+
+    render(<App />)
+    expect(events).toEqual(['effect', 'fetch'])
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('transient setViewport debounces to one replaceState', () => {
+    const replaceSpy = vi.spyOn(window.history, 'replaceState')
+    const pushSpy = vi.spyOn(window.history, 'pushState')
+
+    renderHook(() => useUrlSync())
+
+    act(() => {
+      useWorkingSetStore.getState().setViewport({
+        fromMs: Date.UTC(2014, 0, 1),
+        toMs: Date.UTC(2014, 6, 1),
+      })
+      useWorkingSetStore.getState().setViewport({
+        fromMs: Date.UTC(2014, 0, 1),
+        toMs: Date.UTC(2014, 8, 1),
+      })
+      useWorkingSetStore.getState().setViewport({
+        fromMs: Date.UTC(2014, 0, 1),
+        toMs: Date.UTC(2014, 11, 1),
+      })
+    })
+
+    expect(replaceSpy).not.toHaveBeenCalled()
+    expect(pushSpy).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(pushSpy).not.toHaveBeenCalled()
+    // Initial clearUrl may have called replaceState; filter to search-param writes.
+    const searchWrites = replaceSpy.mock.calls.filter(
+      (c) => typeof c[2] === 'string' && String(c[2]).includes('vf='),
+    )
+    expect(searchWrites.length).toBe(1)
+    const written = decodeURIComponent(String(searchWrites[0]![2]))
+    expect(written).toContain('vt=2014-12-01T00:00:00Z')
+  })
+
+  it('analytical action → pushState', () => {
+    const pushSpy = vi.spyOn(window.history, 'pushState')
+
+    renderHook(() => useUrlSync())
+
+    act(() => {
+      useWorkingSetStore.getState().setView('table')
+    })
+
+    expect(pushSpy).toHaveBeenCalledTimes(1)
+    expect(String(pushSpy.mock.calls[0]![2])).toContain('view=table')
+  })
+
+  it('coalesces identical analytical pushes', () => {
+    const pushSpy = vi.spyOn(window.history, 'pushState')
+    renderHook(() => useUrlSync())
+
+    act(() => {
+      useWorkingSetStore.getState().setView('table')
+    })
+    expect(pushSpy).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      useWorkingSetStore.getState().setView('table')
+    })
+    expect(pushSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('popstate hydrates the store', () => {
+    renderHook(() => useUrlSync())
+
+    act(() => {
+      useWorkingSetStore.getState().setView('table')
+      useWorkingSetStore.getState().addMailbox('a@b.com')
+    })
+
+    // Simulate prior history entry (canvas, no mailbox) then pop back.
+    window.history.replaceState(null, '', '/')
+    act(() => {
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    })
+
+    const s = useWorkingSetStore.getState()
+    expect(s.view).toBe('canvas')
+    expect(s.scope.mailboxes).toBeUndefined()
+  })
+
+  it('applyBrushAsViewport pushes history once', () => {
+    const pushSpy = vi.spyOn(window.history, 'pushState')
+    renderHook(() => useUrlSync())
+
+    act(() => {
+      useWorkingSetStore.getState().setBrush({
+        fromMs: Date.UTC(2015, 0, 1),
+        toMs: Date.UTC(2016, 0, 1),
+      })
+      useWorkingSetStore.getState().applyBrushAsViewport()
+    })
+
+    expect(pushSpy).toHaveBeenCalledTimes(1)
+    expect(String(pushSpy.mock.calls[0]![2])).toContain('vf=')
+    expect(useWorkingSetStore.getState().brush).toBeNull()
+  })
+})

--- a/apps/chronicle/web/src/workingset/useUrlSync.test.tsx
+++ b/apps/chronicle/web/src/workingset/useUrlSync.test.tsx
@@ -36,6 +36,7 @@ describe('useUrlSync', () => {
       },
       aggregation: 'auto',
       view: 'table',
+      selection: null,
     })
     window.history.replaceState(null, '', `/?${params.toString()}`)
 
@@ -59,6 +60,7 @@ describe('useUrlSync', () => {
       viewport: null,
       aggregation: 'auto',
       view: 'table',
+      selection: null,
     })
     window.history.replaceState(null, '', `/?${params.toString()}`)
     resetWorkingSetStore()

--- a/apps/chronicle/web/src/workingset/useUrlSync.ts
+++ b/apps/chronicle/web/src/workingset/useUrlSync.ts
@@ -51,6 +51,7 @@ function onStoreChange(): void {
     aggregation: state.aggregation,
     view: state.view,
     selection: state.selection,
+    lanes: state.lanes,
   })
   const url = buildSearchUrl(params)
 
@@ -143,6 +144,7 @@ export function writeStoreToUrlNow(): void {
     aggregation: s.aggregation,
     view: s.view,
     selection: s.selection,
+    lanes: s.lanes,
   }
   const url = buildSearchUrl(encodeState(slice))
   window.history.replaceState(window.history.state, '', url)

--- a/apps/chronicle/web/src/workingset/useUrlSync.ts
+++ b/apps/chronicle/web/src/workingset/useUrlSync.ts
@@ -50,6 +50,7 @@ function onStoreChange(): void {
     viewport: state.viewport,
     aggregation: state.aggregation,
     view: state.view,
+    selection: state.selection,
   })
   const url = buildSearchUrl(params)
 
@@ -141,6 +142,7 @@ export function writeStoreToUrlNow(): void {
     viewport: s.viewport,
     aggregation: s.aggregation,
     view: s.view,
+    selection: s.selection,
   }
   const url = buildSearchUrl(encodeState(slice))
   window.history.replaceState(window.history.state, '', url)

--- a/apps/chronicle/web/src/workingset/useUrlSync.ts
+++ b/apps/chronicle/web/src/workingset/useUrlSync.ts
@@ -52,6 +52,7 @@ function onStoreChange(): void {
     view: state.view,
     selection: state.selection,
     lanes: state.lanes,
+    focus: state.focus,
   })
   const url = buildSearchUrl(params)
 
@@ -145,6 +146,7 @@ export function writeStoreToUrlNow(): void {
     view: s.view,
     selection: s.selection,
     lanes: s.lanes,
+    focus: s.focus,
   }
   const url = buildSearchUrl(encodeState(slice))
   window.history.replaceState(window.history.state, '', url)

--- a/apps/chronicle/web/src/workingset/useUrlSync.ts
+++ b/apps/chronicle/web/src/workingset/useUrlSync.ts
@@ -1,0 +1,155 @@
+import { useLayoutEffect, useEffect } from 'react'
+
+import { useWorkingSetStore } from './store'
+import { decodeState, encodeState, type UrlWorkingState } from './urlState'
+
+const REPLACE_DEBOUNCE_MS = 300
+
+/** Module-level sync so multiple useUrlSync mounts share one history writer. */
+let syncRefCount = 0
+let storeUnsub: (() => void) | null = null
+let replaceTimer: ReturnType<typeof setTimeout> | null = null
+let lastWritten = ''
+
+function locationSearchParams(): URLSearchParams {
+  return new URLSearchParams(window.location.search)
+}
+
+function buildSearchUrl(params: URLSearchParams): string {
+  const qs = params.toString()
+  const { pathname, hash } = window.location
+  return qs ? `${pathname}?${qs}${hash}` : `${pathname}${hash}`
+}
+
+function currentFullPath(): string {
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`
+}
+
+function clearHistoryIntent(): void {
+  if (useWorkingSetStore.getState().historyIntent !== 'silent') {
+    useWorkingSetStore.setState({ historyIntent: 'silent' })
+  }
+}
+
+function flushReplace(url: string): void {
+  if (url === currentFullPath()) {
+    lastWritten = url
+    return
+  }
+  window.history.replaceState(window.history.state, '', url)
+  lastWritten = url
+}
+
+function onStoreChange(): void {
+  const state = useWorkingSetStore.getState()
+  const intent = state.historyIntent
+  if (intent === 'silent') return
+
+  const params = encodeState({
+    scope: state.scope,
+    viewport: state.viewport,
+    aggregation: state.aggregation,
+    view: state.view,
+  })
+  const url = buildSearchUrl(params)
+
+  if (intent === 'analytical') {
+    if (replaceTimer != null) {
+      clearTimeout(replaceTimer)
+      replaceTimer = null
+    }
+    // Coalesce: skip push when the encoded URL is already current.
+    if (url !== currentFullPath() && url !== lastWritten) {
+      window.history.pushState(window.history.state, '', url)
+      lastWritten = url
+    }
+    clearHistoryIntent()
+    return
+  }
+
+  // transient → debounced replaceState (300ms)
+  if (replaceTimer != null) clearTimeout(replaceTimer)
+  replaceTimer = setTimeout(() => {
+    replaceTimer = null
+    flushReplace(url)
+    clearHistoryIntent()
+  }, REPLACE_DEBOUNCE_MS)
+}
+
+function onPopState(): void {
+  if (replaceTimer != null) {
+    clearTimeout(replaceTimer)
+    replaceTimer = null
+  }
+  const decoded = decodeState(locationSearchParams())
+  useWorkingSetStore.getState().hydrate(decoded)
+  lastWritten = currentFullPath()
+}
+
+function startSync(): void {
+  // Idempotent: never stack store subscriptions or popstate handlers.
+  stopSync()
+  lastWritten = currentFullPath()
+  storeUnsub = useWorkingSetStore.subscribe(onStoreChange)
+  window.addEventListener('popstate', onPopState)
+}
+
+function stopSync(): void {
+  storeUnsub?.()
+  storeUnsub = null
+  window.removeEventListener('popstate', onPopState)
+  if (replaceTimer != null) {
+    clearTimeout(replaceTimer)
+    replaceTimer = null
+  }
+}
+
+/**
+ * URL ↔ working-set sync.
+ *
+ * Decision: do NOT use react-router's `useSearchParams`. That helper always
+ * pushes history entries and re-renders the route tree. Analytical state needs
+ * selective push vs debounced replace; react-router only owns the pathname.
+ * We write with `window.history` and restore on `popstate`.
+ *
+ * The writer is process-wide (ref-counted) so remounts / StrictMode do not
+ * stack duplicate history entries.
+ */
+export function useUrlSync(): void {
+  // Hydrate from the current URL before paint / first fetch (deep-link entry).
+  useLayoutEffect(() => {
+    const decoded = decodeState(locationSearchParams())
+    useWorkingSetStore.getState().hydrate(decoded)
+    lastWritten = currentFullPath()
+  }, [])
+
+  useEffect(() => {
+    if (syncRefCount === 0) startSync()
+    syncRefCount += 1
+    return () => {
+      syncRefCount -= 1
+      if (syncRefCount === 0) stopSync()
+    }
+  }, [])
+}
+
+/** Test helper: apply current store slice to the URL immediately (replace). */
+export function writeStoreToUrlNow(): void {
+  const s = useWorkingSetStore.getState()
+  const slice: UrlWorkingState = {
+    scope: s.scope,
+    viewport: s.viewport,
+    aggregation: s.aggregation,
+    view: s.view,
+  }
+  const url = buildSearchUrl(encodeState(slice))
+  window.history.replaceState(window.history.state, '', url)
+  lastWritten = url
+}
+
+/** Test helper: tear down module-level sync (for isolation). */
+export function resetUrlSyncForTests(): void {
+  syncRefCount = 0
+  stopSync()
+  lastWritten = ''
+}

--- a/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
+++ b/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
@@ -86,7 +86,7 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 
 ## 5. STATE — live progress (update after every task)
 
-**Next up:** Phase 1, Task 1.4 (evidence inspector + reader). Goal mode active (2026-07-13): user delegated review+merge of all phases to Claude via /goal.
+**Next up:** Phase 1, Task 1.5 (people lane + lane configuration). Goal mode active (2026-07-13): user delegated review+merge of all phases to Claude via /goal.
 
 | Date | Task | PR | Outcome |
 | --- | --- | --- | --- |
@@ -99,3 +99,4 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 | 2026-07-13 | 1.1 buckets endpoint: QueryScope v1, auto-aggregation, lanes, density, fingerprint | chronicle-phase-1 | Approved; 93 server tests |
 | 2026-07-13 | 1.2 timeline canvas: timeScale core, pan/zoom/brush, navigator, table alt | chronicle-phase-1 | Approved after reviewer fix (passive React onWheel → native non-passive listener); 32 web tests |
 | 2026-07-13 | 1.3 working set: zustand store w/ historyIntent, URL codec, scope chips | chronicle-phase-1 | Approved; 62 web tests |
+| 2026-07-13 | 1.4 inspector + source list + reader: keyset /api/sources/list, selection URL param, return contract | chronicle-phase-1 | Approved; 98 server / 79 web tests |

--- a/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
+++ b/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
@@ -86,7 +86,7 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 
 ## 5. STATE — live progress (update after every task)
 
-**Next up:** Phase 1, Task 1.6 (focus mode + Chronicle acceptance tests) — last task of Phase 1. Goal mode active (2026-07-13): user delegated review+merge of all phases to Claude via /goal.
+**Next up:** Phase 2, Task 2.1 (search endpoint) — elaborate Phase 2 task specs first. Goal mode active (2026-07-13): user delegated review+merge of all phases to Claude via /goal.
 
 | Date | Task | PR | Outcome |
 | --- | --- | --- | --- |
@@ -101,3 +101,4 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 | 2026-07-13 | 1.3 working set: zustand store w/ historyIntent, URL codec, scope chips | chronicle-phase-1 | Approved; 62 web tests |
 | 2026-07-13 | 1.4 inspector + source list + reader: keyset /api/sources/list, selection URL param, return contract | chronicle-phase-1 | Approved; 98 server / 79 web tests |
 | 2026-07-13 | 1.5 people lane (top_people CTE, user-excluded) + lane config w/ saved lens | chronicle-phase-1 | Approved; 100 server / 93 web tests |
+| 2026-07-13 | 1.6 focus mode + §4.10 acceptance suite (criteria 1–8, #4 todo) | chronicle-phase-1 | Approved; Phase 1 complete (118 web tests) |

--- a/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
+++ b/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
@@ -86,7 +86,7 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 
 ## 5. STATE — live progress (update after every task)
 
-**Next up:** Phase 1, Task 1.2 (timeline canvas MVP). Goal mode active (2026-07-13): user delegated review+merge of all phases to Claude via /goal.
+**Next up:** Phase 1, Task 1.3 (working set + URL state). Goal mode active (2026-07-13): user delegated review+merge of all phases to Claude via /goal.
 
 | Date | Task | PR | Outcome |
 | --- | --- | --- | --- |
@@ -97,3 +97,4 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 | 2026-07-13 | 0.4 Data Health: /api/health/archive + /data-health page | chronicle-phase-0 | Approved; Phase 0 complete (75 server + 17 web tests) |
 | 2026-07-13 | Phase 0 PR #106 merged (2e48ae9) | #106 | CI green |
 | 2026-07-13 | 1.1 buckets endpoint: QueryScope v1, auto-aggregation, lanes, density, fingerprint | chronicle-phase-1 | Approved; 93 server tests |
+| 2026-07-13 | 1.2 timeline canvas: timeScale core, pan/zoom/brush, navigator, table alt | chronicle-phase-1 | Approved after reviewer fix (passive React onWheel → native non-passive listener); 32 web tests |

--- a/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
+++ b/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
@@ -86,7 +86,7 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 
 ## 5. STATE — live progress (update after every task)
 
-**Next up:** Phase 1, Task 1.3 (working set + URL state). Goal mode active (2026-07-13): user delegated review+merge of all phases to Claude via /goal.
+**Next up:** Phase 1, Task 1.4 (evidence inspector + reader). Goal mode active (2026-07-13): user delegated review+merge of all phases to Claude via /goal.
 
 | Date | Task | PR | Outcome |
 | --- | --- | --- | --- |
@@ -98,3 +98,4 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 | 2026-07-13 | Phase 0 PR #106 merged (2e48ae9) | #106 | CI green |
 | 2026-07-13 | 1.1 buckets endpoint: QueryScope v1, auto-aggregation, lanes, density, fingerprint | chronicle-phase-1 | Approved; 93 server tests |
 | 2026-07-13 | 1.2 timeline canvas: timeScale core, pan/zoom/brush, navigator, table alt | chronicle-phase-1 | Approved after reviewer fix (passive React onWheel → native non-passive listener); 32 web tests |
+| 2026-07-13 | 1.3 working set: zustand store w/ historyIntent, URL codec, scope chips | chronicle-phase-1 | Approved; 62 web tests |

--- a/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
+++ b/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
@@ -86,7 +86,7 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 
 ## 5. STATE — live progress (update after every task)
 
-**Next up:** Phase 1, Task 1.1 (chronicle buckets endpoint) — elaborate Phase 1 specs at session start; Phase 0 PR #106 awaiting user merge
+**Next up:** Phase 1, Task 1.2 (timeline canvas MVP). Goal mode active (2026-07-13): user delegated review+merge of all phases to Claude via /goal.
 
 | Date | Task | PR | Outcome |
 | --- | --- | --- | --- |
@@ -95,3 +95,5 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 | 2026-07-13 | 0.2 web scaffold: §13 tokens, login flow, workstation shell, summary panel | chronicle-phase-0 | Approved (1 reviewer fix: unused asset removed); gates green (web 15 tests + build) |
 | 2026-07-13 | 0.3 source contracts: stable IDs, sources/threads endpoints, nh3 sanitizer, cursor util | chronicle-phase-0 | Approved (1 reviewer fix: native nh3 link_rel over regex post-processing); 72 server tests |
 | 2026-07-13 | 0.4 Data Health: /api/health/archive + /data-health page | chronicle-phase-0 | Approved; Phase 0 complete (75 server + 17 web tests) |
+| 2026-07-13 | Phase 0 PR #106 merged (2e48ae9) | #106 | CI green |
+| 2026-07-13 | 1.1 buckets endpoint: QueryScope v1, auto-aggregation, lanes, density, fingerprint | chronicle-phase-1 | Approved; 93 server tests |

--- a/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
+++ b/docs/superpowers/plans/2026-07-13-life-chronicle-plan.md
@@ -86,7 +86,7 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 
 ## 5. STATE — live progress (update after every task)
 
-**Next up:** Phase 1, Task 1.5 (people lane + lane configuration). Goal mode active (2026-07-13): user delegated review+merge of all phases to Claude via /goal.
+**Next up:** Phase 1, Task 1.6 (focus mode + Chronicle acceptance tests) — last task of Phase 1. Goal mode active (2026-07-13): user delegated review+merge of all phases to Claude via /goal.
 
 | Date | Task | PR | Outcome |
 | --- | --- | --- | --- |
@@ -100,3 +100,4 @@ WCAG 2.2 AA audit, security review (CSP, sanitizer corpus, IDOR/enumeration), pe
 | 2026-07-13 | 1.2 timeline canvas: timeScale core, pan/zoom/brush, navigator, table alt | chronicle-phase-1 | Approved after reviewer fix (passive React onWheel → native non-passive listener); 32 web tests |
 | 2026-07-13 | 1.3 working set: zustand store w/ historyIntent, URL codec, scope chips | chronicle-phase-1 | Approved; 62 web tests |
 | 2026-07-13 | 1.4 inspector + source list + reader: keyset /api/sources/list, selection URL param, return contract | chronicle-phase-1 | Approved; 98 server / 79 web tests |
+| 2026-07-13 | 1.5 people lane (top_people CTE, user-excluded) + lane config w/ saved lens | chronicle-phase-1 | Approved; 100 server / 93 web tests |


### PR DESCRIPTION
## Objective

Phase 1 of Life Chronicle (epic #105): the Chronicle timeline foundation. Goal mode: review + merge delegated to Claude by the user via /goal.

## Tasks — all complete

- [x] **1.1** — `POST /api/chronicle/buckets`: QueryScope v1 + fingerprint, pixel-width auto-aggregation (2000-bucket ceiling), lanes, density + extent
- [x] **1.2** — timeline canvas: pure timeScale core (property-tested zoom anchor), pan/zoom/brush, density navigator, accessible table alternative
- [x] **1.3** — working set: historyIntent store, URL codec, debounced replace vs push contract, scope-bar chips
- [x] **1.4** — evidence inspector + keyset `POST /api/sources/list` + `/source/:sid` reader with test-verified return contract
- [x] **1.5** — people lane (top-8 contacts CTE, user-excluded) + configurable lanes with per-device saved lens
- [x] **1.6** — focus mode (URL-first, Back-exits) + acceptance suite encoding spec §4.10 criteria 1–8

## Phase 1 exit criterion (spec §20.1)

"User can navigate full archive to individual sources and return without state loss" — met and encoded as automated acceptance tests (criterion 4/events deferred to Phase 3 as todo).

## Gates

Every task commit green on `uv run just check` (674) and `just check-app` (final: 100 server + 118 web tests + build).

## Reviews

Per-task reviews in session `.cheap-coder/review-NN.md`; 6/6 approved, 0 grok revision rounds. One MAJOR found and reviewer-fixed: React's passive `onWheel` binding silently ignored `preventDefault` (page scroll would fight the timeline) — replaced with a native non-passive listener; the React-vs-DOM WheelEvent type shadow that masked it is also fixed.

## Provenance

Implementer: Grok Build CLI, `grok-4.5` @ max. Architecture, spec, review: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP7M17NHxw6mjpTFtMqwZu